### PR TITLE
chore: fix codeowners formatting

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,5 @@
 # See https://help.github.com/articles/about-codeowners/
-
 # Members of the following team will be notified of each pull request,
-
 # and merging PRs requires approval by a member of this team.
 
-- @mbta/mobile-app-backend
+* @mbta/mobile-app-backend


### PR DESCRIPTION
### Summary

No ticket. https://github.com/mbta/mobile_app_backend/pull/97 changed the codeowners team, but also included auto-formatting that treated this file as markdown and interpreted the `*` as a bullet rather than an indicator of all files.

Removing that auto-formatting change so that auto-review assignment is no longer broken

