### PR TITLE
feat: log finch pool health stats periodically

### DIFF
--- a/lib/mbta_v3_api/stream/instance.ex
+++ b/lib/mbta_v3_api/stream/instance.ex
@@ -131,7 +131,7 @@ defmodule MBTAV3API.Stream.Instance do
 
     consumer_subscribers =
       if consumer_dest do
-        Registry.count_match(MBTAV3API.Stream.PubSub, consumer_dest, :_)
+        length(Registry.lookup(MBTAV3API.Stream.PubSub, consumer_dest))
       end
 
     healthy = consumer_alive

--- a/lib/mobile_app_backend/application.ex
+++ b/lib/mobile_app_backend/application.ex
@@ -14,7 +14,13 @@ defmodule MobileAppBackend.Application do
       {DNSCluster,
        query: Application.get_env(:mobile_app_backend, :dns_cluster_query) || :ignore},
       Supervisor.child_spec({Phoenix.PubSub, name: MobileAppBackend.PubSub}, id: :general_pubsub),
+      {Finch,
+       name: Finch.CustomPool,
+       pools: %{
+         :default => [size: 200, start_pool_metrics?: true]
+       }},
       MBTAV3API.Supervisor,
+      {MobileAppBackend.FinchPoolHealth, pool_name: Finch.CustomPool},
       MobileAppBackend.MapboxTokenRotator,
       MobileAppBackend.StopPredictions.Registry,
       Supervisor.child_spec({Phoenix.PubSub, name: MobileAppBackend.StopPredictions.PubSub},

--- a/lib/mobile_app_backend/finch_pool_health.ex
+++ b/lib/mobile_app_backend/finch_pool_health.ex
@@ -1,0 +1,43 @@
+defmodule MobileAppBackend.FinchPoolHealth do
+  use GenServer
+  require Logger
+
+  @interval :timer.seconds(5)
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @impl true
+  def init(opts) do
+    pool_name = Keyword.fetch!(opts, :pool_name)
+    get_pool_status_fn = Keyword.get(opts, :get_pool_status_fn, &Finch.get_pool_status/2)
+    Process.send_after(self(), :check, @interval)
+
+    {:ok, %{pool_name: pool_name, get_pool_status_fn: get_pool_status_fn}}
+  end
+
+  @impl true
+  def handle_info(:check, %{pool_name: pool_name, get_pool_status_fn: get_pool_status_fn} = state) do
+    v3_api_url = Application.get_env(:mobile_app_backend, :base_url)
+
+    case get_pool_status_fn.(pool_name, v3_api_url) do
+      {:error, :not_found} ->
+        Logger.info("#{__MODULE__} pool not found")
+
+      {:error, error} ->
+        Logger.warning("#{__MODULE__} pool health error=#{inspect(error)}")
+
+      {:ok, statuses} ->
+        Enum.each(statuses, fn status ->
+          Logger.info(
+            "#{__MODULE__} pool_health available_connections=#{status.available_connections} in_use_connections=#{status.in_use_connections} pool_index=#{status.pool_index} pool_size=#{status.pool_size}"
+          )
+        end)
+    end
+
+    Process.send_after(self(), :check, @interval)
+
+    {:noreply, state}
+  end
+end

--- a/test/mobile_app_backend/finch_pool_health_test.exs
+++ b/test/mobile_app_backend/finch_pool_health_test.exs
@@ -1,0 +1,53 @@
+defmodule MobileAppBackend.FinchPoolHealthTest do
+  use ExUnit.Case
+  alias MobileAppBackend.FinchPoolHealth
+  import ExUnit.CaptureLog
+  import Test.Support.Helpers
+
+  describe "handle_info/1" do
+    test "when pool not found yet, logs error" do
+      set_log_level(:info)
+
+      msg =
+        capture_log(fn ->
+          FinchPoolHealth.handle_info(:check, %{
+            pool_name: "test_pool",
+            get_pool_status_fn: fn _, _ -> {:error, :not_found} end
+          })
+        end)
+
+      assert msg =~ "pool not found"
+    end
+
+    test "when error, logs warning" do
+      set_log_level(:warning)
+
+      msg =
+        capture_log(fn ->
+          FinchPoolHealth.handle_info(:check, %{
+            pool_name: "test_pool",
+            get_pool_status_fn: fn _, _ -> {:error, :other_error} end
+          })
+        end)
+
+      assert msg =~ "error=:other_error"
+    end
+
+    test "when pools found, logs status" do
+      set_log_level(:info)
+
+      status = %{available_connections: 5, in_use_connections: 10, pool_index: 1, pool_size: 15}
+
+      msg =
+        capture_log(fn ->
+          FinchPoolHealth.handle_info(:check, %{
+            pool_name: "test_pool",
+            get_pool_status_fn: fn _, _ -> {:ok, [status]} end
+          })
+        end)
+
+      assert msg =~
+               "pool_health available_connections=#{status.available_connections} in_use_connections=#{status.in_use_connections} pool_index=#{status.pool_index} pool_size=#{status.pool_size}"
+    end
+  end
+end


### PR DESCRIPTION
### Summary

No ticket, but identified as an observability improvement while working on 
 [Predictions Scalability: new channel that publishes predictions updates in chunks](https://app.asana.com/0/1205732265579288/1207791938443975/f). 

What is this PR for?
We suspect there are some issues with request pooling based on unexpectedly slow req response logs under load testing. This will help us identify if that is the case ([slack thread](https://mbta.slack.com/archives/GP5QJM98A/p1726249147438039))