### PR TITLE
fix: restart ServerSentEventStage if Stream.Consumer crashes

### DIFF
--- a/lib/mbta_v3_api/stream/instance.ex
+++ b/lib/mbta_v3_api/stream/instance.ex
@@ -36,7 +36,7 @@ defmodule MBTAV3API.Stream.Instance do
       consumer_spec(Keyword.put(opts, :ref, ref))
     ]
 
-    Supervisor.init(children, strategy: :rest_for_one)
+    Supervisor.init(children, strategy: :one_for_all)
   end
 
   @spec consumer_spec(keyword()) :: {module(), keyword()}


### PR DESCRIPTION
### Summary

_Ticket:_ none

Fixes [serious data loss if an alert fails to parse](https://mbta.slack.com/archives/C05QMG9GS9M/p1726693649005009?thread_ts=1726688749.388879&cid=C05QMG9GS9M).