### PR TITLE
fix: keep both physical and logical platforms

### DIFF
--- a/lib/mobile_app_backend_web/controllers/nearby_controller.ex
+++ b/lib/mobile_app_backend_web/controllers/nearby_controller.ex
@@ -31,7 +31,6 @@ defmodule MobileAppBackendWeb.NearbyController do
       stops:
         stops
         |> Map.values()
-        |> Enum.filter(&Map.has_key?(pattern_ids_by_stop, &1.id))
         |> Enum.sort_by(
           &distance_in_degrees(&1.latitude || 0, &1.longitude || 0, latitude, longitude)
         ),


### PR DESCRIPTION
### Summary

_Ticket:_ [Investigate: reports that predictions don't match countdown clocks](https://app.asana.com/0/1205425564113216/1206846399376954/f)

As far as I can tell, once RTR knows which physical track a train will be at, it gives the prediction at that platform instead, but since that's a realtime observation, the route patterns are all associated with the logical platform instead.