### PR TITLE
fix: fix ClientConfig module name and path

### DIFF
--- a/lib/mobile_app_backend/client_config.ex
+++ b/lib/mobile_app_backend/client_config.ex
@@ -1,4 +1,4 @@
-defmodule MobielAppBackend.ClientConfig do
+defmodule MobileAppBackend.ClientConfig do
   @type t :: %__MODULE__{
           mapbox_public_token: String.t()
         }

--- a/lib/mobile_app_backend_web/controllers/client_config_controller.ex
+++ b/lib/mobile_app_backend_web/controllers/client_config_controller.ex
@@ -1,5 +1,5 @@
 defmodule MobileAppBackendWeb.ClientConfigController do
-  alias MobielAppBackend.ClientConfig
+  alias MobileAppBackend.ClientConfig
   use MobileAppBackendWeb, :controller
 
   @spec config(Plug.Conn.t(), any()) :: Plug.Conn.t()


### PR DESCRIPTION
### Summary

_Ticket:_ none

There's a typo in the `ClientConfig` module name - `Mobiel` instead of `Mobile` - and since it's within `MobileAppBackend` it should be in the `mobile_app_backend` folder.

I caught this when the PR that created this file was under review, but frustratingly, I forgot to actually submit the review, so it's still pending:
<img width="924" alt="Screenshot 2024-08-22 at 10 17 06 AM" src="https://github.com/user-attachments/assets/dfc0c569-179b-43df-ae58-159e0bfb4901">