### PR TITLE
feat: overhaul enum handling in the V3 API

### DIFF
--- a/lib/mbta_v3_api/json_api/filter_value.ex
+++ b/lib/mbta_v3_api/json_api/filter_value.ex
@@ -1,19 +1,30 @@
 defprotocol MBTAV3API.JsonApi.FilterValue do
-  @doc "Converts this filter value into a string"
-  @spec filter_value_string(t()) :: String.t()
-  def filter_value_string(data)
+  @doc """
+  Converts this filter value into a string.
+  If a serializer is given, it will be called on each value of a list, or on an individual value.
+  """
+  @spec filter_value_string(t(), (t() -> t()) | nil) :: String.t()
+  def filter_value_string(data, serializer \\ nil)
 end
 
 defimpl MBTAV3API.JsonApi.FilterValue, for: BitString do
-  def filter_value_string(data), do: data
+  def filter_value_string(data, nil), do: data
+
+  def filter_value_string(data, serializer) do
+    @protocol.filter_value_string(serializer.(data), nil)
+  end
 end
 
 defimpl MBTAV3API.JsonApi.FilterValue, for: [Atom, Float, Integer] do
-  def filter_value_string(data), do: String.Chars.to_string(data)
+  def filter_value_string(data, nil), do: String.Chars.to_string(data)
+
+  def filter_value_string(data, serializer) do
+    @protocol.filter_value_string(serializer.(data), nil)
+  end
 end
 
 defimpl MBTAV3API.JsonApi.FilterValue, for: List do
-  def filter_value_string(data) do
-    Enum.map_join(data, ",", &MBTAV3API.JsonApi.FilterValue.filter_value_string/1)
+  def filter_value_string(data, serializer) do
+    Enum.map_join(data, ",", &@protocol.filter_value_string(&1, serializer))
   end
 end

--- a/lib/mbta_v3_api/prediction.ex
+++ b/lib/mbta_v3_api/prediction.ex
@@ -1,4 +1,5 @@
 defmodule MBTAV3API.Prediction do
+  require Util
   alias MBTAV3API.JsonApi
 
   @behaviour JsonApi.Object
@@ -14,8 +15,13 @@ defmodule MBTAV3API.Prediction do
           stop_sequence: integer() | nil,
           trip: MBTAV3API.Trip.t() | JsonApi.Reference.t() | nil
         }
-  @type schedule_relationship ::
-          :added | :cancelled | :no_data | :skipped | :unscheduled | :scheduled
+  Util.declare_enum(
+    :schedule_relationship,
+    Util.enum_values(
+      :uppercase_string,
+      [:added, :cancelled, :no_data, :skipped, :unscheduled]
+    ) ++ [scheduled: nil]
+  )
 
   @derive Jason.Encoder
   defstruct [
@@ -73,12 +79,4 @@ defmodule MBTAV3API.Prediction do
   defp parse_revenue_status("REVENUE"), do: true
   defp parse_revenue_status("NON_REVENUE"), do: false
   defp parse_revenue_status(nil), do: true
-
-  @spec parse_schedule_relationship(String.t() | nil) :: schedule_relationship()
-  defp parse_schedule_relationship("ADDED"), do: :added
-  defp parse_schedule_relationship("CANCELLED"), do: :cancelled
-  defp parse_schedule_relationship("NO_DATA"), do: :no_data
-  defp parse_schedule_relationship("SKIPPED"), do: :skipped
-  defp parse_schedule_relationship("UNSCHEDULED"), do: :unscheduled
-  defp parse_schedule_relationship(nil), do: :scheduled
 end

--- a/lib/mbta_v3_api/route.ex
+++ b/lib/mbta_v3_api/route.ex
@@ -1,11 +1,12 @@
 defmodule MBTAV3API.Route do
+  require Util
   alias MBTAV3API.JsonApi
 
   @behaviour JsonApi.Object
 
   @type t :: %__MODULE__{
           id: String.t(),
-          type: route_type(),
+          type: type(),
           color: String.t(),
           direction_names: [String.t()],
           direction_destinations: [String.t()],
@@ -14,8 +15,11 @@ defmodule MBTAV3API.Route do
           sort_order: String.t(),
           text_color: String.t()
         }
-  @type route_type ::
-          :tram | :subway | :rail | :bus | :ferry
+
+  Util.declare_enum(
+    :type,
+    Util.enum_values(:index, [:light_rail, :heavy_rail, :commuter_rail, :bus, :ferry])
+  )
 
   @derive Jason.Encoder
   defstruct [
@@ -46,11 +50,18 @@ defmodule MBTAV3API.Route do
   @impl JsonApi.Object
   def includes, do: %{}
 
+  @impl JsonApi.Object
+  def serialize_filter_value(:type, type), do: serialize_type(type)
+  def serialize_filter_value(_field, value), do: value
+
   @spec parse(JsonApi.Item.t()) :: t()
   def parse(%JsonApi.Item{} = item) do
     %__MODULE__{
       id: item.id,
-      type: parse_route_type(item.attributes["type"]),
+      type:
+        if type = item.attributes["type"] do
+          parse_type(type)
+        end,
       color: item.attributes["color"],
       direction_names: item.attributes["direction_names"],
       direction_destinations: item.attributes["direction_destinations"],
@@ -60,12 +71,4 @@ defmodule MBTAV3API.Route do
       text_color: item.attributes["text_color"]
     }
   end
-
-  @spec parse_route_type(integer() | nil) :: route_type() | nil
-  defp parse_route_type(0), do: :tram
-  defp parse_route_type(1), do: :subway
-  defp parse_route_type(2), do: :rail
-  defp parse_route_type(3), do: :bus
-  defp parse_route_type(4), do: :ferry
-  defp parse_route_type(nil), do: nil
 end

--- a/lib/mobile_app_backend_web/controllers/nearby_controller.ex
+++ b/lib/mobile_app_backend_web/controllers/nearby_controller.ex
@@ -42,9 +42,9 @@ defmodule MobileAppBackendWeb.NearbyController do
         filter: [
           latitude: latitude,
           longitude: longitude,
-          location_type: [0, 1],
+          location_type: [:stop, :station],
           radius: degree_radius,
-          route_type: 2
+          route_type: :commuter_rail
         ],
         include: [parent_station: :child_stops],
         sort: {:distance, :asc}
@@ -55,9 +55,9 @@ defmodule MobileAppBackendWeb.NearbyController do
         filter: [
           latitude: latitude,
           longitude: longitude,
-          location_type: [0, 1],
+          location_type: [:stop, :station],
           radius: degree_radius / 2,
-          route_type: [0, 1, 3, 4]
+          route_type: [:light_rail, :heavy_rail, :bus, :ferry]
         ],
         include: {:parent_station, :child_stops},
         sort: {:distance, :asc}

--- a/lib/util.ex
+++ b/lib/util.ex
@@ -1,5 +1,180 @@
 defmodule Util do
   @doc """
+  Define some helper types and functions for working with enums returned from the V3 API.
+
+  ## Examples
+
+      iex> quote do
+      ...>   Util.declare_enum(:lifecycle,
+      ...>     new: "NEW",
+      ...>     ongoing: "ONGOING",
+      ...>     ongoing_upcoming: "ONGOING_UPCOMING",
+      ...>     upcoming: "UPCOMING"
+      ...>   )
+      ...> end
+      ...> |> Macro.expand_once(__ENV__)
+      ...> |> Macro.to_string()
+      ...> |> String.split("\\n")
+      [
+        "@type lifecycle :: :new | :ongoing | :ongoing_upcoming | :upcoming",
+        "@type raw_lifecycle :: String.t()",
+        "@spec parse_lifecycle(raw_lifecycle()) :: lifecycle()",
+        "def parse_lifecycle(lifecycle) do",
+        "  case lifecycle do",
+        "    \\"NEW\\" -> :new",
+        "    \\"ONGOING\\" -> :ongoing",
+        "    \\"ONGOING_UPCOMING\\" -> :ongoing_upcoming",
+        "    \\"UPCOMING\\" -> :upcoming",
+        "  end",
+        "end",
+        "",
+        "@spec serialize_lifecycle(lifecycle()) :: raw_lifecycle()",
+        "def serialize_lifecycle(lifecycle) do",
+        "  case lifecycle do",
+        "    :new -> \\"NEW\\"",
+        "    :ongoing -> \\"ONGOING\\"",
+        "    :ongoing_upcoming -> \\"ONGOING_UPCOMING\\"",
+        "    :upcoming -> \\"UPCOMING\\"",
+        "  end",
+        "end"
+      ]
+
+      iex> quote do
+      ...>   Util.declare_enum(:x, a: 0, b: 1)
+      ...> end
+      ...> |> Macro.expand_once(__ENV__)
+      ...> |> Macro.to_string()
+      ...> |> String.split("\\n")
+      [
+        "@type x :: :a | :b",
+        "@type raw_x :: 0 | 1",
+        "@spec parse_x(raw_x()) :: x()",
+        "def parse_x(x) do",
+        "  case x do",
+        "    0 -> :a",
+        "    1 -> :b",
+        "  end",
+        "end",
+        "",
+        "@spec serialize_x(x()) :: raw_x()",
+        "def serialize_x(x) do",
+        "  case x do",
+        "    :a -> 0",
+        "    :b -> 1",
+        "  end",
+        "end"
+      ]
+
+      iex> quote do
+      ...>   Util.declare_enum(:a, x: "X", y: nil)
+      ...> end
+      ...> |> Macro.expand_once(__ENV__)
+      ...> |> Macro.to_string()
+      ...> |> String.replace("\\n\\n", "\\n#\\n")
+      ...> |> then(&(&1 <> "\\n"))
+      \"\"\"
+      @type a :: :x | :y
+      @type raw_a :: String.t() | nil
+      @spec parse_a(raw_a()) :: a()
+      def parse_a(a) do
+        case a do
+          "X" -> :x
+          nil -> :y
+        end
+      end
+      #
+      @spec serialize_a(a()) :: raw_a()
+      def serialize_a(a) do
+        case a do
+          :x -> "X"
+          :y -> nil
+        end
+      end
+      \"\"\"
+  """
+  defmacro declare_enum(name, values) do
+    {values, _} = Code.eval_quoted(values, [], __CALLER__)
+
+    type_spec =
+      values
+      |> Enum.map(fn {value, _raw_value} -> typeof(value) end)
+      |> Enum.uniq()
+      |> type_union()
+
+    raw_type_spec =
+      values
+      |> Enum.map(fn {_value, raw_value} -> typeof(raw_value) end)
+      |> Enum.uniq()
+      |> type_union()
+
+    type_name = Macro.var(name, nil)
+    parse_fn = :"parse_#{name}"
+    serialize_fn = :"serialize_#{name}"
+    method_arg = Macro.var(name, __MODULE__)
+    raw_type = :"raw_#{name}"
+    raw_type_name = Macro.var(raw_type, nil)
+
+    parse_clauses =
+      Enum.map(values, fn {value, raw_value} ->
+        [{:->, _, _} = clause] =
+          quote do
+            unquote(raw_value) -> unquote(value)
+          end
+
+        clause
+      end)
+
+    serialize_clauses =
+      Enum.map(values, fn {value, raw_value} ->
+        [{:->, _, _} = clause] =
+          quote do
+            unquote(value) -> unquote(raw_value)
+          end
+
+        clause
+      end)
+
+    parse_body = {:case, [], [method_arg, [do: parse_clauses]]}
+    serialize_body = {:case, [], [method_arg, [do: serialize_clauses]]}
+
+    quote do
+      @type unquote(type_name) :: unquote(type_spec)
+      @type unquote(raw_type_name) :: unquote(raw_type_spec)
+
+      @spec unquote(parse_fn)(unquote(raw_type)()) :: unquote(name)()
+      def unquote(parse_fn)(unquote(method_arg)) do
+        unquote(parse_body)
+      end
+
+      @spec unquote(serialize_fn)(unquote(name)()) :: unquote(raw_type)()
+      def unquote(serialize_fn)(unquote(method_arg)) do
+        unquote(serialize_body)
+      end
+    end
+  end
+
+  defp typeof(x) when is_atom(x) when is_integer(x), do: x
+  defp typeof(x) when is_binary(x), do: quote(do: String.t())
+
+  @doc """
+  Builds enum values based on common patterns in the V3 API.
+
+  ## Examples
+
+      iex> Util.enum_values(:uppercase_string, [:new, :ongoing, :ongoing_upcoming, :upcoming])
+      [new: "NEW", ongoing: "ONGOING", ongoing_upcoming: "ONGOING_UPCOMING", upcoming: "UPCOMING"]
+
+      iex> Util.enum_values(:index, [:light_rail, :heavy_rail, :commuter_rail, :bus, :ferry])
+      [light_rail: 0, heavy_rail: 1, commuter_rail: 2, bus: 3, ferry: 4]
+  """
+  def enum_values(transform, values) do
+    case transform do
+      :uppercase_string -> Enum.map(values, &{&1, String.upcase(Atom.to_string(&1))})
+      :index -> Enum.with_index(values)
+    end
+  end
+
+  @doc """
   Parses an optional value as an `America/New_York` datetime.
 
   ## Examples
@@ -17,5 +192,28 @@ defmodule Util do
   def parse_optional_datetime(data) do
     {:ok, datetime, _} = DateTime.from_iso8601(data)
     DateTime.shift_zone!(datetime, "America/New_York")
+  end
+
+  @doc """
+  Constructs a union out of a list of types.
+
+  ## Examples
+
+      iex> values = quote(do: [Foo.t(), Bar.t(), Baz.t()])
+      iex> Util.type_union(values) |> Macro.to_string()
+      "Foo.t() | Bar.t() | Baz.t()"
+
+      iex> options = [:a, :b, :c]
+      iex> quote do
+      ...>   @type test :: unquote(Util.type_union(options))
+      ...> end |> Macro.to_string()
+      "@type test :: :a | :b | :c"
+  """
+  def type_union(args) do
+    # must reverse args because | is right-associative
+
+    args
+    |> Enum.reverse()
+    |> Enum.reduce(fn t, acc -> quote(do: unquote(t) | unquote(acc)) end)
   end
 end

--- a/test/mbta_v3_api/json_api/params_test.exs
+++ b/test/mbta_v3_api/json_api/params_test.exs
@@ -59,5 +59,13 @@ defmodule MBTAV3API.JsonApi.ParamsTest do
       assert %{"filter[abc]" => "123,45.67,abc,def"} =
                flatten_params([filter: [abc: [123, 45.67, :abc, "def"]]], :stop)
     end
+
+    test "uses custom serialize for filter" do
+      assert %{"filter[route_type]" => "0,4", "filter[location_type]" => "0,1"} =
+               flatten_params(
+                 [filter: [route_type: [:light_rail, :ferry], location_type: [:stop, :station]]],
+                 :stop
+               )
+    end
   end
 end

--- a/test/mbta_v3_api/route_test.exs
+++ b/test/mbta_v3_api/route_test.exs
@@ -14,7 +14,8 @@ defmodule MBTAV3API.RouteTest do
                "long_name" => "Green Line C",
                "short_name" => "C",
                "sort_order" => 10_033,
-               "text_color" => "FFFFFF"
+               "text_color" => "FFFFFF",
+               "type" => 0
              }
            }) == %Route{
              id: "Green-C",
@@ -24,7 +25,8 @@ defmodule MBTAV3API.RouteTest do
              long_name: "Green Line C",
              short_name: "C",
              sort_order: 10_033,
-             text_color: "FFFFFF"
+             text_color: "FFFFFF",
+             type: :light_rail
            }
   end
 end

--- a/test/mbta_v3_api/stream/state_test.exs
+++ b/test/mbta_v3_api/stream/state_test.exs
@@ -78,7 +78,7 @@ defmodule MBTAV3API.Stream.StateTest do
                %Event{
                  event: "update",
                  data:
-                   ~s({"attributes":{"latitude":-42.35302,"longitude":71.06459,"name":"Not Boylston"},"id":"place-boyls","type":"stop"})
+                   ~s({"attributes":{"latitude":-42.35302,"location_type":3,"longitude":71.06459,"name":"Not Boylston"},"id":"place-boyls","type":"stop"})
                }
              ]) == %State{
                data: %{
@@ -88,7 +88,7 @@ defmodule MBTAV3API.Stream.StateTest do
                      latitude: -42.35302,
                      longitude: 71.06459,
                      name: "Not Boylston",
-                     location_type: :stop,
+                     location_type: :generic_node,
                      parent_station: nil
                    }
                  }
@@ -102,6 +102,7 @@ defmodule MBTAV3API.Stream.StateTest do
         |> put_in([Stop, "place-boyls"], %Stop{
           id: "place-boyls",
           latitude: 42.35302,
+          location_type: :station,
           longitude: -71.06459,
           name: "Boylston",
           parent_station: nil
@@ -111,7 +112,7 @@ defmodule MBTAV3API.Stream.StateTest do
                %Event{
                  event: "reset",
                  data:
-                   ~s([{"attributes":{"latitude":42.377359,"longitude":-71.094761,"name":"Union Square"},"id":"place-unsqu","type":"stop"}])
+                   ~s([{"attributes":{"latitude":42.377359,"location_type":1,"longitude":-71.094761,"name":"Union Square"},"id":"place-unsqu","type":"stop"}])
                }
              ]) == %State{
                data: %{
@@ -121,7 +122,7 @@ defmodule MBTAV3API.Stream.StateTest do
                      latitude: 42.377359,
                      longitude: -71.094761,
                      name: "Union Square",
-                     location_type: :stop,
+                     location_type: :station,
                      parent_station: nil
                    }
                  }


### PR DESCRIPTION
Asana task: [Accept atoms rather than int values for filters to the V3 client](https://app.asana.com/0/1205425564113216/1206549419172908/f)

This was built as part of #55 and went through several drafts to reach the point it's at now.