### PR TITLE
refactor: use modules for include resolution

### DIFF
--- a/lib/mbta_v3_api/alert.ex
+++ b/lib/mbta_v3_api/alert.ex
@@ -72,7 +72,7 @@ defmodule MBTAV3API.Alert do
 
   @spec get_all(JsonApi.Params.t(), Keyword.t()) :: {:ok, [t()]} | {:error, term()}
   def get_all(params, opts \\ []) do
-    params = JsonApi.Params.flatten_params(params, :alert)
+    params = JsonApi.Params.flatten_params(params, __MODULE__)
 
     case MBTAV3API.get_json("/alerts", params, opts) do
       %JsonApi{data: data} -> {:ok, Enum.map(data, &parse/1)}

--- a/lib/mbta_v3_api/prediction.ex
+++ b/lib/mbta_v3_api/prediction.ex
@@ -50,12 +50,12 @@ defmodule MBTAV3API.Prediction do
     ]
   end
 
-  def includes, do: %{stop: :stop, trip: :trip, vehicle: :vehicle}
+  def includes, do: %{stop: MBTAV3API.Stop, trip: MBTAV3API.Trip, vehicle: MBTAV3API.Vehicle}
 
   @spec stream_all(JsonApi.Params.t(), Keyword.t()) ::
           MBTAV3API.Stream.Supervisor.on_start_instance()
   def stream_all(params, opts \\ []) do
-    params = JsonApi.Params.flatten_params(params, :prediction)
+    params = JsonApi.Params.flatten_params(params, __MODULE__)
     opts = Keyword.put(opts, :type, __MODULE__)
 
     MBTAV3API.start_stream("/predictions", params, opts)

--- a/lib/mbta_v3_api/route_pattern.ex
+++ b/lib/mbta_v3_api/route_pattern.ex
@@ -34,11 +34,11 @@ defmodule MBTAV3API.RoutePattern do
   def fields, do: [:direction_id, :name, :sort_order, :typicality]
 
   @impl JsonApi.Object
-  def includes, do: %{representative_trip: :trip, route: :route}
+  def includes, do: %{representative_trip: MBTAV3API.Trip, route: MBTAV3API.Route}
 
   @spec get_all(JsonApi.Params.t(), Keyword.t()) :: {:ok, [t()]} | {:error, term()}
   def get_all(params, opts \\ []) do
-    params = JsonApi.Params.flatten_params(params, :route_pattern)
+    params = JsonApi.Params.flatten_params(params, __MODULE__)
 
     case MBTAV3API.get_json("/route_patterns", params, opts) do
       %JsonApi{data: data} -> {:ok, Enum.map(data, &parse/1)}

--- a/lib/mbta_v3_api/stop.ex
+++ b/lib/mbta_v3_api/stop.ex
@@ -39,8 +39,8 @@ defmodule MBTAV3API.Stop do
   @impl JsonApi.Object
   def includes,
     do: %{
-      child_stops: :stop,
-      parent_station: :stop
+      child_stops: __MODULE__,
+      parent_station: __MODULE__
     }
 
   @impl JsonApi.Object
@@ -56,7 +56,7 @@ defmodule MBTAV3API.Stop do
 
   @spec get_all(JsonApi.Params.t(), Keyword.t()) :: {:ok, [t()]} | {:error, term()}
   def get_all(params, opts \\ []) do
-    params = JsonApi.Params.flatten_params(params, :stop)
+    params = JsonApi.Params.flatten_params(params, __MODULE__)
 
     case MBTAV3API.get_json("/stops", params, opts) do
       %JsonApi{data: data} -> {:ok, Enum.map(data, &parse/1)}

--- a/lib/mbta_v3_api/trip.ex
+++ b/lib/mbta_v3_api/trip.ex
@@ -13,7 +13,7 @@ defmodule MBTAV3API.Trip do
 
   def fields, do: [:headsign]
 
-  def includes, do: %{route_pattern: :route_pattern, stops: :stop}
+  def includes, do: %{route_pattern: MBTAV3API.RoutePattern, stops: MBTAV3API.Stop}
 
   @spec parse(JsonApi.Item.t()) :: t()
   def parse(%JsonApi.Item{} = item) do

--- a/lib/mbta_v3_api/vehicle.ex
+++ b/lib/mbta_v3_api/vehicle.ex
@@ -19,7 +19,7 @@ defmodule MBTAV3API.Vehicle do
   def fields, do: [:current_status]
 
   @impl JsonApi.Object
-  def includes, do: %{stop: :stop, trip: :trip}
+  def includes, do: %{stop: MBTAV3API.Stop, trip: MBTAV3API.Trip}
 
   @spec parse(JsonApi.Item.t()) :: t()
   def parse(%JsonApi.Item{} = item) do

--- a/test/mbta_v3_api/json_api/object_test.exs
+++ b/test/mbta_v3_api/json_api/object_test.exs
@@ -93,6 +93,34 @@ defmodule MBTAV3API.JsonApi.ObjectTest do
     end
   end
 
+  test "__using__/1" do
+    expected =
+      quote do
+        alias MBTAV3API.JsonApi
+
+        @behaviour JsonApi.Object
+
+        Module.put_attribute(__MODULE__, :jsonapi_object_renames, %{a_raw: :a})
+
+        @impl JsonApi.Object
+        def jsonapi_type, do: :object_test
+
+        @after_compile JsonApi.Object
+      end
+      |> Macro.to_string()
+
+    renames_arg = Macro.escape(%{a_raw: :a})
+
+    actual =
+      quote do
+        MBTAV3API.JsonApi.Object.__using__(renames: unquote(renames_arg))
+      end
+      |> Macro.expand_once(__ENV__)
+      |> Macro.to_string()
+
+    assert expected == actual
+  end
+
   describe "__after_compile__/2" do
     test "correctly raises errors" do
       bad_module =
@@ -106,7 +134,7 @@ defmodule MBTAV3API.JsonApi.ObjectTest do
             def fields, do: [:f1, :f2, :f3, :f4]
 
             @impl true
-            def includes, do: %{r1: :stop, r2: :trip, r3: :alert}
+            def includes, do: %{r1: MBTAV3API.Stop, r2: MBTAV3API.Trip, r3: MBTAV3API.Alert}
           end
         end
 
@@ -129,7 +157,7 @@ defmodule MBTAV3API.JsonApi.ObjectTest do
             def fields, do: [:field_raw]
 
             @impl true
-            def includes, do: %{related_raw: :stop}
+            def includes, do: %{related_raw: MBTAV3API.Stop}
           end
         end
 

--- a/test/mbta_v3_api/json_api/params_test.exs
+++ b/test/mbta_v3_api/json_api/params_test.exs
@@ -6,20 +6,20 @@ defmodule MBTAV3API.JsonApi.ParamsTest do
     import MBTAV3API.JsonApi.Params, only: [flatten_params: 2]
 
     test "does not sort if no sort given" do
-      refute Map.has_key?(flatten_params([], :stop), "sort")
+      refute Map.has_key?(flatten_params([], MBTAV3API.Stop), "sort")
     end
 
     test "sorts ascending" do
-      assert %{"sort" => "name"} = flatten_params([sort: {:name, :asc}], :trip)
+      assert %{"sort" => "name"} = flatten_params([sort: {:name, :asc}], MBTAV3API.Trip)
     end
 
     test "sorts descending" do
-      assert %{"sort" => "-id"} = flatten_params([sort: {:id, :desc}], :route)
+      assert %{"sort" => "-id"} = flatten_params([sort: {:id, :desc}], MBTAV3API.Route)
     end
 
     test "uses fields for type if no includes or overrides" do
       assert %{"fields[stop]" => "latitude,longitude,name,location_type"} =
-               flatten_params([], :stop)
+               flatten_params([], MBTAV3API.Stop)
     end
 
     test "uses fields for included type" do
@@ -28,7 +28,7 @@ defmodule MBTAV3API.JsonApi.ParamsTest do
                  "type,color,direction_names,direction_destinations,long_name,short_name,sort_order,text_color",
                "fields[route_pattern]" => "direction_id,name,sort_order,typicality"
              } =
-               flatten_params([include: :route], :route_pattern)
+               flatten_params([include: :route], MBTAV3API.RoutePattern)
     end
 
     test "can override fields" do
@@ -38,33 +38,37 @@ defmodule MBTAV3API.JsonApi.ParamsTest do
              } =
                flatten_params(
                  [include: :representative_trip, fields: [trip: [:asdf, :ghjk]]],
-                 :route_pattern
+                 MBTAV3API.RoutePattern
                )
     end
 
     test "does not include if no include given" do
-      refute Map.has_key?(flatten_params([], :trip), "include")
+      refute Map.has_key?(flatten_params([], MBTAV3API.Trip), "include")
     end
 
     test "includes single related object" do
-      assert %{"include" => "parent_station"} = flatten_params([include: :parent_station], :stop)
+      assert %{"include" => "parent_station"} =
+               flatten_params([include: :parent_station], MBTAV3API.Stop)
     end
 
     test "handles nested includes" do
       assert %{"include" => "route,representative_trip,representative_trip.stops"} =
-               flatten_params([include: [:route, representative_trip: :stops]], :route_pattern)
+               flatten_params(
+                 [include: [:route, representative_trip: :stops]],
+                 MBTAV3API.RoutePattern
+               )
     end
 
     test "filter works" do
       assert %{"filter[abc]" => "123,45.67,abc,def"} =
-               flatten_params([filter: [abc: [123, 45.67, :abc, "def"]]], :stop)
+               flatten_params([filter: [abc: [123, 45.67, :abc, "def"]]], MBTAV3API.Stop)
     end
 
     test "uses custom serialize for filter" do
       assert %{"filter[route_type]" => "0,4", "filter[location_type]" => "0,1"} =
                flatten_params(
                  [filter: [route_type: [:light_rail, :ferry], location_type: [:stop, :station]]],
-                 :stop
+                 MBTAV3API.Stop
                )
     end
   end


### PR DESCRIPTION
### Summary

_Ticket:_ none
[Slack thread](https://mbta.slack.com/archives/C062QNAJZ2M/p1708640339133919?thread_ts=1708637850.326209&cid=C062QNAJZ2M)

This was a bit confusing to work with, and it's now substantially more obvious what the values in `includes/0` represent. Since the mapping between JSON:API types and Elixir modules is already specified the other direction in `module_for/1` and all the object modules `use MBTAV3API.JsonApi.Object` anyway, it's even trivial to implement `jsonapi_type/0` automatically.