### PR TITLE
ci: set up deployment

### DIFF
--- a/.github/workflows/deploy-dev-orange.yml
+++ b/.github/workflows/deploy-dev-orange.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   deploy:
-    name: Deploy ${{ github.ref }} to Dev-Orange
+    name: Deploy ${{ github.ref_type }} ${{ github.ref_name }} to Dev-Orange
     uses: ./.github/workflows/deploy.yml
     with:
       env: dev-orange

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    name: Deploy ${{ github.ref }} to Staging
+    name: Deploy ${{ github.ref_type }} ${{ github.ref_name }} to Staging
     uses: ./.github/workflows/deploy.yml
     with:
       env: staging

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,4 +68,4 @@ jobs:
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK }}
           job-status: ${{ job.status }}
-          custom-message: Deployed ${{ github.ref }} to ${{ inputs.env }}
+          custom-message: Deployed ${{ github.ref_type }} ${{ github.ref_name }} to ${{ inputs.env }}


### PR DESCRIPTION
Asana task: [Deploy mobile backend to dev environment](https://app.asana.com/0/1205425564113216/1205940684099184/f)

Derived from the [Glides deployment process](https://github.com/mbta/glides/blob/main/.github/workflows/deploy.yml), which is designed around a [GitHub-releases-driven prod deployment workflow](https://github.com/mbta/glides/blob/main/.github/workflows/deploy-prod.yml) where manually assigned versions are used as Docker tags (and Sentry releases, but Sentry is not configured here yet). Adds an extra Docker container tag of `latest-$ENV`.

Glides also has a PR label set up to [deploy automatically to dev-green](https://github.com/mbta/glides/blob/main/.github/workflows/deploy-dev-green.yml), which has been useful there, but I'm not sure how useful it'd be here in the backend repo, so I haven't set it up here yet. If we think we'll want it, we may as well set it up now.

The environment names of `staging` and `dev-orange` are chosen in accordance with [RFC 15](https://github.com/mbta/technology-docs/blob/main/rfcs/accepted/0015-consistent-environment-naming.md). Orange was selected arbitrarily.

Staging environment was created in https://github.com/mbta/devops/pull/1378.
Dev-orange environment was created in https://github.com/mbta/devops/pull/1380.