### PR TITLE
feat(Store.Predictions): Add support for writing + reading predictions

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -7,6 +7,10 @@ config :mobile_app_backend, MobileAppBackendWeb.Endpoint,
   secret_key_base: "i2tUYeAO95DpQJMjLPg+aBuneGbF6hGMyTvth/i1csZT7LeeH6ZsWpDO9F9IkJ7f",
   server: false
 
+# Don't start the real predictions processes so we can test with
+# isolated fake prediction processes
+config :mobile_app_backend, start_predictions_store?: false
+
 # Print only warnings and errors during test
 config :logger, level: :warning
 

--- a/lib/mbta_v3_api/store.ex
+++ b/lib/mbta_v3_api/store.ex
@@ -27,4 +27,9 @@ defmodule MBTAV3API.Store do
   Retrieve all records that match the given filter keys.
   """
   @callback fetch(keyword()) :: [JsonApi.Object.t()]
+
+  @doc """
+  Retrieve all records that match any of the given filter keyword sets
+  """
+  @callback fetch_multi_filter([keyword()]) :: [JsonApi.Object.t()]
 end

--- a/lib/mbta_v3_api/store/predictions.ex
+++ b/lib/mbta_v3_api/store/predictions.ex
@@ -5,28 +5,153 @@ defmodule MBTAV3API.Store.Predictions do
 
   Based on https://github.com/mbta/dotcom/blob/main/lib/predictions/store.ex
   """
+  use GenServer
+  require Logger
+  alias MBTAV3API.{Prediction}
+
   @behaviour MBTAV3API.Store
 
+  @predictions_table_name :predictions_from_streams
+
+  @spec start_link(Keyword.t()) :: GenServer.on_start()
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
   @impl true
-  def process_upsert(_event, _objects) do
-    # TODO
+  def init(_) do
+    _table = :ets.new(@predictions_table_name, [:named_table])
+
+    {:ok, %{}}
+  end
+
+  @impl true
+  def fetch(fetch_keys) do
+    match_spec = prediction_match_spec(fetch_keys)
+
+    timed_fetch([{match_spec, [], [:"$1"]}], "fetch_keys=#{inspect(fetch_keys)}")
+  end
+
+  @impl true
+  def fetch_multi_filter(fetch_keys_list) do
+    match_specs =
+      fetch_keys_list
+      |> Enum.map(&prediction_match_spec(&1))
+      |> Enum.map(&{&1, [], [:"$1"]})
+
+    timed_fetch(match_specs, "multi_fetch=true fetch_keys=#{inspect(fetch_keys_list)}")
+  end
+
+  defp prediction_match_spec(fetch_keys) do
+    # https://www.erlang.org/doc/apps/erts/match_spec.html
+    # Match the fields specified in the fetch_keys and return the full prediction
+    # see to_record/1 for the defined order of fields
+    {
+      Keyword.get(fetch_keys, :prediction_id, :_) || :_,
+      Keyword.get(fetch_keys, :route_id, :_) || :_,
+      Keyword.get(fetch_keys, :stop_id, :_) || :_,
+      Keyword.get(fetch_keys, :direction_id, :_) || :_,
+      Keyword.get(fetch_keys, :trip_id, :_) || :_,
+      Keyword.get(fetch_keys, :vehicle_id, :_) || :_,
+      :"$1"
+    }
+  end
+
+  defp timed_fetch(match_specs, log_metadata) do
+    {time_micros, results} =
+      :timer.tc(:ets, :select, [@predictions_table_name, match_specs])
+
+    time_ms = time_micros / 1000
+    Logger.info("#{__MODULE__} fetch predictions #{log_metadata} duration_ms=#{time_ms}")
+    results
+  end
+
+  @impl true
+  def process_upsert(event, data) do
+    GenServer.call(__MODULE__, {:process_upsert, event, data})
     :ok
   end
 
   @impl true
-  def process_reset(_objects, _scope) do
-    # TODO
+  def process_reset(data, scope) do
+    GenServer.call(__MODULE__, {:process_reset, data, scope})
     :ok
   end
 
   @impl true
-  def process_remove(_references) do
-    # TODO
+  def process_remove(references) do
+    GenServer.call(__MODULE__, {:process_remove, references})
     :ok
   end
 
   @impl true
-  def fetch(_scope) do
-    []
+  def handle_call({:process_upsert, _event, data}, _from, state) do
+    upsert_data(data)
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_call({:process_reset, data, scope}, _from, state) do
+    clear_data(scope)
+    upsert_data(data)
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_call({:process_remove, references}, _from, state) do
+    for reference <- references do
+      case reference do
+        %{type: "prediction", id: id} -> :ets.delete(@predictions_table_name, id)
+        # TODO: handle other included types like trips
+        _ -> :ok
+      end
+    end
+
+    {:reply, :ok, state}
+  end
+
+  defp upsert_data(data) do
+    prediction_records =
+      data
+      # TODO: handle other included types like trips
+      |> Enum.filter(&match?(%Prediction{}, &1))
+      |> Enum.map(&to_record/1)
+
+    :ets.insert(@predictions_table_name, prediction_records)
+  end
+
+  defp clear_data(keys) do
+    match_pattern = {
+      Keyword.get(keys, :prediction_id, :_) || :_,
+      Keyword.get(keys, :route_id, :_) || :_,
+      Keyword.get(keys, :stop_id, :_) || :_,
+      Keyword.get(keys, :direction_id, :_) || :_,
+      Keyword.get(keys, :trip_id, :_) || :_,
+      Keyword.get(keys, :vehicle_id, :_) || :_,
+      :"$1"
+    }
+
+    :ets.select_delete(@predictions_table_name, [{match_pattern, [], [true]}])
+  end
+
+  defp to_record(
+         %Prediction{
+           id: id,
+           direction_id: direction_id,
+           route_id: route_id,
+           stop_id: stop_id,
+           trip_id: trip_id,
+           vehicle_id: vehicle_id
+         } = prediction
+       ) do
+    {
+      id,
+      route_id,
+      stop_id,
+      direction_id,
+      trip_id,
+      vehicle_id,
+      prediction
+    }
   end
 end

--- a/lib/mbta_v3_api/supervisor.ex
+++ b/lib/mbta_v3_api/supervisor.ex
@@ -7,12 +7,21 @@ defmodule MBTAV3API.Supervisor do
 
   @impl true
   def init(_) do
-    children = [
-      MBTAV3API.Stream.Registry,
-      MBTAV3API.Stream.PubSub,
-      MBTAV3API.Stream.Supervisor,
-      MBTAV3API.Stream.Health
-    ]
+    start_predictions_store? =
+      Application.get_env(:mobile_app_backend, :start_predictions_store?, true)
+
+    children =
+      if start_predictions_store? do
+        [MBTAV3API.Store.Predictions]
+      else
+        []
+      end ++
+        [
+          MBTAV3API.Stream.Registry,
+          MBTAV3API.Stream.PubSub,
+          MBTAV3API.Stream.Supervisor,
+          MBTAV3API.Stream.Health
+        ]
 
     Supervisor.init(children, strategy: :one_for_one)
   end

--- a/test/mbta_v3_api/store/predictions_test.exs
+++ b/test/mbta_v3_api/store/predictions_test.exs
@@ -1,0 +1,136 @@
+defmodule MBTAV3API.Store.PredictionsTest do
+  use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
+  import MobileAppBackend.Factory
+  import Test.Support.Helpers
+  import Test.Support.Sigils
+
+  alias MBTAV3API.{JsonApi.Reference, Store}
+
+  describe "process_events" do
+    setup do
+      # Don't start the real predictions processes so we can test with an isolated Predictions store
+      reassign_env(:mobile_app_backend, :start_predictions_store?, false)
+      start_link_supervised!(Store.Predictions)
+      :ok
+    end
+
+    test "process_upsert when add" do
+      prediction_1 = build(:prediction, id: "1", stop_id: "12345")
+      prediction_2 = build(:prediction, id: "2", stop_id: "12345")
+
+      Store.Predictions.process_upsert(:add, [prediction_1, prediction_2])
+
+      assert [prediction_1, prediction_2] ==
+               Enum.sort_by(Store.Predictions.fetch(stop_id: "12345"), & &1.id)
+    end
+
+    test "process_upsert when update" do
+      prediction_1 = build(:prediction, id: "1", stop_id: "12345")
+      prediction_2 = build(:prediction, id: "2", stop_id: "12345")
+
+      prediction_1_update =
+        build(:prediction, id: "1", stop_id: "12345", departure_time: ~B[2024-03-20 16:42:01])
+
+      Store.Predictions.process_upsert(:add, [prediction_1, prediction_2])
+      Store.Predictions.process_upsert(:update, [prediction_1_update])
+
+      assert [prediction_1_update, prediction_2] ==
+               Enum.sort_by(Store.Predictions.fetch(stop_id: "12345"), & &1.id)
+    end
+
+    test "process_remove" do
+      prediction_1 = build(:prediction, id: "1", stop_id: "12345")
+      prediction_2 = build(:prediction, id: "2", stop_id: "12345")
+
+      Store.Predictions.process_upsert(:add, [prediction_1, prediction_2])
+      Store.Predictions.process_remove([%Reference{type: "prediction", id: "1"}])
+
+      assert [prediction_2] ==
+               Enum.sort_by(Store.Predictions.fetch(stop_id: "12345"), & &1.id)
+    end
+
+    test "process_reset" do
+      prediction_66 = build(:prediction, id: "1", stop_id: "12345", route_id: "66")
+      prediction_66_2 = build(:prediction, id: "2", stop_id: "12345", route_id: "66")
+      prediction_39 = build(:prediction, id: "3", stop_id: "12345", route_id: "39")
+
+      Store.Predictions.process_upsert(:add, [prediction_66, prediction_39])
+      Store.Predictions.process_reset([prediction_66_2], route_id: "66")
+
+      assert [prediction_66_2, prediction_39] ==
+               Enum.sort_by(Store.Predictions.fetch(stop_id: "12345"), & &1.id)
+    end
+  end
+
+  describe "fetch" do
+    setup do
+      reassign_env(:mobile_app_backend, :start_predictions_store?, false)
+      start_link_supervised!(Store.Predictions)
+      :ok
+    end
+
+    test "by stop_id" do
+      prediction_1 = build(:prediction, id: "1", stop_id: "12345")
+      prediction_2 = build(:prediction, id: "2", stop_id: "6789")
+
+      Store.Predictions.process_upsert(:add, [prediction_1, prediction_2])
+
+      assert [prediction_1] ==
+               Enum.sort_by(Store.Predictions.fetch(stop_id: "12345"), & &1.id)
+    end
+
+    test "by route_id" do
+      prediction_1 = build(:prediction, id: "1", route_id: "66")
+      prediction_2 = build(:prediction, id: "2", route_id: "39")
+
+      Store.Predictions.process_upsert(:add, [prediction_1, prediction_2])
+
+      assert [prediction_1] ==
+               Enum.sort_by(Store.Predictions.fetch(route_id: "66"), & &1.id)
+    end
+
+    test "by trip_id" do
+      prediction_1 = build(:prediction, id: "1", trip_id: "t1")
+      prediction_2 = build(:prediction, id: "2", trip_id: "t2")
+
+      Store.Predictions.process_upsert(:add, [prediction_1, prediction_2])
+
+      assert [prediction_1] ==
+               Enum.sort_by(Store.Predictions.fetch(trip_id: "t1"), & &1.id)
+    end
+
+    test "logs duration" do
+      set_log_level(:info)
+      prediction_1 = build(:prediction, id: "1", stop_id: "12345")
+
+      Store.Predictions.process_upsert(:add, [prediction_1])
+      msg = capture_log([level: :info], fn -> Store.Predictions.fetch(stop_id: "12345") end)
+
+      assert msg =~
+               "Elixir.MBTAV3API.Store.Predictions fetch predictions fetch_keys=[stop_id: \"12345\"] duration_ms="
+    end
+  end
+
+  describe "fetch_multi_filters" do
+    setup do
+      reassign_env(:mobile_app_backend, :start_predictions_store?, false)
+      start_link_supervised!(Store.Predictions)
+      :ok
+    end
+
+    test "process_upsert when add" do
+      prediction_1 = build(:prediction, id: "1", stop_id: "12345")
+      prediction_2 = build(:prediction, id: "2", stop_id: "6789")
+      prediction_3 = build(:prediction, id: "3", stop_id: "00000")
+
+      Store.Predictions.process_upsert(:add, [prediction_1, prediction_2, prediction_3])
+
+      assert [prediction_1, prediction_2] ==
+               Enum.sort_by(
+                 Store.Predictions.fetch_multi_filter([[stop_id: "12345"], [stop_id: "6789"]]),
+                 & &1.id
+               )
+    end
+  end
+end


### PR DESCRIPTION
### Summary

_Ticket:_ [Predictions Scalability: new channel that publishes predictions updates in chunks](https://app.asana.com/0/1205732265579288/1207791938443975/f)

What is this PR for?

This PR adds only the functionality for reading + writing predictions to the ETS store. The functionality for actually using this ETS table is underway in https://github.com/mbta/mobile_app_backend/pull/186. 