### PR TITLE
ci: adopt build-push-ecr shared action for deployment

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,11 +3,6 @@ run-name: ${{ github.event_name == 'workflow_dispatch' && format('Deploy {0} {1}
 
 on:
   workflow_dispatch:
-    inputs:
-      release-name:
-        description: The name to use for the created release
-        type: string
-        required: false
   push:
     branches: [main]
 
@@ -17,6 +12,5 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     with:
       env: staging
-      version-name: ${{ inputs.release-name }}
       deploy-desc: ${{ github.ref_type }} ${{ github.ref_name }}
     secrets: inherit


### PR DESCRIPTION
As mentioned in #10, loading the Docker container as cached in GitHub Actions isn't possible in the current version of `mbta/actions/build-push-ecr`. However, as of https://github.com/mbta/actions/pull/41, it will be. Or at least it should be, which is why I'm testing this here.

Validating that named releases work properly without a prod to deploy to required a bit of creativity.