### PR TITLE
ci: Deploy to prod workflow

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,14 @@
+name: Deploy to Prod
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('Deploy {0} {1} to Prod', github.ref_type, github.ref_name) || '' }}
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy ${{ github.ref_type }} ${{ github.ref_name }} to Staging
+    uses: ./.github/workflows/deploy.yml
+    with:
+      env: prod
+      deploy-desc: ${{ github.ref_type }} ${{ github.ref_name }}
+    secrets: inherit


### PR DESCRIPTION
### Summary

_Ticket:_ [Create prod backend with autoscaling](https://app.asana.com/0/1205732265579288/1207426144069469/f)

What is this PR for?

Initial workflow to trigger a deploy to the prod environment to confirm it is working as expected. 

In the future we'll want more documentation around this and potentially configure to deploy based on release tags, but for the short term this will make it easy to do a test prod deploy.
