### PR TITLE
feat(NearbyController): Preserve representative_trip fields

### DIFF
--- a/lib/mobile_app_backend_web/controllers/nearby_controller.ex
+++ b/lib/mobile_app_backend_web/controllers/nearby_controller.ex
@@ -77,7 +77,7 @@ defmodule MobileAppBackendWeb.NearbyController do
   end
 
   @spec fetch_route_patterns(stops :: stop_map()) ::
-          {%{(route_pattern_id :: String.t()) => route_pattern :: MBTAV3API.RoutePattern.t()},
+          {%{(route_pattern_id :: String.t()) => MBTAV3API.RoutePattern.t()},
            %{(stop_id :: String.t()) => route_pattern_ids :: [String.t()]}}
   defp fetch_route_patterns(stops) do
     {:ok, route_patterns} =


### PR DESCRIPTION
### Summary

_Ticket:_ [[Nearby Transit] Route group structure](https://app.asana.com/0/1205425564113216/1206443369281295/f)

What is this PR for?

While working on https://github.com/mbta/mobile_app/pull/42, I was getting the following error:
```
Illegal input: Fields [id, route_pattern, stops] are required for type 
with serial name 'com.mbta.tid.mbta_app.model.Trip', but they were 
missing at path: $.route_patterns['68-_-0'].representative_trip
```

By keeping the representative trip structure, we can add a `representativeTrip` field to the `RoutePattern` data type in the app, as I've done [here](https://github.com/mbta/mobile_app/pull/42/files#diff-f30e567b11d102864ae8184cb16e8fba26c7782399f2e1e3e316ce9d743b14fcR12). Otherwise, we could write a custom type there that is only a headsign field, but for now I think using the existing Trip type will be easier.