### PR TITLE
util: Add VS Code configs for running mix tasks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "mix_task",
+            "request": "launch",
+            "name": "mix phx.server",
+            "task": "phx.server",
+            "taskArgs": [],
+            "projectDir": "${workspaceRoot}",
+            "debugAutoInterpretAllModules": false,
+            "exitAfterTaskReturns": false
+        },
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,23 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "test",
+            "type": "shell",
+            "command": "mix test",
+            "group": "test"
+        },
+        {
+            "label": "deps.compile",
+            "type": "shell",
+            "command": "mix deps.compile",
+            "group": "build"
+        },
+        {
+            "label": "deps.get",
+            "type": "shell",
+            "command": "mix deps.get",
+            "group": "build"
+        }
+    ]
+}


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket

I put these together last time I was working on the backend, partly for ease of running and keybinding basic commands from the editor, but also because running through the Code runner vs a regular terminal gives easy access to log filtering, and that's really helpful when doing local debugging, since the backend logs are painfully noisy.

Not sure if anyone else on the team even uses VS Code, and if we don't think this is appropriate to include in the repo, I'll just change this PR to put it in `.gitignore` (though if my computer dies at some point, it would then be annoying to have to get them working again).