### PR TITLE
feat(Predictions.PubSub): publish related trip data

### DIFF
--- a/lib/mbta_v3_api/store.ex
+++ b/lib/mbta_v3_api/store.ex
@@ -27,7 +27,18 @@ defmodule MBTAV3API.Store do
   @doc """
   Retrieve all records that match the given filter keys.
   When given a single keyword list, all keys in the list must match.
-  When given a list of keyword lists, must match any of the keyword lists
+  When given a list of keyword lists, must match any of the keyword lists.
+
+  Does not include any associated records
   """
   @callback fetch(fetch_keys()) :: [JsonApi.Object.t()]
+
+  @doc """
+  Retrieve all records that match the given filter keys, and the relevant associated records
+  based on the included record types for the  `MBTAV3API.Stream.StaticInstance.` that is populating the store.
+
+  When given a single keyword list, all keys in the list must match.
+  When given a list of keyword lists, must match any of the keyword lists
+  """
+  @callback fetch_with_associations(fetch_keys()) :: JsonApi.Object.full_map()
 end

--- a/lib/mbta_v3_api/store/predictions.ex
+++ b/lib/mbta_v3_api/store/predictions.ex
@@ -67,8 +67,8 @@ defmodule MBTAV3API.Store.Predictions.Impl do
   use GenServer
   require Logger
   alias MBTAV3API.JsonApi
-  alias MBTAV3API.Trip
   alias MBTAV3API.Prediction
+  alias MBTAV3API.Trip
 
   @behaviour MBTAV3API.Store
 

--- a/lib/mbta_v3_api/store/predictions.ex
+++ b/lib/mbta_v3_api/store/predictions.ex
@@ -27,6 +27,13 @@ defmodule MBTAV3API.Store.Predictions do
   end
 
   @impl true
+  def fetch_with_associations(fetch_keys) do
+    Application.get_env(:mobile_app_backend, MBTAV3API.Store.Predictions, Predictions.Impl).fetch_with_associations(
+      fetch_keys
+    )
+  end
+
+  @impl true
   def process_upsert(event, data) do
     Application.get_env(:mobile_app_backend, MBTAV3API.Store.Predictions, Predictions.Impl).process_upsert(
       event,
@@ -59,11 +66,14 @@ defmodule MBTAV3API.Store.Predictions.Impl do
   """
   use GenServer
   require Logger
+  alias MBTAV3API.JsonApi
+  alias MBTAV3API.Trip
   alias MBTAV3API.Prediction
 
   @behaviour MBTAV3API.Store
 
   @predictions_table_name :predictions_from_streams
+  @trips_table_name :trips_from_predictions
 
   @spec start_link(Keyword.t()) :: GenServer.on_start()
   def start_link(_) do
@@ -73,6 +83,7 @@ defmodule MBTAV3API.Store.Predictions.Impl do
   @impl true
   def init(_) do
     _table = :ets.new(@predictions_table_name, [:named_table, :public, read_concurrency: true])
+    _trips_table = :ets.new(@trips_table_name, [:named_table, :public, read_concurrency: true])
 
     {:ok, %{}}
   end
@@ -81,7 +92,12 @@ defmodule MBTAV3API.Store.Predictions.Impl do
   def fetch(fetch_keys) do
     if Keyword.keyword?(fetch_keys) do
       match_spec = prediction_match_spec(fetch_keys)
-      timed_fetch([{match_spec, [], [:"$1"]}], "fetch_keys=#{inspect(fetch_keys)}")
+
+      timed_fetch(
+        @predictions_table_name,
+        [{match_spec, [], [:"$1"]}],
+        "fetch_keys=#{inspect(fetch_keys)}"
+      )
     else
       fetch_any(fetch_keys)
     end
@@ -93,7 +109,33 @@ defmodule MBTAV3API.Store.Predictions.Impl do
       |> Enum.map(&prediction_match_spec(&1))
       |> Enum.map(&{&1, [], [:"$1"]})
 
-    timed_fetch(match_specs, "multi_fetch=true fetch_keys=#{inspect(fetch_keys_list)}")
+    timed_fetch(
+      @predictions_table_name,
+      match_specs,
+      "multi_fetch=true fetch_keys=#{inspect(fetch_keys_list)}"
+    )
+  end
+
+  @impl true
+  def fetch_with_associations(fetch_keys) do
+    predictions = fetch(fetch_keys)
+
+    trip_fetch_keys_list =
+      predictions
+      |> Enum.flat_map(fn prediction ->
+        if is_nil(prediction.trip_id), do: [], else: [[id: prediction.trip_id]]
+      end)
+
+    trip_match_specs = Enum.map(trip_fetch_keys_list, &{trip_match_spec(&1), [], [:"$1"]})
+
+    trips =
+      timed_fetch(
+        @trips_table_name,
+        trip_match_specs,
+        "fetch_keys=#{inspect(trip_fetch_keys_list)}"
+      )
+
+    JsonApi.Object.to_full_map(predictions ++ trips)
   end
 
   defp prediction_match_spec(fetch_keys) do
@@ -111,12 +153,68 @@ defmodule MBTAV3API.Store.Predictions.Impl do
     }
   end
 
-  defp timed_fetch(match_specs, log_metadata) do
+  defp trip_match_spec(fetch_keys) do
+    # https://www.erlang.org/doc/apps/erts/match_spec.html
+    # Match the fields specified in the fetch_keys and return the full prediction
+    # see to_record/1 for the defined order of fields
+    {
+      Keyword.get(fetch_keys, :id) || :_,
+      Keyword.get(fetch_keys, :direction_id) || :_,
+      Keyword.get(fetch_keys, :route_id) || :_,
+      Keyword.get(fetch_keys, :route_pattern_id) || :_,
+      :"$1"
+    }
+  end
+
+  # Conver the struct to a record for ETS
+  defp to_record(
+         %Prediction{
+           id: id,
+           direction_id: direction_id,
+           route_id: route_id,
+           stop_id: stop_id,
+           trip_id: trip_id,
+           vehicle_id: vehicle_id
+         } = prediction
+       ) do
+    {
+      id,
+      route_id,
+      stop_id,
+      direction_id,
+      trip_id,
+      vehicle_id,
+      prediction
+    }
+  end
+
+  defp to_record(
+         %Trip{
+           id: id,
+           direction_id: direction_id,
+           route_id: route_id,
+           route_pattern_id: route_pattern_id
+         } = trip
+       ) do
+    {
+      id,
+      direction_id,
+      route_id,
+      route_pattern_id,
+      trip
+    }
+  end
+
+  defp timed_fetch(table_name, match_specs, log_metadata) do
     {time_micros, results} =
-      :timer.tc(:ets, :select, [@predictions_table_name, match_specs])
+      :timer.tc(:ets, :select, [table_name, match_specs])
 
     time_ms = time_micros / 1000
-    Logger.info("#{__MODULE__} fetch predictions #{log_metadata} duration=#{time_ms}")
+
+    Logger.info(
+      "#{__MODULE__} fetch table_name=#{table_name} #{log_metadata} duration=#{time_ms}"
+    )
+
     results
   end
 
@@ -138,7 +236,7 @@ defmodule MBTAV3API.Store.Predictions.Impl do
     for reference <- references do
       case reference do
         %{type: "prediction", id: id} -> :ets.delete(@predictions_table_name, id)
-        # TODO: handle other included types like trips
+        %{type: "trip", id: id} -> :ets.delete(@trips_table_name, id)
         _ -> :ok
       end
     end
@@ -147,39 +245,27 @@ defmodule MBTAV3API.Store.Predictions.Impl do
   end
 
   defp upsert_data(data) do
-    prediction_records =
+    records_by_type =
       data
-      # TODO: handle other included types like trips
-      |> Enum.filter(&match?(%Prediction{}, &1))
-      |> Enum.map(&to_record/1)
+      |> Enum.group_by(
+        fn data ->
+          %data_type{} = data
+          data_type
+        end,
+        fn data -> to_record(data) end
+      )
 
-    :ets.insert(@predictions_table_name, prediction_records)
+    :ets.insert(@predictions_table_name, Map.get(records_by_type, Prediction, []))
+    :ets.insert(@trips_table_name, Map.get(records_by_type, Trip, []))
   end
 
   defp clear_data(keys) do
-    match_pattern = prediction_match_spec(keys)
+    # Since we stream predictions by route, we can clear both the predictions  & route
+    # tables by route
+    predictions_match_pattern = prediction_match_spec(keys)
+    trips_match_pattern = trip_match_spec(keys)
 
-    :ets.select_delete(@predictions_table_name, [{match_pattern, [], [true]}])
-  end
-
-  defp to_record(
-         %Prediction{
-           id: id,
-           direction_id: direction_id,
-           route_id: route_id,
-           stop_id: stop_id,
-           trip_id: trip_id,
-           vehicle_id: vehicle_id
-         } = prediction
-       ) do
-    {
-      id,
-      route_id,
-      stop_id,
-      direction_id,
-      trip_id,
-      vehicle_id,
-      prediction
-    }
+    :ets.select_delete(@predictions_table_name, [{predictions_match_pattern, [], [true]}])
+    :ets.select_delete(@trips_table_name, [{trips_match_pattern, [], [true]}])
   end
 end

--- a/lib/mbta_v3_api/stream/static_instance.ex
+++ b/lib/mbta_v3_api/stream/static_instance.ex
@@ -84,7 +84,7 @@ defmodule MBTAV3API.Stream.StaticInstance.Impl do
       type: MBTAV3API.Prediction,
       url: "/predictions",
       filter: [route: route_id],
-      include: [:trip, :vehicle],
+      include: [:trip],
       # `:topic` is unique to a route because we stream predictions separately by route
       # `:destination` is the same across all routes because all predictions
       # are unified in `Store.Predictions`

--- a/lib/mobile_app_backend/predictions/pub_sub.ex
+++ b/lib/mobile_app_backend/predictions/pub_sub.ex
@@ -32,7 +32,7 @@ defmodule MobileAppBackend.Predictions.PubSub do
   Based on https://github.com/mbta/dotcom/blob/main/lib/predictions/pub_sub.ex
   """
   use GenServer
-  alias MBTAV3API.{JsonApi, Stop, Store, Stream}
+  alias MBTAV3API.{JsonApi, Prediction, Stop, Store, Stream}
   alias MobileAppBackend.Predictions.PubSub
 
   @behaviour PubSub.Behaviour

--- a/test/mobile_app_backend/predictions/pub_sub_test.exs
+++ b/test/mobile_app_backend/predictions/pub_sub_test.exs
@@ -1,6 +1,7 @@
 defmodule MobileAppBackend.Predictions.PubSubTests do
   use ExUnit.Case
 
+  alias MBTAV3API.JsonApi
   alias MBTAV3API.{Store, Stream}
   alias MobileAppBackend.Predictions.{PubSub, StreamSubscriber}
   import Mox
@@ -20,27 +21,37 @@ defmodule MobileAppBackend.Predictions.PubSubTests do
 
   describe "subscribe_for_stop/1" do
     test "returns initial data for the given isolated stop" do
-      prediction_1 = build(:prediction, stop_id: "12345")
-      prediction_2 = build(:prediction, stop_id: "12345")
+      prediction_1 = build(:prediction, stop_id: "12345", trip_id: "trip_1")
+      prediction_2 = build(:prediction, stop_id: "12345", trip_id: "trip_1")
+      trip_1 = build(:trip, id: "trip_1")
+      trip_2 = build(:trip, id: "trip_2")
 
-      expect(PredictionsStoreMock, :fetch, fn _ -> [prediction_1, prediction_2] end)
+      full_map = JsonApi.Object.to_full_map([prediction_1, prediction_2, trip_1, trip_2])
+
+      expect(PredictionsStoreMock, :fetch_with_associations, fn _ ->
+        full_map
+      end)
 
       RepositoryMock
       |> expect(:stops, fn _, _ -> ok_response([build(:stop, id: "12345")]) end)
 
       expect(StreamSubscriberMock, :subscribe_for_stops, fn _ -> :ok end)
 
-      assert %{"12345" => [prediction_1, prediction_2]} == PubSub.subscribe_for_stop("12345")
+      assert %{"12345" => full_map} == PubSub.subscribe_for_stop("12345")
     end
 
     test "returns initial data for the given parent stop" do
-      prediction_1 = build(:prediction, stop_id: "12345", id: "1")
-      prediction_2 = build(:prediction, stop_id: "6789", id: "2")
+      prediction_1 = build(:prediction, stop_id: "12345", id: "1", trip_id: "trip_1")
+      prediction_2 = build(:prediction, stop_id: "6789", id: "2", trip_id: "trip_2")
+      trip_1 = build(:trip, id: "trip_1")
+      trip_2 = build(:trip, id: "trip_2")
 
-      expect(PredictionsStoreMock, :fetch, fn fetch_keyword_list ->
+      full_map = JsonApi.Object.to_full_map([prediction_1, prediction_2, trip_1, trip_2])
+
+      expect(PredictionsStoreMock, :fetch_with_associations, fn fetch_keyword_list ->
         assert Enum.any?(fetch_keyword_list, &(Keyword.get(&1, :stop_id) == "12345"))
         assert Enum.any?(fetch_keyword_list, &(Keyword.get(&1, :stop_id) == "6789"))
-        [prediction_1, prediction_2]
+        full_map
       end)
 
       RepositoryMock
@@ -53,20 +64,25 @@ defmodule MobileAppBackend.Predictions.PubSubTests do
 
       expect(StreamSubscriberMock, :subscribe_for_stops, fn _ -> :ok end)
 
-      assert %{"parent_stop_id" => [prediction_1, prediction_2]} ==
+      assert %{"parent_stop_id" => full_map} ==
                PubSub.subscribe_for_stop("parent_stop_id")
     end
   end
 
   describe "subscribe_for_stops/1" do
     test "returns initial data for each stop given" do
-      prediction_1 = build(:prediction, stop_id: "standalone")
-      prediction_2 = build(:prediction, stop_id: "child")
+      prediction_1 = build(:prediction, stop_id: "standalone", trip_id: "trip_1")
+      prediction_2 = build(:prediction, stop_id: "child", trip_id: "trip_2")
+      trip_1 = build(:trip, id: "trip_1")
+      trip_2 = build(:trip, id: "trip_2")
 
-      expect(PredictionsStoreMock, :fetch, 2, fn keys ->
+      standalone_full_map = JsonApi.Object.to_full_map([prediction_1, trip_1])
+      child_full_map = JsonApi.Object.to_full_map([prediction_2, trip_2])
+
+      expect(PredictionsStoreMock, :fetch_with_associations, 2, fn keys ->
         case keys do
-          [stop_id: "standalone"] -> [prediction_1]
-          [[stop_id: "child"]] -> [prediction_2]
+          [stop_id: "standalone"] -> standalone_full_map
+          [[stop_id: "child"]] -> child_full_map
         end
       end)
 
@@ -79,7 +95,7 @@ defmodule MobileAppBackend.Predictions.PubSubTests do
 
       expect(StreamSubscriberMock, :subscribe_for_stops, fn _ -> :ok end)
 
-      assert %{"standalone" => [prediction_1], "parent" => [prediction_2]} ==
+      assert %{"standalone" => standalone_full_map, "parent" => child_full_map} ==
                PubSub.subscribe_for_stops(["parent", "standalone"])
     end
   end
@@ -96,17 +112,24 @@ defmodule MobileAppBackend.Predictions.PubSubTests do
     end
 
     test ":broadcast sends message to subscribed pid", state do
-      prediction_1 = build(:prediction, stop_id: "12345")
-      prediction_2 = build(:prediction, stop_id: "12345")
-      prediction_3 = build(:prediction, stop_id: "12345")
+      prediction_1 = build(:prediction, stop_id: "12345", trip_id: "trip_1")
+      prediction_2 = build(:prediction, stop_id: "12345", trip_id: "trip_1")
+      prediction_3 = build(:prediction, stop_id: "12345", trip_id: "trip_1")
+      trip_1 = build(:trip, id: "trip_1")
 
       PredictionsStoreMock
       # Subscribe
-      |> expect(:fetch, fn _ -> [prediction_1] end)
+      |> expect(:fetch_with_associations, fn _ ->
+        JsonApi.Object.to_full_map([prediction_1, trip_1])
+      end)
       # 1st and 2nd broadcast
-      |> expect(:fetch, 2, fn _ -> [prediction_2] end)
+      |> expect(:fetch_with_associations, 2, fn _ ->
+        JsonApi.Object.to_full_map([prediction_2, trip_1])
+      end)
       # 3rd broadcast
-      |> expect(:fetch, fn _ -> [prediction_3] end)
+      |> expect(:fetch_with_associations, fn _ ->
+        JsonApi.Object.to_full_map([prediction_3, trip_1])
+      end)
 
       RepositoryMock
       |> expect(:stops, fn _, _ ->
@@ -118,7 +141,10 @@ defmodule MobileAppBackend.Predictions.PubSubTests do
       PubSub.subscribe_for_stop("12345")
 
       PubSub.handle_info(:broadcast, state)
-      assert_receive {:new_predictions, %{"12345" => [^prediction_2]}}
+      assert_receive {:new_predictions, %{"12345" => %{predictions: predictions, trips: trips}}}
+
+      assert %{prediction_2.id => prediction_2} == predictions
+      assert %{trip_1.id => trip_1} == trips
 
       # Doesn't re-send the same predictions that have already been seen
       PubSub.handle_info(:broadcast, state)
@@ -128,18 +154,22 @@ defmodule MobileAppBackend.Predictions.PubSubTests do
       # Sends new predictions
       PubSub.handle_info(:broadcast, state)
 
-      assert_receive {:new_predictions, %{"12345" => [^prediction_3]}}
+      assert_receive {:new_predictions, %{"12345" => %{predictions: predictions, trips: trips}}}
+      assert %{prediction_3.id => prediction_3} == predictions
+      assert %{trip_1.id => trip_1} == trips
     end
 
     test "pid can be subscribed to multiple keys", state do
-      prediction_1 = build(:prediction, stop_id: "12345")
-      prediction_2 = build(:prediction, stop_id: "6789")
+      prediction_1 = build(:prediction, id: "prediction_1", stop_id: "12345", trip_id: "trip_1")
+      prediction_2 = build(:prediction, id: "prediction_2", stop_id: "6789", trip_id: "trip_2")
+      trip_1 = build(:trip, id: "trip_1")
+      trip_2 = build(:trip, id: "trip_2")
 
       PredictionsStoreMock
-      |> expect(:fetch, 4, fn keys ->
+      |> expect(:fetch_with_associations, 4, fn keys ->
         case keys do
-          [stop_id: "12345"] -> [prediction_1]
-          [stop_id: "6789"] -> [prediction_2]
+          [stop_id: "12345"] -> JsonApi.Object.to_full_map([prediction_1, trip_1])
+          [stop_id: "6789"] -> JsonApi.Object.to_full_map([prediction_2, trip_2])
         end
       end)
 
@@ -155,18 +185,33 @@ defmodule MobileAppBackend.Predictions.PubSubTests do
 
       PubSub.handle_info(:broadcast, state)
       assert_receive {:new_predictions, new_predictions}
-      assert %{"12345" => [^prediction_1]} = new_predictions
+
+      assert %{
+               "12345" => %{
+                 predictions: %{"prediction_1" => ^prediction_1},
+                 trips: %{"trip_1" => ^trip_1}
+               }
+             } = new_predictions
 
       assert_receive {:new_predictions, new_predictions}
-      assert %{"6789" => [^prediction_2]} = new_predictions
+
+      assert %{
+               "6789" => %{
+                 predictions: %{"prediction_2" => ^prediction_2},
+                 trips: %{"trip_2" => ^trip_2}
+               }
+             } = new_predictions
     end
   end
 
   describe "reset event e2e" do
     test "when a reset event is broadcast, subscribers are pushed latest predictions" do
-      prediction_1 = build(:prediction, stop_id: "12345")
+      prediction_1 = build(:prediction, stop_id: "12345", trip_id: "trip_1")
+      trip_1 = build(:trip, id: "trip_1")
 
-      expect(PredictionsStoreMock, :fetch, 2, fn _ -> [prediction_1] end)
+      full_map = JsonApi.Object.to_full_map([prediction_1, trip_1])
+
+      expect(PredictionsStoreMock, :fetch_with_associations, 2, fn _ -> full_map end)
 
       RepositoryMock
       |> expect(:stops, fn _, _ ->
@@ -178,7 +223,7 @@ defmodule MobileAppBackend.Predictions.PubSubTests do
       PubSub.subscribe_for_stop("12345")
 
       Stream.PubSub.broadcast!("predictions:all:events", :reset_event)
-      assert_receive {:new_predictions, %{"12345" => [^prediction_1]}}
+      assert_receive {:new_predictions, %{"12345" => ^full_map}}
     end
   end
 end

--- a/test/mobile_app_backend/predictions/pub_sub_test.exs
+++ b/test/mobile_app_backend/predictions/pub_sub_test.exs
@@ -21,8 +21,8 @@ defmodule MobileAppBackend.Predictions.PubSubTests do
 
   describe "subscribe_for_stop/1" do
     test "returns initial data for the given isolated stop" do
-      prediction_1 = build(:prediction, stop_id: "12345", trip_id: "trip_1")
-      prediction_2 = build(:prediction, stop_id: "12345", trip_id: "trip_1")
+      prediction_1 = build(:prediction, id: "p_1", stop_id: "12345", trip_id: "trip_1")
+      prediction_2 = build(:prediction, id: "p_2", stop_id: "12345", trip_id: "trip_1")
       trip_1 = build(:trip, id: "trip_1")
       trip_2 = build(:trip, id: "trip_2")
 
@@ -37,12 +37,15 @@ defmodule MobileAppBackend.Predictions.PubSubTests do
 
       expect(StreamSubscriberMock, :subscribe_for_stops, fn _ -> :ok end)
 
-      assert full_map == PubSub.subscribe_for_stop("12345")
+      assert %{
+               predictions_by_stop: %{"12345" => %{"p_1" => prediction_1, "p_2" => prediction_2}},
+               trips: %{"trip_1" => trip_1, "trip_2" => trip_2}
+             } == PubSub.subscribe_for_stop("12345")
     end
 
     test "returns initial data for the given parent stop" do
-      prediction_1 = build(:prediction, stop_id: "12345", id: "1", trip_id: "trip_1")
-      prediction_2 = build(:prediction, stop_id: "6789", id: "2", trip_id: "trip_2")
+      prediction_1 = build(:prediction, stop_id: "12345", id: "p_1", trip_id: "trip_1")
+      prediction_2 = build(:prediction, stop_id: "6789", id: "p_2", trip_id: "trip_2")
       trip_1 = build(:trip, id: "trip_1")
       trip_2 = build(:trip, id: "trip_2")
 
@@ -64,15 +67,20 @@ defmodule MobileAppBackend.Predictions.PubSubTests do
 
       expect(StreamSubscriberMock, :subscribe_for_stops, fn _ -> :ok end)
 
-      assert full_map ==
+      assert %{
+               predictions_by_stop: %{
+                 "parent_stop_id" => %{"p_1" => prediction_1, "p_2" => prediction_2}
+               },
+               trips: %{"trip_1" => trip_1, "trip_2" => trip_2}
+             } ==
                PubSub.subscribe_for_stop("parent_stop_id")
     end
   end
 
   describe "subscribe_for_stops/1" do
     test "returns initial data for each stop given" do
-      prediction_1 = build(:prediction, stop_id: "standalone", trip_id: "trip_1")
-      prediction_2 = build(:prediction, stop_id: "child", trip_id: "trip_2")
+      prediction_1 = build(:prediction, id: "p_1", stop_id: "standalone", trip_id: "trip_1")
+      prediction_2 = build(:prediction, id: "p_2", stop_id: "child", trip_id: "trip_2")
       trip_1 = build(:trip, id: "trip_1")
       trip_2 = build(:trip, id: "trip_2")
 
@@ -94,7 +102,13 @@ defmodule MobileAppBackend.Predictions.PubSubTests do
 
       expect(StreamSubscriberMock, :subscribe_for_stops, fn _ -> :ok end)
 
-      assert full_map ==
+      assert %{
+               predictions_by_stop: %{
+                 "standalone" => %{"p_1" => prediction_1},
+                 "parent" => %{"p_2" => prediction_2}
+               },
+               trips: %{"trip_1" => trip_1, "trip_2" => trip_2}
+             } ==
                PubSub.subscribe_for_stops(["parent", "standalone"])
     end
   end

--- a/test/mobile_app_backend_web/channels/predictions_for_stops_v2_channel_test.exs
+++ b/test/mobile_app_backend_web/channels/predictions_for_stops_v2_channel_test.exs
@@ -24,20 +24,16 @@ defmodule MobileAppBackendWeb.PredictionsForStopsV2ChannelTest do
     trip_1 = build(:trip, id: "trip_1")
     trip_2 = build(:trip, id: "trip_2")
 
+    full_map = to_full_map([prediction_1, prediction_2, trip_1, trip_2])
+
     expect(PredictionsPubSubMock, :subscribe_for_stops, 1, fn _ ->
-      %{
-        "12345" => to_full_map([prediction_1, trip_1]),
-        "67890" => to_full_map([prediction_2, trip_2])
-      }
+      full_map
     end)
 
     {:ok, reply, _socket} =
       subscribe_and_join(socket, "predictions:stops:v2:12345,67890")
 
-    assert reply == %{
-             "12345" => to_full_map([prediction_1, trip_1]),
-             "67890" => to_full_map([prediction_2, trip_2])
-           }
+    assert reply == full_map
   end
 
   test "error if missing stop ids in topic", %{socket: socket} do

--- a/test/mobile_app_backend_web/channels/predictions_for_stops_v2_channel_test.exs
+++ b/test/mobile_app_backend_web/channels/predictions_for_stops_v2_channel_test.exs
@@ -18,17 +18,26 @@ defmodule MobileAppBackendWeb.PredictionsForStopsV2ChannelTest do
   end
 
   test "joins and leaves ok", %{socket: socket} do
-    prediction_1 = build(:prediction)
-    prediction_2 = build(:prediction)
+    prediction_1 = build(:prediction, trip_id: "trip_1", stop_id: "12345")
+    prediction_2 = build(:prediction, trip_id: "trip_2", stop_id: "67890")
+
+    trip_1 = build(:trip, id: "trip_1")
+    trip_2 = build(:trip, id: "trip_2")
 
     expect(PredictionsPubSubMock, :subscribe_for_stops, 1, fn _ ->
-      %{"12345" => [prediction_1], "67890" => [prediction_2]}
+      %{
+        "12345" => to_full_map([prediction_1, trip_1]),
+        "67890" => to_full_map([prediction_2, trip_2])
+      }
     end)
 
     {:ok, reply, _socket} =
       subscribe_and_join(socket, "predictions:stops:v2:12345,67890")
 
-    assert reply == %{"12345" => [prediction_1], "67890" => [prediction_2]}
+    assert reply == %{
+             "12345" => to_full_map([prediction_1, trip_1]),
+             "67890" => to_full_map([prediction_2, trip_2])
+           }
   end
 
   test "error if missing stop ids in topic", %{socket: socket} do
@@ -42,13 +51,16 @@ defmodule MobileAppBackendWeb.PredictionsForStopsV2ChannelTest do
     {:ok, _reply, socket} =
       subscribe_and_join(socket, "predictions:stops:v2:12345")
 
-    prediction = build(:prediction, stop_id: "12345")
+    prediction = build(:prediction, id: "prediction_1", stop_id: "12345", trip_id: "trip_1")
+    trip = build(:trip, id: "trip_1")
 
     PredictionsForStopsV2Channel.handle_info(
-      {:new_predictions, %{"12345" => [prediction]}},
+      {:new_predictions, %{"12345" => to_full_map([prediction, trip])}},
       socket
     )
 
-    assert_push "stream_data", %{"12345" => [^prediction]}
+    assert_push "stream_data", %{
+      "12345" => %{predictions: %{"prediction_1" => ^prediction}, trips: %{"trip_1" => ^trip}}
+    }
   end
 end

--- a/test/mobile_app_backend_web/channels/predictions_for_stops_v2_channel_test.exs
+++ b/test/mobile_app_backend_web/channels/predictions_for_stops_v2_channel_test.exs
@@ -18,22 +18,27 @@ defmodule MobileAppBackendWeb.PredictionsForStopsV2ChannelTest do
   end
 
   test "joins and leaves ok", %{socket: socket} do
-    prediction_1 = build(:prediction, trip_id: "trip_1", stop_id: "12345")
-    prediction_2 = build(:prediction, trip_id: "trip_2", stop_id: "67890")
+    prediction_1 = build(:prediction, id: "p_1", trip_id: "trip_1", stop_id: "12345")
+    prediction_2 = build(:prediction, id: "p_2", trip_id: "trip_2", stop_id: "67890")
 
     trip_1 = build(:trip, id: "trip_1")
     trip_2 = build(:trip, id: "trip_2")
 
-    full_map = to_full_map([prediction_1, prediction_2, trip_1, trip_2])
+    response = %{
+      predictions_by_stop: %{
+        "12345" => %{"p_1" => prediction_1, "p_2" => prediction_2},
+        trips: %{"trip_1" => trip_1, "trip_2" => trip_2}
+      }
+    }
 
     expect(PredictionsPubSubMock, :subscribe_for_stops, 1, fn _ ->
-      full_map
+      response
     end)
 
     {:ok, reply, _socket} =
       subscribe_and_join(socket, "predictions:stops:v2:12345,67890")
 
-    assert reply == full_map
+    assert reply == response
   end
 
   test "error if missing stop ids in topic", %{socket: socket} do


### PR DESCRIPTION
### Summary

_Ticket:_ [Predictions Scalability: new channel that publishes predictions updates in chunks](https://app.asana.com/0/1205732265579288/1207791938443975/f)

What is this PR for?

This PR publishes trips associated with predictions by stop. Associated vehicles to follow in a separate PR