### PR TITLE
feat: throttle stream updates

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -33,6 +33,8 @@ config :mobile_app_backend, :logger, [
    }}
 ]
 
+config :mobile_app_backend, MBTAV3API.Stream.Consumer, default_throttle_ms: 1000
+
 # Configure esbuild (the version is required)
 config :esbuild,
   version: "0.17.11",

--- a/lib/mbta_v3_api/stream/consumer.ex
+++ b/lib/mbta_v3_api/stream/consumer.ex
@@ -1,15 +1,17 @@
 defmodule MBTAV3API.Stream.Consumer do
   use GenStage
 
+  require Logger
   alias MBTAV3API.Stream
 
   defmodule State do
     @type t :: %__MODULE__{
             data: Stream.State.t(),
             destination: pid() | Phoenix.PubSub.topic(),
-            type: module()
+            type: module(),
+            throttle: %{ms: integer(), last_send: integer() | nil, timer: reference() | nil}
           }
-    defstruct [:data, :destination, :type]
+    defstruct [:data, :destination, :type, :throttle]
   end
 
   def start_link(opts) do
@@ -21,10 +23,21 @@ defmodule MBTAV3API.Stream.Consumer do
   def init(opts) do
     subscribe_to = Keyword.fetch!(opts, :subscribe_to)
 
+    throttle_ms =
+      Keyword.get(
+        opts,
+        :throttle_ms,
+        Keyword.fetch!(
+          Application.get_env(:mobile_app_backend, __MODULE__),
+          :default_throttle_ms
+        )
+      )
+
     state = %State{
       data: Stream.State.new(),
       destination: Keyword.fetch!(opts, :destination),
-      type: Keyword.fetch!(opts, :type)
+      type: Keyword.fetch!(opts, :type),
+      throttle: %{ms: throttle_ms, last_send: nil, timer: nil}
     }
 
     {:consumer, state, subscribe_to: subscribe_to}
@@ -34,18 +47,62 @@ defmodule MBTAV3API.Stream.Consumer do
   def handle_events(events, _from, state) do
     data = Stream.State.apply_events(state.data, events)
 
-    message = {:stream_data, data}
+    now = System.monotonic_time(:millisecond)
 
-    case state.destination do
-      pid when is_pid(pid) -> send(pid, message)
-      topic when is_binary(topic) -> MBTAV3API.Stream.PubSub.broadcast!(topic, message)
-    end
+    action_now =
+      cond do
+        is_nil(state.throttle.last_send) ->
+          :send_now
 
-    {:noreply, [], %{state | data: data}}
+        state.throttle.last_send + state.throttle.ms <= now ->
+          :send_now
+
+        is_nil(state.throttle.timer) ->
+          send_at = state.throttle.last_send + state.throttle.ms
+          {:send_at, send_at}
+
+        true ->
+          nil
+      end
+
+    throttle =
+      case action_now do
+        :send_now ->
+          send_update(data, state.destination)
+          %{state.throttle | last_send: now}
+
+        {:send_at, send_at} ->
+          ref = Process.send_after(self(), :send_update, send_at, abs: true)
+          %{state.throttle | timer: ref}
+
+        nil ->
+          state.throttle
+      end
+
+    {:noreply, [], %{state | data: data, throttle: throttle}}
   end
 
   @impl true
   def handle_call(:get_data, _from, state) do
     {:reply, state.data, [], state}
+  end
+
+  @impl true
+  def handle_info(:send_update, state) do
+    now = System.monotonic_time(:millisecond)
+    send_update(state.data, state.destination)
+    throttle = %{state.throttle | last_send: now, timer: nil}
+    {:noreply, [], %{state | throttle: throttle}}
+  end
+
+  defp send_update(data, destination) do
+    message = {:stream_data, data}
+
+    case destination do
+      pid when is_pid(pid) -> send(pid, message)
+      topic when is_binary(topic) -> MBTAV3API.Stream.PubSub.broadcast!(topic, message)
+    end
+
+    :ok
   end
 end

--- a/test/mobile_app_backend_web/channels/predictions_channel_test.exs
+++ b/test/mobile_app_backend_web/channels/predictions_channel_test.exs
@@ -12,6 +12,7 @@ defmodule MobileAppBackendWeb.PredictionsChannelTest do
   setup do
     reassign_env(:mobile_app_backend, :base_url, "https://api.example.net")
     reassign_env(:mobile_app_backend, :api_key, "abcdef")
+    reassign_env(:mobile_app_backend, MBTAV3API.Stream.Consumer, default_throttle_ms: 20)
 
     {:ok, socket} = connect(MobileAppBackendWeb.UserSocket, %{})
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Improve scalability of predictions streaming](https://app.asana.com/0/1205425564113216/1206467839191098/f), somewhat

The ServerSentEventStage library can batch up stream events to some extent, but I've frequently noticed that the predictions update multiple times in quick succession in the frontend, and upon further investigation, it's not infrequent to get, for example, 130 events and then 72 events and then 9 events all in a row, and there's no point in sending three updates in the same second just because of how the events got buffered.

However, now that I'm typing this up, it seems like that issue might go away depending on how we rebalance predictions subscriptions to improve scalability, so I'm marking this as a draft until I can validate that theory.