### PR TITLE
fix(Vehicle): parse nil occupancy status

### DIFF
--- a/lib/mbta_v3_api/vehicle.ex
+++ b/lib/mbta_v3_api/vehicle.ex
@@ -73,11 +73,16 @@ defmodule MBTAV3API.Vehicle do
       direction_id: item.attributes["direction_id"],
       latitude: item.attributes["latitude"],
       longitude: item.attributes["longitude"],
-      occupancy_status: parse_occupancy_status(item.attributes["occupancy_status"]),
+      occupancy_status: parse_optional_occupancy(item.attributes["occupancy_status"]),
       updated_at: Util.parse_datetime!(item.attributes["updated_at"]),
       route_id: JsonApi.Object.get_one_id(item.relationships["route"]),
       stop_id: JsonApi.Object.get_one_id(item.relationships["stop"]),
       trip_id: JsonApi.Object.get_one_id(item.relationships["trip"])
     }
   end
+
+  @spec parse_optional_occupancy(String.t() | nil) :: occupancy_status()
+  defp parse_optional_occupancy(occupancy_status)
+  defp parse_optional_occupancy(nil), do: :no_data_available
+  defp parse_optional_occupancy(status), do: parse_occupancy_status(status)
 end

--- a/test/mbta_v3_api/vehicle_test.exs
+++ b/test/mbta_v3_api/vehicle_test.exs
@@ -38,4 +38,38 @@ defmodule MBTAV3API.VehicleTest do
                }
              })
   end
+
+  test "parse/1 with nil occupancy status" do
+    assert %Vehicle{
+             id: "y1886",
+             bearing: 315,
+             current_status: :in_transit_to,
+             direction_id: 0,
+             latitude: 42.359901428222656,
+             longitude: -71.09449005126953,
+             occupancy_status: :no_data_available,
+             route_id: "1",
+             stop_id: "99",
+             trip_id: "61391720",
+             updated_at: ~B[2024-01-24 17:08:51]
+           } ==
+             Vehicle.parse(%JsonApi.Item{
+               type: "vehicle",
+               id: "y1886",
+               attributes: %{
+                 "bearing" => 315,
+                 "current_status" => "IN_TRANSIT_TO",
+                 "occupancy_status" => nil,
+                 "direction_id" => 0,
+                 "latitude" => 42.359901428222656,
+                 "longitude" => -71.09449005126953,
+                 "updated_at" => "2024-01-24T17:08:51-05:00"
+               },
+               relationships: %{
+                 "route" => %JsonApi.Reference{type: "route", id: "1"},
+                 "stop" => %JsonApi.Reference{type: "stop", id: "99"},
+                 "trip" => %JsonApi.Reference{type: "trip", id: "61391720"}
+               }
+             })
+  end
 end


### PR DESCRIPTION
### Summary

What is this PR for?
No ticket, fix for https://github.com/mbta/mobile_app_backend/pull/139 not accounting for occupancy_status as a nullable field.