### PR TITLE
feat: Fetch schedules for the entire current service day

### DIFF
--- a/lib/mobile_app_backend_web/controllers/schedule_controller.ex
+++ b/lib/mobile_app_backend_web/controllers/schedule_controller.ex
@@ -38,8 +38,8 @@ defmodule MobileAppBackendWeb.ScheduleController do
   @spec get_filter(String.t(), String.t()) :: [JsonApi.Params.filter_param()]
   defp get_filter(stop_ids, date_time) do
     date_time = Util.parse_datetime!(date_time)
-    {service_date, min_time} = Util.datetime_to_gtfs(date_time)
-    [stop: stop_ids, date: service_date, min_time: min_time]
+    service_date = Util.datetime_to_gtfs(date_time)
+    [stop: stop_ids, date: service_date]
   end
 
   @spec fetch_schedules([JsonApi.Params.filter_param()]) ::

--- a/lib/util.ex
+++ b/lib/util.ex
@@ -234,13 +234,13 @@ defmodule Util do
 
       iex> import Test.Support.Sigils
       iex> Util.datetime_to_gtfs(~B[2024-03-12 10:55:39])
-      {~D[2024-03-12], "10:55"}
+      ~D[2024-03-12]
       iex> Util.datetime_to_gtfs(~B[2024-03-12 00:19:03])
-      {~D[2024-03-11], "24:19"}
+      ~D[2024-03-11]
       iex> Util.datetime_to_gtfs(~B[2024-03-12 01:23:45])
-      {~D[2024-03-11], "25:23"}
+      ~D[2024-03-11]
       iex> Util.datetime_to_gtfs(~B[2024-03-12 02:11:00])
-      {~D[2024-03-12], "02:11"}
+      ~D[2024-03-12]
   """
   @spec datetime_to_gtfs(DateTime.t()) :: Date.t()
   def datetime_to_gtfs(%DateTime{hour: hour, time_zone: "America/New_York"} = datetime) do

--- a/lib/util.ex
+++ b/lib/util.ex
@@ -242,22 +242,14 @@ defmodule Util do
       iex> Util.datetime_to_gtfs(~B[2024-03-12 02:11:00])
       {~D[2024-03-12], "02:11"}
   """
-  @spec datetime_to_gtfs(DateTime.t()) :: {Date.t(), String.t()}
-  def datetime_to_gtfs(
-        %DateTime{hour: hour, minute: minute, time_zone: "America/New_York"} = datetime
-      ) do
+  @spec datetime_to_gtfs(DateTime.t()) :: Date.t()
+  def datetime_to_gtfs(%DateTime{hour: hour, time_zone: "America/New_York"} = datetime) do
     date = DateTime.to_date(datetime)
 
-    {date, hour} =
-      if hour in [0, 1] do
-        {Date.add(date, -1), hour + 24}
-      else
-        {date, hour}
-      end
-
-    hour = to_string(hour) |> String.pad_leading(2, "0")
-    minute = to_string(minute) |> String.pad_leading(2, "0")
-
-    {date, "#{hour}:#{minute}"}
+    if hour in [0, 1] do
+      Date.add(date, -1)
+    else
+      date
+    end
   end
 end

--- a/test/mobile_app_backend_web/controllers/schedule_controller_test.exs
+++ b/test/mobile_app_backend_web/controllers/schedule_controller_test.exs
@@ -46,8 +46,7 @@ defmodule MobileAppBackendWeb.ScheduleControllerTest do
       assert [
                filter: [
                  stop: "place-boyls",
-                 date: ~D[2024-03-12],
-                 min_time: "25:06"
+                 date: ~D[2024-03-12]
                ],
                include: :trip,
                sort: {:departure_time, :asc}


### PR DESCRIPTION
### Summary

_Ticket:_ [Fetch schedules for the entire current service day](https://app.asana.com/0/1205732265579288/1208252548197533/f)

Remove the time filtering on the schedules request. Confirmed that the frontend handles this fine on latest `main` and doesn't display scheduled trips in the past.
