### PR TITLE
feat: Add cause and updated_at fields to alert

### DIFF
--- a/lib/mbta_v3_api/alert.ex
+++ b/lib/mbta_v3_api/alert.ex
@@ -7,13 +7,68 @@ defmodule MBTAV3API.Alert do
   @type t :: %__MODULE__{
           id: String.t(),
           active_period: [ActivePeriod.t()],
+          cause: cause(),
           description: String.t() | nil,
           effect: effect(),
           effect_name: String.t() | nil,
           header: String.t() | nil,
           informed_entity: [InformedEntity.t()],
-          lifecycle: lifecycle()
+          lifecycle: lifecycle(),
+          updated_at: DateTime.t()
         }
+
+  Util.declare_enum(
+    :cause,
+    Util.enum_values(:uppercase_string, [
+      :accident,
+      :amtrak,
+      :an_earlier_mechanical_problem,
+      :an_earlier_signal_problem,
+      :autos_impeding_service,
+      :coast_guard_restriction,
+      :congestion,
+      :construction,
+      :crossing_malfunction,
+      :demonstration,
+      :disabled_bus,
+      :disabled_train,
+      :drawbridge_being_raised,
+      :electrical_work,
+      :fire,
+      :fog,
+      :freight_train_interference,
+      :hazmat_condition,
+      :heavy_ridership,
+      :high_winds,
+      :holiday,
+      :hurricane,
+      :ice_in_harbor,
+      :maintenance,
+      :mechanical_problem,
+      :medical_emergency,
+      :other_cause,
+      :parade,
+      :police_action,
+      :police_activity,
+      :power_problem,
+      :severe_weather,
+      :signal_problem,
+      :slippery_rail,
+      :snow,
+      :special_event,
+      :speed_restriction,
+      :strike,
+      :switch_problem,
+      :technical_problem,
+      :tie_replacement,
+      :track_problem,
+      :track_work,
+      :traffic,
+      :unruly_passenger,
+      :unknown_cause,
+      :weather
+    ])
+  )
 
   Util.declare_enum(
     :effect,
@@ -46,6 +101,7 @@ defmodule MBTAV3API.Alert do
       :stop_closure,
       :stop_move,
       :stop_moved,
+      :stop_shoveling,
       :summary,
       :suspension,
       :track_change,
@@ -62,24 +118,28 @@ defmodule MBTAV3API.Alert do
   defstruct [
     :id,
     :active_period,
+    :cause,
     :description,
     :effect,
     :effect_name,
     :header,
     :informed_entity,
-    :lifecycle
+    :lifecycle,
+    :updated_at
   ]
 
   @impl JsonApi.Object
   def fields do
     [
       :active_period,
+      :cause,
       :description,
       :effect,
       :effect_name,
       :header,
       :informed_entity,
-      :lifecycle
+      :lifecycle,
+      :updated_at
     ]
   end
 
@@ -108,12 +168,14 @@ defmodule MBTAV3API.Alert do
     %__MODULE__{
       id: item.id,
       active_period: Enum.map(item.attributes["active_period"], &ActivePeriod.parse/1),
+      cause: parse_cause(item.attributes["cause"]),
       description: item.attributes["description"],
       effect: parse_effect(item.attributes["effect"]),
       effect_name: item.attributes["effect_name"],
       header: item.attributes["header"],
       informed_entity: Enum.map(item.attributes["informed_entity"], &InformedEntity.parse/1),
-      lifecycle: parse_lifecycle(item.attributes["lifecycle"])
+      lifecycle: parse_lifecycle(item.attributes["lifecycle"]),
+      updated_at: Util.parse_datetime!(item.attributes["updated_at"])
     }
   end
 end

--- a/test/mbta_v3_api/alert_test.exs
+++ b/test/mbta_v3_api/alert_test.exs
@@ -15,7 +15,7 @@ defmodule MBTAV3API.AlertTest do
       fn %Req.Request{url: %URI{path: "/alerts"}, options: %{params: params}} ->
         assert params == %{
                  "fields[alert]" =>
-                   "active_period,description,effect,effect_name,header,informed_entity,lifecycle",
+                   "active_period,cause,description,effect,effect_name,header,informed_entity,lifecycle,updated_at",
                  "filter[lifecycle]" => "NEW,ONGOING,ONGOING_UPCOMING",
                  "filter[stop]" =>
                    "9983,6542,1241,8281,place-boyls,8279,49002,6565,place-tumnl,145,place-pktrm,place-bbsta"
@@ -29,6 +29,7 @@ defmodule MBTAV3API.AlertTest do
                  "active_period" => [
                    %{"end" => "2024-02-08T19:12:40-05:00", "start" => "2024-02-08T14:38:00-05:00"}
                  ],
+                 "cause" => "UNKNOWN_CAUSE",
                  "description" => "Description 1",
                  "effect" => "DELAY",
                  "header" => "Header 1",
@@ -39,7 +40,8 @@ defmodule MBTAV3API.AlertTest do
                      "route_type" => 3
                    }
                  ],
-                 "lifecycle" => "NEW"
+                 "lifecycle" => "NEW",
+                 "updated_at" => "2024-02-08T14:38:00-05:00"
                },
                "id" => "552825",
                "links" => %{"self" => "/alerts/552825"},
@@ -50,6 +52,7 @@ defmodule MBTAV3API.AlertTest do
                  "active_period" => [
                    %{"end" => "2024-02-08T19:12:40-05:00", "start" => "2024-02-08T12:55:00-05:00"}
                  ],
+                 "cause" => "UNRULY_PASSENGER",
                  "description" => "Description 2",
                  "effect" => "DELAY",
                  "header" => "Header 2",
@@ -60,7 +63,8 @@ defmodule MBTAV3API.AlertTest do
                      "route_type" => 3
                    }
                  ],
-                 "lifecycle" => "NEW"
+                 "lifecycle" => "NEW",
+                 "updated_at" => "2024-02-08T12:55:00-05:00"
                },
                "id" => "552803",
                "links" => %{"self" => "/alerts/552803"},
@@ -98,6 +102,7 @@ defmodule MBTAV3API.AlertTest do
                active_period: [
                  %Alert.ActivePeriod{start: ~B[2024-02-08 14:38:00], end: ~B[2024-02-08 19:12:40]}
                ],
+               cause: :unknown_cause,
                description: "Description 1",
                effect: :delay,
                header: "Header 1",
@@ -108,13 +113,15 @@ defmodule MBTAV3API.AlertTest do
                    route_type: :bus
                  }
                ],
-               lifecycle: :new
+               lifecycle: :new,
+               updated_at: ~B[2024-02-08 14:38:00]
              },
              %Alert{
                id: "552803",
                active_period: [
                  %Alert.ActivePeriod{start: ~B[2024-02-08 12:55:00], end: ~B[2024-02-08 19:12:40]}
                ],
+               cause: :unruly_passenger,
                description: "Description 2",
                effect: :delay,
                header: "Header 2",
@@ -125,7 +132,8 @@ defmodule MBTAV3API.AlertTest do
                    route_type: :bus
                  }
                ],
-               lifecycle: :new
+               lifecycle: :new,
+               updated_at: ~B[2024-02-08 12:55:00]
              }
            ]
   end
@@ -203,19 +211,22 @@ defmodule MBTAV3API.AlertTest do
                "active_period" => [
                  %{"start" => "2024-02-12T11:49:00-05:00", "end" => "2024-02-12T14:26:40-05:00"}
                ],
+               "cause" => "FIRE",
                "description" => "Description",
                "effect" => "DELAY",
                "header" => "Header",
                "informed_entity" => [
                  %{"activities" => ["BOARD", "EXIT", "RIDE"], "route" => "39", "route_type" => 3}
                ],
-               "lifecycle" => "NEW"
+               "lifecycle" => "NEW",
+               "updated_at" => "2024-02-12T11:49:00-05:00"
              }
            }) == %Alert{
              id: "553407",
              active_period: [
                %Alert.ActivePeriod{start: ~B[2024-02-12 11:49:00], end: ~B[2024-02-12 14:26:40]}
              ],
+             cause: :fire,
              description: "Description",
              effect: :delay,
              header: "Header",
@@ -226,7 +237,8 @@ defmodule MBTAV3API.AlertTest do
                  route_type: :bus
                }
              ],
-             lifecycle: :new
+             lifecycle: :new,
+             updated_at: ~B[2024-02-12 11:49:00]
            }
   end
 end

--- a/test/mbta_v3_api/repository_test.exs
+++ b/test/mbta_v3_api/repository_test.exs
@@ -15,7 +15,7 @@ defmodule MBTAV3API.RepositoryTest do
       fn %Req.Request{url: %URI{path: "/alerts"}, options: %{params: params}} ->
         assert params == %{
                  "fields[alert]" =>
-                   "active_period,description,effect,effect_name,header,informed_entity,lifecycle",
+                   "active_period,cause,description,effect,effect_name,header,informed_entity,lifecycle,updated_at",
                  "filter[lifecycle]" => "NEW,ONGOING,ONGOING_UPCOMING",
                  "filter[stop]" =>
                    "9983,6542,1241,8281,place-boyls,8279,49002,6565,place-tumnl,145,place-pktrm,place-bbsta"
@@ -29,6 +29,7 @@ defmodule MBTAV3API.RepositoryTest do
                  "active_period" => [
                    %{"end" => "2024-02-08T19:12:40-05:00", "start" => "2024-02-08T14:38:00-05:00"}
                  ],
+                 "cause" => "AMTRAK",
                  "description" => "Description 1",
                  "effect" => "DELAY",
                  "header" => "Header 1",
@@ -39,7 +40,8 @@ defmodule MBTAV3API.RepositoryTest do
                      "route_type" => 3
                    }
                  ],
-                 "lifecycle" => "NEW"
+                 "lifecycle" => "NEW",
+                 "updated_at" => "2024-02-08T14:38:00-05:00"
                },
                "id" => "552825",
                "links" => %{"self" => "/alerts/552825"},
@@ -50,6 +52,7 @@ defmodule MBTAV3API.RepositoryTest do
                  "active_period" => [
                    %{"end" => "2024-02-08T19:12:40-05:00", "start" => "2024-02-08T12:55:00-05:00"}
                  ],
+                 "cause" => "HURRICANE",
                  "description" => "Description 2",
                  "effect" => "DELAY",
                  "header" => "Header 2",
@@ -60,7 +63,8 @@ defmodule MBTAV3API.RepositoryTest do
                      "route_type" => 3
                    }
                  ],
-                 "lifecycle" => "NEW"
+                 "lifecycle" => "NEW",
+                 "updated_at" => "2024-02-08T12:55:00-05:00"
                },
                "id" => "552803",
                "links" => %{"self" => "/alerts/552803"},
@@ -98,6 +102,7 @@ defmodule MBTAV3API.RepositoryTest do
                active_period: [
                  %Alert.ActivePeriod{start: ~B[2024-02-08 14:38:00], end: ~B[2024-02-08 19:12:40]}
                ],
+               cause: :amtrak,
                description: "Description 1",
                effect: :delay,
                header: "Header 1",
@@ -108,13 +113,15 @@ defmodule MBTAV3API.RepositoryTest do
                    route_type: :bus
                  }
                ],
-               lifecycle: :new
+               lifecycle: :new,
+               updated_at: ~B[2024-02-08 14:38:00]
              },
              %Alert{
                id: "552803",
                active_period: [
                  %Alert.ActivePeriod{start: ~B[2024-02-08 12:55:00], end: ~B[2024-02-08 19:12:40]}
                ],
+               cause: :hurricane,
                description: "Description 2",
                effect: :delay,
                header: "Header 2",
@@ -125,7 +132,8 @@ defmodule MBTAV3API.RepositoryTest do
                    route_type: :bus
                  }
                ],
-               lifecycle: :new
+               lifecycle: :new,
+               updated_at: ~B[2024-02-08 12:55:00]
              }
            ]
   end


### PR DESCRIPTION
### Summary

_Ticket:_ [[Disruptions] Initial Disruptions details content](https://app.asana.com/0/1205732265579288/1207678190799469/f)

Add two more fields to alerts which are required for displaying the alert details page.

Must be merged before https://github.com/mbta/mobile_app/pull/338
