### PR TITLE
refactor: use Module.concat/2 in JsonApi.Object codegen

### DIFF
--- a/lib/mbta_v3_api/json_api/object.ex
+++ b/lib/mbta_v3_api/json_api/object.ex
@@ -9,7 +9,7 @@ defmodule MBTAV3API.JsonApi.Object do
 
   modules =
     for type <- [:prediction, :route, :route_pattern, :stop, :trip] do
-      module = :"#{MBTAV3API}.#{Macro.camelize(to_string(type))}"
+      module = Module.concat(MBTAV3API, Macro.camelize(to_string(type)))
 
       def module_for(unquote(type)), do: unquote(module)
       def module_for(unquote("#{type}")), do: unquote(module)


### PR DESCRIPTION
Was browsing some unrelated documentation and saw a reference to this function from the Elixir stdlib; this seems like a far better approach than using string interpolation inside an atom literal.