### PR TITLE
chore: use Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,9 @@ updates:
       time: "09:00"
     open-pull-requests-limit: 10
     versioning-strategy: lockfile-only
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "09:00"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
### Summary

_Ticket:_ none

We're getting Node.js 16 warnings (and occasionally Node.js 12 warnings) in our GitHub Actions workflows, so it seems like a good idea to automatically keep those dependencies up to date, too.