### PR TITLE
feat(ShapesController): Return full segment for each route pattern

### DIFF
--- a/test/mobile_app_backend_web/controllers/shapes_controller_test.exs
+++ b/test/mobile_app_backend_web/controllers/shapes_controller_test.exs
@@ -90,7 +90,7 @@ defmodule MobileAppBackendWeb.ShapeControllerTest do
       reassign_env(:mobile_app_backend, MBTAV3API.Repository, RepositoryMock)
     end
 
-    test "returns route segments for the most canonical direction 0 route patterns with the associated shape",
+    test "when separate_overlapping_segments is true, returns non-overlapping segments for the most canonical direction 0 route patterns with the associated shape",
          %{conn: conn} do
       red_route = build(:route, id: "Red")
       andrew = build(:stop, id: "andrew", location_type: :station)
@@ -191,7 +191,8 @@ defmodule MobileAppBackendWeb.ShapeControllerTest do
         end
       end)
 
-      conn = get(conn, "/api/shapes/map-friendly/rail")
+      conn =
+        get(conn, "/api/shapes/map-friendly/rail", %{"separate_overlapping_segments" => "true"})
 
       %{"map_friendly_route_shapes" => map_friendly_route_shapes} = json_response(conn, 200)
 
@@ -229,6 +230,166 @@ defmodule MobileAppBackendWeb.ShapeControllerTest do
                          "source_route_pattern_id" => "red-braintree",
                          "stop_ids" => ["jfk/umass", "north_quincy"],
                          "other_patterns_by_stop_id" => %{}
+                       }
+                     ],
+                     "shape" => %{
+                       "id" => "braintree_shape",
+                       "polyline" => "braintree_shape_polyline"
+                     }
+                   }
+                 ]
+               }
+             ] =
+               map_friendly_route_shapes
+    end
+
+    test "when separate_overlapping_segments is not set, returns a segment per route pattern for the most canonical direction 0 route patterns with the associated shape",
+         %{conn: conn} do
+      red_route = build(:route, id: "Red")
+      andrew = build(:stop, id: "andrew", location_type: :station)
+      jfk = build(:stop, id: "jfk/umass", location_type: :station)
+
+      jfk_child_1 =
+        build(:stop, id: "jfk/umass-1", location_type: :stop, parent_station_id: jfk.id)
+
+      jfk_child_2 =
+        build(:stop, id: "jfk/umass-2", location_type: :stop, parent_station_id: jfk.id)
+
+      savin = build(:stop, id: "savin_hill", location_type: :station)
+      north_quincy = build(:stop, id: "north_quincy", location_type: :station)
+
+      ashmont_shape = build(:shape, id: "ashmont_shape", polyline: "ashmont_shape_polyline")
+      braintree_shape = build(:shape, id: "braintree_shape", polyline: "braintree_shape_polyline")
+
+      ashmont_trip =
+        build(:trip,
+          id: "ashmont_trip",
+          stop_ids: [andrew.id, jfk_child_1.id, savin.id],
+          shape_id: "ashmont_shape"
+        )
+
+      braintree_trip =
+        build(:trip,
+          id: "braintree_trip",
+          stop_ids: [andrew.id, jfk_child_2.id, north_quincy.id],
+          shape_id: "braintree_shape"
+        )
+
+      ashmont_rp =
+        build(:route_pattern,
+          id: "red-ashmont",
+          representative_trip_id: ashmont_trip.id,
+          route_id: "Red",
+          canonical: true,
+          typicality: :typical
+        )
+
+      braintree_rp =
+        build(:route_pattern,
+          id: "red-braintree",
+          representative_trip_id: braintree_trip.id,
+          route_id: "Red",
+          canonical: true,
+          typicality: :typical
+        )
+
+      rl_diversion_rp =
+        build(:route_pattern,
+          id: "rl_diversion",
+          route_id: "Red",
+          typicality: :diversion,
+          canonical: false
+        )
+
+      rl_canonical_direction_1 =
+        build(:route_pattern,
+          id: "rl_diversion",
+          route_id: "Red",
+          typicality: :typical,
+          canonical: true,
+          direction_id: 1
+        )
+
+      RepositoryMock
+      |> expect(:routes, 1, fn params, _opts ->
+        case params
+             |> Keyword.get(:filter)
+             |> Keyword.get(:type) do
+          [:light_rail, :heavy_rail, :commuter_rail] ->
+            ok_response([red_route], [
+              ashmont_rp,
+              braintree_rp,
+              rl_diversion_rp,
+              rl_canonical_direction_1
+            ])
+        end
+      end)
+
+      RepositoryMock
+      |> expect(:trips, 1, fn params, _opts ->
+        case params
+             |> Keyword.get(:filter)
+             |> Keyword.get(:id) do
+          ["ashmont_trip", "braintree_trip"] ->
+            ok_response([ashmont_trip, braintree_trip], [
+              ashmont_shape,
+              braintree_shape,
+              andrew,
+              jfk,
+              jfk_child_1,
+              jfk_child_2,
+              savin,
+              north_quincy
+            ])
+        end
+      end)
+
+      conn =
+        get(conn, "/api/shapes/map-friendly/rail")
+
+      %{"map_friendly_route_shapes" => map_friendly_route_shapes} = json_response(conn, 200)
+
+      assert [
+               %{
+                 "route_id" => "Red",
+                 "route_shapes" => [
+                   %{
+                     "source_route_pattern_id" => "red-ashmont",
+                     "source_route_id" => "Red",
+                     "route_segments" => [
+                       %{
+                         "id" => "andrew-savin_hill",
+                         "source_route_pattern_id" => "red-ashmont",
+                         "stop_ids" => ["andrew", "jfk/umass", "savin_hill"],
+                         "other_patterns_by_stop_id" => %{
+                           "andrew" => [
+                             %{"route_id" => "Red", "route_pattern_id" => "red-braintree"}
+                           ],
+                           "jfk/umass" => [
+                             %{"route_id" => "Red", "route_pattern_id" => "red-braintree"}
+                           ]
+                         }
+                       }
+                     ],
+                     "shape" => %{"id" => "ashmont_shape", "polyline" => "ashmont_shape_polyline"}
+                   },
+                   %{
+                     "source_route_pattern_id" => "red-braintree",
+                     "source_route_id" => "Red",
+                     "route_segments" => [
+                       %{
+                         "id" => "andrew-north_quincy",
+                         "source_route_id" => "Red",
+                         "source_route_pattern_id" => "red-braintree",
+                         "stop_ids" => ["andrew", "jfk/umass", "north_quincy"],
+                         "other_patterns_by_stop_id" => %{
+                           "andrew" => [
+                             %{"route_id" => "Red", "route_pattern_id" => "red-ashmont"}
+                           ],
+                           "jfk/umass" => [
+                             %{"route_id" => "Red", "route_pattern_id" => "red-ashmont"}
+                           ]
+                         }
                        }
                      ],
                      "shape" => %{


### PR DESCRIPTION
### Summary

_Ticket:_ [Improve alert styling for overlapping routes](https://app.asana.com/0/1205425564113216/1206923917064606/f)

What is this PR for?

This updates the "/shapes/map-friendly/rail" endpoint to *not* break up route patterns into non-overlapping segments by default and instead return all stops associated with each route pattern. This is a short-term fix to address unexpected gaps in route shapes as discussed in [this slack thread](https://mbta.slack.com/archives/C05QMG9GS9M/p1713453094417659). I've opted to leave the overlap detection logic in place in case we want to revisit it as part of the longer-term solution.

Pairs with https://github.com/mbta/mobile_app/pull/142 to ensure overlapping route shapes don't cover the special styling for alerting segments.