### PR TITLE
chore: update codeowners to backend group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,7 @@
 # See https://help.github.com/articles/about-codeowners/
 
 # Members of the following team will be notified of each pull request,
+
 # and merging PRs requires approval by a member of this team.
-* @mbta/mobile-app
+
+- @mbta/mobile-app-backend


### PR DESCRIPTION
### Summary

What is this PR for?
No ticket, updating codeowners to pull from the backend team