### PR TITLE
feat(Predictions.PubSub): Include related vehicles

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -7,9 +7,9 @@ config :mobile_app_backend, MobileAppBackendWeb.Endpoint,
   secret_key_base: "i2tUYeAO95DpQJMjLPg+aBuneGbF6hGMyTvth/i1csZT7LeeH6ZsWpDO9F9IkJ7f",
   server: false
 
-# Don't start the real predictions processes so we can test with
-# isolated fake prediction processes
-config :mobile_app_backend, start_predictions_store?: false
+# Don't start the real stream store processes so we can test with
+# isolated fake processes
+config :mobile_app_backend, start_stream_stores?: false
 
 # Print only warnings and errors during test
 config :logger, level: :warning

--- a/lib/mbta_v3_api/store.ex
+++ b/lib/mbta_v3_api/store.ex
@@ -41,4 +41,60 @@ defmodule MBTAV3API.Store do
   When given a list of keyword lists, must match any of the keyword lists
   """
   @callback fetch_with_associations(fetch_keys()) :: JsonApi.Object.full_map()
+
+  defmacro __using__(opts) do
+    quote location: :keep, bind_quoted: [opts: opts] do
+      @behaviour MBTAV3API.Store
+
+      implementation_module = Keyword.fetch!(opts, :implementation_module)
+
+      def start_link(opts) do
+        Application.get_env(:mobile_app_backend, __MODULE__, unquote(implementation_module)).start_link(
+          opts
+        )
+      end
+
+      @impl true
+      def init(opts) do
+        Application.get_env(:mobile_app_backend, __MODULE__, unquote(implementation_module)).init(opts)
+      end
+
+      @impl true
+      def fetch(fetch_keys) do
+        Application.get_env(:mobile_app_backend, __MODULE__, unquote(implementation_module)).fetch(
+          fetch_keys
+        )
+      end
+
+      @impl true
+      def fetch_with_associations(fetch_keys) do
+        Application.get_env(:mobile_app_backend, __MODULE__, unquote(implementation_module)).fetch_with_associations(
+          fetch_keys
+        )
+      end
+
+      @impl true
+      def process_upsert(event, data) do
+        Application.get_env(:mobile_app_backend, __MODULE__, unquote(implementation_module)).process_upsert(
+          event,
+          data
+        )
+      end
+
+      @impl true
+      def process_reset(data, scope) do
+        Application.get_env(:mobile_app_backend, __MODULE__, unquote(implementation_module)).process_reset(
+          data,
+          scope
+        )
+      end
+
+      @impl true
+      def process_remove(references) do
+        Application.get_env(:mobile_app_backend, __MODULE__, unquote(implementation_module)).process_remove(
+          references
+        )
+      end
+    end
+  end
 end

--- a/lib/mbta_v3_api/store/predictions.ex
+++ b/lib/mbta_v3_api/store/predictions.ex
@@ -68,9 +68,9 @@ defmodule MBTAV3API.Store.Predictions.Impl do
   """
   use GenServer
   require Logger
-  alias MBTAV3API.Store.Vehicles
   alias MBTAV3API.JsonApi
   alias MBTAV3API.Prediction
+  alias MBTAV3API.Store.Vehicles
   alias MBTAV3API.Trip
 
   @behaviour MBTAV3API.Store

--- a/lib/mbta_v3_api/store/predictions.ex
+++ b/lib/mbta_v3_api/store/predictions.ex
@@ -1,60 +1,8 @@
 defmodule MBTAV3API.Store.Predictions do
   use GenServer
+  use MBTAV3API.Store, implementation_module: MBTAV3API.Store.Predictions.Impl
   require Logger
   alias MBTAV3API.Prediction
-  alias MBTAV3API.Store.Predictions
-
-  @behaviour MBTAV3API.Store
-
-  def start_link(opts) do
-    Application.get_env(:mobile_app_backend, MBTAV3API.Store.Predictions, Predictions.Impl).start_link(
-      opts
-    )
-  end
-
-  @impl true
-  def init(opts) do
-    Application.get_env(:mobile_app_backend, MBTAV3API.Store.Predictions, Predictions.Impl).init(
-      opts
-    )
-  end
-
-  @impl true
-  def fetch(fetch_keys) do
-    Application.get_env(:mobile_app_backend, MBTAV3API.Store.Predictions, Predictions.Impl).fetch(
-      fetch_keys
-    )
-  end
-
-  @impl true
-  def fetch_with_associations(fetch_keys) do
-    Application.get_env(:mobile_app_backend, MBTAV3API.Store.Predictions, Predictions.Impl).fetch_with_associations(
-      fetch_keys
-    )
-  end
-
-  @impl true
-  def process_upsert(event, data) do
-    Application.get_env(:mobile_app_backend, MBTAV3API.Store.Predictions, Predictions.Impl).process_upsert(
-      event,
-      data
-    )
-  end
-
-  @impl true
-  def process_reset(data, scope) do
-    Application.get_env(:mobile_app_backend, MBTAV3API.Store.Predictions, Predictions.Impl).process_reset(
-      data,
-      scope
-    )
-  end
-
-  @impl true
-  def process_remove(references) do
-    Application.get_env(:mobile_app_backend, MBTAV3API.Store.Predictions, Predictions.Impl).process_remove(
-      references
-    )
-  end
 end
 
 defmodule MBTAV3API.Store.Predictions.Impl do

--- a/lib/mbta_v3_api/store/vehicles.ex
+++ b/lib/mbta_v3_api/store/vehicles.ex
@@ -1,0 +1,199 @@
+defmodule MBTAV3API.Store.Vehicles do
+  use GenServer
+  require Logger
+  alias MBTAV3API.Store.Vehicles
+
+  alias MBTAV3API.Vehicle
+
+  @behaviour MBTAV3API.Store
+
+  def start_link(opts) do
+    Application.get_env(:mobile_app_backend, MBTAV3API.Store.Vehicles, Vehicles.Impl).start_link(
+      opts
+    )
+  end
+
+  @impl true
+  def init(opts) do
+    Application.get_env(:mobile_app_backend, MBTAV3API.Store.Vehicles, Vehicles.Impl).init(opts)
+  end
+
+  @impl true
+  def fetch(fetch_keys) do
+    Application.get_env(:mobile_app_backend, MBTAV3API.Store.Vehicles, Vehicles.Impl).fetch(
+      fetch_keys
+    )
+  end
+
+  @impl true
+  def fetch_with_associations(fetch_keys) do
+    Application.get_env(:mobile_app_backend, MBTAV3API.Store.Vehicles, Vehicles.Impl).fetch_with_associations(
+      fetch_keys
+    )
+  end
+
+  @impl true
+  def process_upsert(event, data) do
+    Application.get_env(:mobile_app_backend, MBTAV3API.Store.Vehicles, Vehicles.Impl).process_upsert(
+      event,
+      data
+    )
+  end
+
+  @impl true
+  def process_reset(data, scope) do
+    Application.get_env(:mobile_app_backend, MBTAV3API.Store.Vehicles, Vehicles.Impl).process_reset(
+      data,
+      scope
+    )
+  end
+
+  @impl true
+  def process_remove(references) do
+    Application.get_env(:mobile_app_backend, MBTAV3API.Store.Vehicles, Vehicles.Impl).process_remove(
+      references
+    )
+  end
+end
+
+defmodule MBTAV3API.Store.Vehicles.Impl do
+  @moduledoc """
+  Store of vehicles. Store is written to by a single `MBTAV3API.Stream.ConsumerToStore`
+  and can be read in parallel by other processes.
+  """
+  use GenServer
+  require Logger
+  alias MBTAV3API.JsonApi
+
+  alias MBTAV3API.Vehicle
+
+  @behaviour MBTAV3API.Store
+
+  @vehicles_table_name :vehicles_from_stream
+
+  @spec start_link(Keyword.t()) :: GenServer.on_start()
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @impl true
+  def init(_) do
+    _table = :ets.new(@vehicles_table_name, [:named_table, :public, read_concurrency: true])
+
+    {:ok, %{}}
+  end
+
+  @impl true
+  def fetch(fetch_keys) do
+    if Keyword.keyword?(fetch_keys) do
+      match_spec = vehicle_match_spec(fetch_keys)
+
+      timed_fetch(
+        @vehicles_table_name,
+        [{match_spec, [], [:"$1"]}],
+        "fetch_keys=#{inspect(fetch_keys)}"
+      )
+    else
+      fetch_any(fetch_keys)
+    end
+  end
+
+  defp fetch_any(fetch_keys_list) do
+    match_specs =
+      fetch_keys_list
+      |> Enum.map(&vehicle_match_spec(&1))
+      |> Enum.map(&{&1, [], [:"$1"]})
+
+    timed_fetch(
+      @vehicles_table_name,
+      match_specs,
+      "multi_fetch=true fetch_keys=#{inspect(fetch_keys_list)}"
+    )
+  end
+
+  @impl true
+  def fetch_with_associations(fetch_keys) do
+    vehicles = fetch(fetch_keys)
+    JsonApi.Object.to_full_map(vehicles)
+  end
+
+  defp vehicle_match_spec(fetch_keys) do
+    # https://www.erlang.org/doc/apps/erts/match_spec.html
+    # Match the fields specified in the fetch_keys and return the full vehicles
+    # see to_record/1 for the defined order of fields
+    {
+      Keyword.get(fetch_keys, :id) || :_,
+      Keyword.get(fetch_keys, :direction_id) || :_,
+      Keyword.get(fetch_keys, :route_id) || :_,
+      Keyword.get(fetch_keys, :trip_id) || :_,
+      :"$1"
+    }
+  end
+
+  # Conver the struct to a record for ETS
+  defp to_record(
+         %Vehicle{
+           id: id,
+           direction_id: direction_id,
+           route_id: route_id,
+           trip_id: trip_id
+         } = vehicle
+       ) do
+    {
+      id,
+      direction_id,
+      route_id,
+      trip_id,
+      vehicle
+    }
+  end
+
+  defp timed_fetch(table_name, match_specs, log_metadata) do
+    {time_micros, results} =
+      :timer.tc(:ets, :select, [table_name, match_specs])
+
+    time_ms = time_micros / 1000
+
+    Logger.info(
+      "#{__MODULE__} fetch table_name=#{table_name} #{log_metadata} duration=#{time_ms}"
+    )
+
+    results
+  end
+
+  @impl true
+  def process_upsert(_event, data) do
+    upsert_data(data)
+    :ok
+  end
+
+  @impl true
+  def process_reset(data, scope) do
+    clear_data(scope)
+    upsert_data(data)
+    :ok
+  end
+
+  @impl true
+  def process_remove(references) do
+    for reference <- references do
+      case reference do
+        %{type: "vehicle", id: id} -> :ets.delete(@vehicles_table_name, id)
+        _ -> :ok
+      end
+    end
+
+    :ok
+  end
+
+  defp upsert_data(vehicles) do
+    records = Enum.map(vehicles, &to_record(&1))
+
+    :ets.insert(@vehicles_table_name, records)
+  end
+
+  defp clear_data(keys) do
+    vehicles_match_pattern = vehicle_match_spec(keys)
+    :ets.select_delete(@vehicles_table_name, [{vehicles_match_pattern, [], [true]}])
+  end
+end

--- a/lib/mbta_v3_api/store/vehicles.ex
+++ b/lib/mbta_v3_api/store/vehicles.ex
@@ -13,7 +13,7 @@ defmodule MBTAV3API.Store.Vehicles.Impl do
   use GenServer
   require Logger
   alias MBTAV3API.JsonApi
-
+  alias MBTAV3API.Store
   alias MBTAV3API.Vehicle
 
   @behaviour MBTAV3API.Store
@@ -36,7 +36,7 @@ defmodule MBTAV3API.Store.Vehicles.Impl do
     if Keyword.keyword?(fetch_keys) do
       match_spec = vehicle_match_spec(fetch_keys)
 
-      timed_fetch(
+      Store.timed_fetch(
         @vehicles_table_name,
         [{match_spec, [], [:"$1"]}],
         "fetch_keys=#{inspect(fetch_keys)}"
@@ -52,7 +52,7 @@ defmodule MBTAV3API.Store.Vehicles.Impl do
       |> Enum.map(&vehicle_match_spec(&1))
       |> Enum.map(&{&1, [], [:"$1"]})
 
-    timed_fetch(
+    Store.timed_fetch(
       @vehicles_table_name,
       match_specs,
       "multi_fetch=true fetch_keys=#{inspect(fetch_keys_list)}"
@@ -94,19 +94,6 @@ defmodule MBTAV3API.Store.Vehicles.Impl do
       trip_id,
       vehicle
     }
-  end
-
-  defp timed_fetch(table_name, match_specs, log_metadata) do
-    {time_micros, results} =
-      :timer.tc(:ets, :select, [table_name, match_specs])
-
-    time_ms = time_micros / 1000
-
-    Logger.info(
-      "#{__MODULE__} fetch table_name=#{table_name} #{log_metadata} duration=#{time_ms}"
-    )
-
-    results
   end
 
   @impl true

--- a/lib/mbta_v3_api/store/vehicles.ex
+++ b/lib/mbta_v3_api/store/vehicles.ex
@@ -79,7 +79,6 @@ defmodule MBTAV3API.Store.Vehicles.Impl do
   @impl true
   def init(_) do
     _table = :ets.new(@vehicles_table_name, [:named_table, :public, read_concurrency: true])
-
     {:ok, %{}}
   end
 

--- a/lib/mbta_v3_api/store/vehicles.ex
+++ b/lib/mbta_v3_api/store/vehicles.ex
@@ -1,59 +1,8 @@
 defmodule MBTAV3API.Store.Vehicles do
   use GenServer
+  use MBTAV3API.Store, implementation_module: MBTAV3API.Store.Vehicles.Impl
   require Logger
-  alias MBTAV3API.Store.Vehicles
-
   alias MBTAV3API.Vehicle
-
-  @behaviour MBTAV3API.Store
-
-  def start_link(opts) do
-    Application.get_env(:mobile_app_backend, MBTAV3API.Store.Vehicles, Vehicles.Impl).start_link(
-      opts
-    )
-  end
-
-  @impl true
-  def init(opts) do
-    Application.get_env(:mobile_app_backend, MBTAV3API.Store.Vehicles, Vehicles.Impl).init(opts)
-  end
-
-  @impl true
-  def fetch(fetch_keys) do
-    Application.get_env(:mobile_app_backend, MBTAV3API.Store.Vehicles, Vehicles.Impl).fetch(
-      fetch_keys
-    )
-  end
-
-  @impl true
-  def fetch_with_associations(fetch_keys) do
-    Application.get_env(:mobile_app_backend, MBTAV3API.Store.Vehicles, Vehicles.Impl).fetch_with_associations(
-      fetch_keys
-    )
-  end
-
-  @impl true
-  def process_upsert(event, data) do
-    Application.get_env(:mobile_app_backend, MBTAV3API.Store.Vehicles, Vehicles.Impl).process_upsert(
-      event,
-      data
-    )
-  end
-
-  @impl true
-  def process_reset(data, scope) do
-    Application.get_env(:mobile_app_backend, MBTAV3API.Store.Vehicles, Vehicles.Impl).process_reset(
-      data,
-      scope
-    )
-  end
-
-  @impl true
-  def process_remove(references) do
-    Application.get_env(:mobile_app_backend, MBTAV3API.Store.Vehicles, Vehicles.Impl).process_remove(
-      references
-    )
-  end
 end
 
 defmodule MBTAV3API.Store.Vehicles.Impl do

--- a/lib/mbta_v3_api/stream/instance.ex
+++ b/lib/mbta_v3_api/stream/instance.ex
@@ -79,7 +79,7 @@ defmodule MBTAV3API.Stream.Instance do
 
     {_, consumer_pid, _, _} =
       Enum.find(children, {nil, nil, nil, nil}, fn {_, _, _, [module]} ->
-        module == MBTAV3API.Stream.Consumer
+        module == MBTAV3API.Stream.Consumer || MBTAV3API.Stream.ConsumerToStore
       end)
 
     {stage_healthy, stage_info} = stage_health(sses_pid)
@@ -120,7 +120,7 @@ defmodule MBTAV3API.Stream.Instance do
 
     consumer_dest =
       if consumer_alive do
-        %GenStage{state: %MBTAV3API.Stream.Consumer.State{destination: destination}} =
+        %GenStage{state: %{destination: destination}} =
           :sys.get_state(consumer_pid)
 
         case destination do

--- a/lib/mbta_v3_api/stream/static_instance.ex
+++ b/lib/mbta_v3_api/stream/static_instance.ex
@@ -107,6 +107,22 @@ defmodule MBTAV3API.Stream.StaticInstance.Impl do
     ]
   end
 
+  defp args_for_topic("vehicles:to_store") do
+    [
+      type: MBTAV3API.Vehicle,
+      url: "/vehicles",
+      # `:topic` is unique to a route because we stream predictions separately by route
+      # `:destination` is the same across all routes because all predictions
+      # are unified in `Store.Predictions`
+      topic: "vehicles:to_store",
+      consumer: %{
+        store: MBTAV3API.Store.Vehicles,
+        # Single stream for all vehicles
+        scope: []
+      }
+    ]
+  end
+
   defp args_for_topic("vehicles") do
     [type: MBTAV3API.Vehicle, url: "/vehicles", topic: "vehicles"]
   end

--- a/lib/mbta_v3_api/stream/static_instance.ex
+++ b/lib/mbta_v3_api/stream/static_instance.ex
@@ -28,7 +28,11 @@ defmodule MBTAV3API.Stream.StaticInstance do
   end
 
   def ensure_stream_started(topic, opts \\ []) do
-    Application.get_env(:mobile_app_backend, MBTAV3API.Stream.StaticInstance, StaticInstance.Impl).ensure_stream_started(
+    Application.get_env(
+      :mobile_app_backend,
+      MBTAV3API.Stream.StaticInstance,
+      StaticInstance.Impl
+    ).ensure_stream_started(
       topic,
       opts
     )

--- a/lib/mbta_v3_api/supervisor.ex
+++ b/lib/mbta_v3_api/supervisor.ex
@@ -7,12 +7,12 @@ defmodule MBTAV3API.Supervisor do
 
   @impl true
   def init(_) do
-    start_predictions_store? =
-      Application.get_env(:mobile_app_backend, :start_predictions_store?, true)
+    start_stream_stores? =
+      Application.get_env(:mobile_app_backend, :start_stream_stores?, true)
 
     children =
-      if start_predictions_store? do
-        [MBTAV3API.Store.Predictions]
+      if start_stream_stores? do
+        [MBTAV3API.Store.Predictions, MBTAV3API.Store.Vehicles]
       else
         []
       end ++

--- a/lib/mobile_app_backend/predictions/pub_sub.ex
+++ b/lib/mobile_app_backend/predictions/pub_sub.ex
@@ -33,7 +33,6 @@ defmodule MobileAppBackend.Predictions.PubSub do
   Based on https://github.com/mbta/dotcom/blob/main/lib/predictions/pub_sub.ex
   """
   use GenServer
-  alias MBTAV3API.Stream.StaticInstance
   alias MBTAV3API.{JsonApi, Prediction, Stop, Store, Stream}
   alias MobileAppBackend.Predictions.PubSub
 
@@ -188,12 +187,10 @@ defmodule MobileAppBackend.Predictions.PubSub do
 
   @impl GenServer
   def init(opts \\ []) do
-    # Predictions are streamed from the V3 API by route, but events are aggregated
-    # under this single topic
+    # Predictions are streamed from the V3 API by route,
+    # but reset event messages are aggregated under this single topic
     Stream.PubSub.subscribe("predictions:all:events")
-
-    # There is only one vehicle stream - subscribe & start it if it hasn't already been started
-    StaticInstance.subscribe("vehicles:to_store", include_current_data: false)
+    Stream.PubSub.subscribe("vehicles:to_store")
 
     broadcast_timer(50)
 

--- a/lib/mobile_app_backend/predictions/pub_sub.ex
+++ b/lib/mobile_app_backend/predictions/pub_sub.ex
@@ -1,12 +1,13 @@
 defmodule MobileAppBackend.Predictions.PubSub.Behaviour do
   alias MBTAV3API.JsonApi
-  alias MBTAV3API.{Prediction, Stop, Trip}
+  alias MBTAV3API.{Prediction, Stop, Trip, Vehicle}
 
   @type predictions_for_stop :: %{Stop.id() => JsonApi.Object.full_map()}
 
   @type subscribe_response :: %{
           predictions_by_stop: %{Stop.id() => %{Prediction.id() => Prediction.t()}},
-          trips: %{Trip.id() => Trip.t()}
+          trips: %{Trip.id() => Trip.t()},
+          vehicles: %{Vehicle.id() => Vehicle.t()}
         }
 
   @doc """
@@ -99,7 +100,11 @@ defmodule MobileAppBackend.Predictions.PubSub do
         child_ids_by_parent_id
       )
 
-    %{predictions_by_stop: predictions_by_stop, trips: all_predictions_data.trips}
+    %{
+      predictions_by_stop: predictions_by_stop,
+      trips: all_predictions_data.trips,
+      vehicles: all_predictions_data.vehicles
+    }
   end
 
   @impl true

--- a/lib/mobile_app_backend/predictions/stream_subscriber.ex
+++ b/lib/mobile_app_backend/predictions/stream_subscriber.ex
@@ -25,7 +25,9 @@ defmodule MobileAppBackend.Predictions.StreamSubscriber.Impl do
   @moduledoc """
   Ensure that prediction streams from the V3 API have been started for
   each route relevant to a subscriber. Once the streams have been started,
-  prediction updates will be sent to `Store.Predictions`.
+  prediction updates will be sent to `Store.Predictions`. and vehicle updates
+  will be sent to `Store.Vehicles`.
+
   """
   @behaviour MobileAppBackend.Predictions.StreamSubscriber
 
@@ -33,7 +35,8 @@ defmodule MobileAppBackend.Predictions.StreamSubscriber.Impl do
 
   @spec subscribe_for_stops([Stop.id()]) :: :ok
   @doc """
-  Ensure prediction streams have been started for every route served by the given stops.
+  Ensure prediction streams have been started for every route served by the given stops
+  and the stream of all vehicles has been started.
   """
   def subscribe_for_stops(stop_ids) do
     {:ok, %{data: routes}} = MBTAV3API.Repository.routes(filter: [stop: stop_ids])
@@ -44,5 +47,7 @@ defmodule MobileAppBackend.Predictions.StreamSubscriber.Impl do
           include_current_data: false
         )
     end)
+
+    MBTAV3API.Stream.StaticInstance.subscribe("vehicles:to_store", include_current_data: false)
   end
 end

--- a/lib/mobile_app_backend/predictions/stream_subscriber.ex
+++ b/lib/mobile_app_backend/predictions/stream_subscriber.ex
@@ -48,5 +48,7 @@ defmodule MobileAppBackend.Predictions.StreamSubscriber.Impl do
           include_current_data: false
         )
     end)
+
+    StaticInstance.ensure_stream_started("vehicles:to_store", include_current_data: false)
   end
 end

--- a/lib/mobile_app_backend/predictions/stream_subscriber.ex
+++ b/lib/mobile_app_backend/predictions/stream_subscriber.ex
@@ -2,13 +2,16 @@ defmodule MobileAppBackend.Predictions.StreamSubscriber do
   @moduledoc """
   Ensure that prediction streams from the V3 API have been started for
   each route relevant to a subscriber. Once the streams have been started,
-  prediction updates will be sent to `Store.Predictions`.
+  prediction updates will be sent to `Store.Predictions`. and vehicle updates
+  will be sent to `Store.Vehicles`.
+
   """
   alias MBTAV3API.Stop
   alias MobileAppBackend.Predictions.StreamSubscriber
 
   @doc """
-  Ensure prediction streams have been started for every route served by the given stops.
+  Ensure prediction streams have been started for every route served by the given stops
+  and the stream of all vehicles has been started.
   """
   @callback subscribe_for_stops([Stop.id()]) :: :ok
 
@@ -22,33 +25,24 @@ defmodule MobileAppBackend.Predictions.StreamSubscriber do
 end
 
 defmodule MobileAppBackend.Predictions.StreamSubscriber.Impl do
-  @moduledoc """
-  Ensure that prediction streams from the V3 API have been started for
-  each route relevant to a subscriber. Once the streams have been started,
-  prediction updates will be sent to `Store.Predictions`. and vehicle updates
-  will be sent to `Store.Vehicles`.
-
-  """
   @behaviour MobileAppBackend.Predictions.StreamSubscriber
 
-  alias MBTAV3API.Stop
   alias MBTAV3API.Stream.StaticInstance
 
-  @spec subscribe_for_stops([Stop.id()]) :: :ok
-  @doc """
-  Ensure prediction streams have been started for every route served by the given stops
-  and the stream of all vehicles has been started.
-  """
+  @impl true
   def subscribe_for_stops(stop_ids) do
     {:ok, %{data: routes}} = MBTAV3API.Repository.routes(filter: [stop: stop_ids])
 
     Enum.each(routes, fn %MBTAV3API.Route{id: route_id} ->
       {:ok, _data} =
-        StaticInstance.subscribe("predictions:route:to_store:#{route_id}",
+        StaticInstance.ensure_stream_started("predictions:route:to_store:#{route_id}",
           include_current_data: false
         )
     end)
 
-    StaticInstance.ensure_stream_started("vehicles:to_store", include_current_data: false)
+    {:ok, _data} =
+      StaticInstance.ensure_stream_started("vehicles:to_store", include_current_data: false)
+
+    :ok
   end
 end

--- a/lib/mobile_app_backend/predictions/stream_subscriber.ex
+++ b/lib/mobile_app_backend/predictions/stream_subscriber.ex
@@ -32,6 +32,7 @@ defmodule MobileAppBackend.Predictions.StreamSubscriber.Impl do
   @behaviour MobileAppBackend.Predictions.StreamSubscriber
 
   alias MBTAV3API.Stop
+  alias MBTAV3API.Stream.StaticInstance
 
   @spec subscribe_for_stops([Stop.id()]) :: :ok
   @doc """
@@ -43,11 +44,11 @@ defmodule MobileAppBackend.Predictions.StreamSubscriber.Impl do
 
     Enum.each(routes, fn %MBTAV3API.Route{id: route_id} ->
       {:ok, _data} =
-        MBTAV3API.Stream.StaticInstance.subscribe("predictions:route:to_store:#{route_id}",
+        StaticInstance.subscribe("predictions:route:to_store:#{route_id}",
           include_current_data: false
         )
     end)
 
-    MBTAV3API.Stream.StaticInstance.subscribe("vehicles:to_store", include_current_data: false)
+    StaticInstance.subscribe("vehicles:to_store", include_current_data: false)
   end
 end

--- a/lib/mobile_app_backend/predictions/stream_subscriber.ex
+++ b/lib/mobile_app_backend/predictions/stream_subscriber.ex
@@ -48,7 +48,5 @@ defmodule MobileAppBackend.Predictions.StreamSubscriber.Impl do
           include_current_data: false
         )
     end)
-
-    StaticInstance.subscribe("vehicles:to_store", include_current_data: false)
   end
 end

--- a/test/mbta_v3_api/store/predictions_test.exs
+++ b/test/mbta_v3_api/store/predictions_test.exs
@@ -142,7 +142,7 @@ defmodule MBTAV3API.Store.PredictionsTest do
       msg = capture_log([level: :info], fn -> Store.Predictions.fetch(stop_id: "12345") end)
 
       assert msg =~
-               "Elixir.MBTAV3API.Store.Predictions.Impl fetch table_name=predictions_from_streams fetch_keys=[stop_id: \"12345\"] duration="
+               "fetch table_name=predictions_from_streams fetch_keys=[stop_id: \"12345\"] duration="
     end
   end
 

--- a/test/mbta_v3_api/store/vehicles_test.exs
+++ b/test/mbta_v3_api/store/vehicles_test.exs
@@ -92,7 +92,7 @@ defmodule MBTAV3API.Store.VehiclesTest do
       msg = capture_log([level: :info], fn -> Store.Vehicles.fetch(id: "v_1") end)
 
       assert msg =~
-               "Elixir.MBTAV3API.Store.Vehicles.Impl fetch table_name=vehicles_from_stream fetch_keys=[id: \"v_1\"] duration="
+               "fetch table_name=vehicles_from_stream fetch_keys=[id: \"v_1\"] duration="
     end
   end
 

--- a/test/mbta_v3_api/store/vehicles_test.exs
+++ b/test/mbta_v3_api/store/vehicles_test.exs
@@ -1,0 +1,130 @@
+defmodule MBTAV3API.Store.VehiclesTest do
+  use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
+  import MBTAV3API.JsonApi.Object, only: [to_full_map: 1]
+  import MobileAppBackend.Factory
+  import Test.Support.Helpers
+
+  alias MBTAV3API.JsonApi
+  alias MBTAV3API.{JsonApi.Reference, Store}
+
+  setup do
+    start_link_supervised!(Store.Vehicles)
+    vehicle_1 = build(:vehicle, id: "v_1", route_id: "66")
+    vehicle_2 = build(:vehicle, id: "v_2", route_id: "66")
+
+    %{
+      vehicle_1: vehicle_1,
+      vehicle_1_updated: %{vehicle_1 | route_id: "39"},
+      vehicle_2: vehicle_2,
+      vehicle_2_updated: %{vehicle_2 | route_id: "15"}
+    }
+  end
+
+  describe "process_events" do
+    test "process_upsert when add", %{
+      vehicle_1: vehicle_1,
+      vehicle_2: vehicle_2
+    } do
+      Store.Vehicles.process_upsert(:add, [vehicle_1, vehicle_2])
+
+      assert to_full_map([vehicle_1, vehicle_2]) == Store.Vehicles.fetch_with_associations([])
+    end
+
+    test "process_upsert when update", %{
+      vehicle_1: vehicle_1,
+      vehicle_1_updated: vehicle_1_updated,
+      vehicle_2: vehicle_2
+    } do
+      Store.Vehicles.process_upsert(:add, [vehicle_1, vehicle_2])
+
+      assert to_full_map([vehicle_1, vehicle_2]) == Store.Vehicles.fetch_with_associations([])
+
+      Store.Vehicles.process_upsert(:update, [vehicle_1_updated])
+
+      assert to_full_map([vehicle_1_updated, vehicle_2]) ==
+               Store.Vehicles.fetch_with_associations([])
+    end
+
+    test "process_remove", %{
+      vehicle_1: vehicle_1,
+      vehicle_2: vehicle_2
+    } do
+      Store.Vehicles.process_upsert(:add, [vehicle_1, vehicle_2])
+
+      Store.Vehicles.process_remove([
+        %Reference{type: "vehicle", id: vehicle_1.id}
+      ])
+
+      assert to_full_map([vehicle_2]) ==
+               Store.Vehicles.fetch_with_associations([])
+    end
+
+    test "process_reset", %{
+      vehicle_1: vehicle_1,
+      vehicle_1_updated: vehicle_1_updated,
+      vehicle_2: vehicle_2
+    } do
+      Store.Vehicles.process_upsert(:add, [vehicle_1, vehicle_2])
+      Store.Vehicles.process_reset([vehicle_1_updated], [])
+
+      assert to_full_map([vehicle_1_updated]) ==
+               Store.Vehicles.fetch_with_associations([])
+    end
+  end
+
+  describe "fetch" do
+    test "by id", %{vehicle_1: vehicle_1, vehicle_2: vehicle_2} do
+      Store.Vehicles.process_upsert(:add, [vehicle_1, vehicle_2])
+
+      assert [vehicle_1] == Store.Vehicles.fetch(id: "v_1")
+    end
+
+    test "by route_id", %{vehicle_1: vehicle_1, vehicle_2_updated: vehicle_2_updated} do
+      Store.Vehicles.process_upsert(:add, [vehicle_1, vehicle_2_updated])
+
+      assert [vehicle_1] == Store.Vehicles.fetch(route_id: "66")
+    end
+
+    test "logs duration", %{vehicle_1: vehicle_1} do
+      set_log_level(:info)
+
+      Store.Vehicles.process_upsert(:add, [vehicle_1])
+      msg = capture_log([level: :info], fn -> Store.Vehicles.fetch(id: "v_1") end)
+
+      assert msg =~
+               "Elixir.MBTAV3API.Store.Vehicles.Impl fetch table_name=vehicles_from_stream fetch_keys=[id: \"v_1\"] duration="
+    end
+  end
+
+  describe "fetch list of keywords" do
+    test "fetches all matches from multiple fetch keys", %{
+      vehicle_1: vehicle_1,
+      vehicle_2: vehicle_2
+    } do
+      Store.Vehicles.process_upsert(:add, [vehicle_1, vehicle_2])
+
+      assert [vehicle_1, vehicle_2] ==
+               Enum.sort_by(
+                 Store.Vehicles.fetch([[id: "v_1"], [id: "v_2"]]),
+                 & &1.id
+               )
+    end
+  end
+
+  describe "fetch_with_associations/1" do
+    test "returns matching vehicles only", %{vehicle_1: vehicle_1, vehicle_2: vehicle_2} do
+      Store.Vehicles.process_upsert(:add, [
+        vehicle_1,
+        vehicle_2
+      ])
+
+      assert to_full_map([
+               vehicle_1
+             ]) == Store.Vehicles.fetch_with_associations(id: "v_1")
+
+      assert to_full_map([vehicle_1, vehicle_2]) ==
+               Store.Vehicles.fetch_with_associations([[id: "v_1"], [id: "v_2"]])
+    end
+  end
+end

--- a/test/mbta_v3_api/store/vehicles_test.exs
+++ b/test/mbta_v3_api/store/vehicles_test.exs
@@ -1,11 +1,10 @@
 defmodule MBTAV3API.Store.VehiclesTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   import ExUnit.CaptureLog
   import MBTAV3API.JsonApi.Object, only: [to_full_map: 1]
   import MobileAppBackend.Factory
   import Test.Support.Helpers
 
-  alias MBTAV3API.JsonApi
   alias MBTAV3API.{JsonApi.Reference, Store}
 
   setup do

--- a/test/mbta_v3_api/store_test.exs
+++ b/test/mbta_v3_api/store_test.exs
@@ -1,0 +1,44 @@
+defmodule MBTAV3API.StoreTest do
+  use ExUnit.Case
+  import ExUnit.CaptureLog
+
+  import Test.Support.Helpers
+
+  alias MBTAV3API.Store
+
+  defmodule TestTableOwner do
+    use GenServer
+    @spec start_link(Keyword.t()) :: GenServer.on_start()
+    def start_link(_) do
+      GenServer.start_link(__MODULE__, [], name: __MODULE__)
+    end
+
+    @impl true
+    def init(_) do
+      _table = :ets.new(:test_table, [:named_table, :public, read_concurrency: true])
+      {:ok, %{}}
+    end
+  end
+
+  setup do
+    start_link_supervised!(TestTableOwner)
+    :ok
+  end
+
+  describe "timed_fetch/3" do
+    test "returns matches & logs duration" do
+      set_log_level(:info)
+      :ets.insert(:test_table, [{"key", "value"}, {"other", "other_value"}])
+
+      {results, log} =
+        with_log([level: :info], fn ->
+          Store.timed_fetch(:test_table, [{{"key", :"$1"}, [], [:"$1"]}], "other_field=true")
+        end)
+
+      assert ["value"] == results
+
+      assert log =~
+               "fetch table_name=test_table other_field=true duration="
+    end
+  end
+end

--- a/test/mbta_v3_api/stream/static_instance_test.exs
+++ b/test/mbta_v3_api/stream/static_instance_test.exs
@@ -104,4 +104,28 @@ defmodule MBTAV3API.Stream.StaticInstanceTest do
                Stream.StaticInstance.subscribe("test:topic", include_current_data: false)
     end
   end
+
+  describe "ensure_stream_started/1" do
+    test "when existing stream, only fetches current data" do
+      start_link_supervised!({FakeStaticInstance, topic: "test:topic", data: :existing_data})
+
+      assert {:ok, :existing_data} == Stream.StaticInstance.ensure_stream_started("test:topic")
+    end
+
+    test "launches new instance if not already running" do
+      topic = "predictions:route:fake-route"
+      refute Stream.Registry.find_pid(topic)
+      assert {:ok, _} = Stream.StaticInstance.ensure_stream_started(topic)
+      assert Stream.Registry.find_pid(topic)
+    end
+
+    test "when include_current_data is false, skips returning latest data" do
+      start_link_supervised!({FakeStaticInstance, topic: "test:topic", data: :existing_data})
+
+      assert {:ok, :current_data_not_requested} ==
+               Stream.StaticInstance.ensure_stream_started("test:topic",
+                 include_current_data: false
+               )
+    end
+  end
 end

--- a/test/mobile_app_backend/predictions/pub_sub_test.exs
+++ b/test/mobile_app_backend/predictions/pub_sub_test.exs
@@ -13,8 +13,6 @@ defmodule MobileAppBackend.Predictions.PubSubTests do
 
     reassign_env(:mobile_app_backend, StreamSubscriber, StreamSubscriberMock)
     reassign_env(:mobile_app_backend, MBTAV3API.Repository, RepositoryMock)
-    reassign_env(:mobile_app_backend, MBTAV3API.Stream.StaticInstance, StaticInstanceMock)
-
     reassign_env(:mobile_app_backend, Store.Predictions, PredictionsStoreMock)
     :ok
   end
@@ -23,21 +21,13 @@ defmodule MobileAppBackend.Predictions.PubSubTests do
   setup :set_mox_from_context
 
   describe "init/1" do
-    test "starts vehicle stream" do
-      StaticInstanceMock
-      |> expect(:subscribe, fn "vehicles:to_store", include_current_data: false ->
-        {:ok, :no_data}
-      end)
-
+    test "subscribes to vehicle events" do
       PubSub.init(create_table_fn: fn -> :no_op end)
+      Stream.PubSub.broadcast!("vehicles:to_store", :reset_event)
+      assert_receive :reset_event
     end
 
     test "subscribes to prediction events" do
-      StaticInstanceMock
-      |> expect(:subscribe, fn "vehicles:to_store", include_current_data: false ->
-        {:ok, :no_data}
-      end)
-
       PubSub.init(create_table_fn: fn -> :no_op end)
 
       Stream.PubSub.broadcast!("predictions:all:events", :reset_event)

--- a/test/mobile_app_backend/predictions/pub_sub_test.exs
+++ b/test/mobile_app_backend/predictions/pub_sub_test.exs
@@ -21,12 +21,26 @@ defmodule MobileAppBackend.Predictions.PubSubTests do
 
   describe "subscribe_for_stop/1" do
     test "returns initial data for the given isolated stop" do
-      prediction_1 = build(:prediction, id: "p_1", stop_id: "12345", trip_id: "trip_1")
-      prediction_2 = build(:prediction, id: "p_2", stop_id: "12345", trip_id: "trip_1")
+      prediction_1 =
+        build(:prediction, id: "p_1", stop_id: "12345", trip_id: "trip_1", vehicle_id: "v_1")
+
+      prediction_2 =
+        build(:prediction, id: "p_2", stop_id: "12345", trip_id: "trip_1", vehicle_id: "v_2")
+
       trip_1 = build(:trip, id: "trip_1")
       trip_2 = build(:trip, id: "trip_2")
+      vehicle_1 = build(:vehicle, id: "v_1")
+      vehicle_2 = build(:vehicle, id: "v_2")
 
-      full_map = JsonApi.Object.to_full_map([prediction_1, prediction_2, trip_1, trip_2])
+      full_map =
+        JsonApi.Object.to_full_map([
+          prediction_1,
+          prediction_2,
+          trip_1,
+          trip_2,
+          vehicle_1,
+          vehicle_2
+        ])
 
       expect(PredictionsStoreMock, :fetch_with_associations, fn [[stop_id: "12345"]] ->
         full_map
@@ -39,17 +53,32 @@ defmodule MobileAppBackend.Predictions.PubSubTests do
 
       assert %{
                predictions_by_stop: %{"12345" => %{"p_1" => prediction_1, "p_2" => prediction_2}},
-               trips: %{"trip_1" => trip_1, "trip_2" => trip_2}
+               trips: %{"trip_1" => trip_1, "trip_2" => trip_2},
+               vehicles: %{"v_1" => vehicle_1, "v_2" => vehicle_2}
              } == PubSub.subscribe_for_stop("12345")
     end
 
     test "returns initial data for the given parent stop" do
-      prediction_1 = build(:prediction, stop_id: "12345", id: "p_1", trip_id: "trip_1")
-      prediction_2 = build(:prediction, stop_id: "6789", id: "p_2", trip_id: "trip_2")
+      prediction_1 =
+        build(:prediction, stop_id: "12345", id: "p_1", trip_id: "trip_1", vehicle_id: "v_1")
+
+      prediction_2 =
+        build(:prediction, stop_id: "6789", id: "p_2", trip_id: "trip_2", vehicle_id: "v_2")
+
       trip_1 = build(:trip, id: "trip_1")
       trip_2 = build(:trip, id: "trip_2")
+      vehicle_1 = build(:vehicle, id: "v_1")
+      vehicle_2 = build(:vehicle, id: "v_2")
 
-      full_map = JsonApi.Object.to_full_map([prediction_1, prediction_2, trip_1, trip_2])
+      full_map =
+        JsonApi.Object.to_full_map([
+          prediction_1,
+          prediction_2,
+          trip_1,
+          trip_2,
+          vehicle_1,
+          vehicle_2
+        ])
 
       expect(PredictionsStoreMock, :fetch_with_associations, fn fetch_keyword_list ->
         assert Enum.any?(fetch_keyword_list, &(Keyword.get(&1, :stop_id) == "12345"))
@@ -71,7 +100,8 @@ defmodule MobileAppBackend.Predictions.PubSubTests do
                predictions_by_stop: %{
                  "parent_stop_id" => %{"p_1" => prediction_1, "p_2" => prediction_2}
                },
-               trips: %{"trip_1" => trip_1, "trip_2" => trip_2}
+               trips: %{"trip_1" => trip_1, "trip_2" => trip_2},
+               vehicles: %{"v_1" => vehicle_1, "v_2" => vehicle_2}
              } ==
                PubSub.subscribe_for_stop("parent_stop_id")
     end
@@ -79,12 +109,26 @@ defmodule MobileAppBackend.Predictions.PubSubTests do
 
   describe "subscribe_for_stops/1" do
     test "returns initial data for each stop given" do
-      prediction_1 = build(:prediction, id: "p_1", stop_id: "standalone", trip_id: "trip_1")
-      prediction_2 = build(:prediction, id: "p_2", stop_id: "child", trip_id: "trip_2")
+      prediction_1 =
+        build(:prediction, id: "p_1", stop_id: "standalone", trip_id: "trip_1", vehicle_id: "v_1")
+
+      prediction_2 =
+        build(:prediction, id: "p_2", stop_id: "child", trip_id: "trip_2", vehicle_id: "v_2")
+
       trip_1 = build(:trip, id: "trip_1")
       trip_2 = build(:trip, id: "trip_2")
+      vehicle_1 = build(:vehicle, id: "v_1")
+      vehicle_2 = build(:vehicle, id: "v_2")
 
-      full_map = JsonApi.Object.to_full_map([prediction_1, prediction_2, trip_1, trip_2])
+      full_map =
+        JsonApi.Object.to_full_map([
+          prediction_1,
+          prediction_2,
+          trip_1,
+          trip_2,
+          vehicle_1,
+          vehicle_2
+        ])
 
       expect(PredictionsStoreMock, :fetch_with_associations, 1, fn [
                                                                      [stop_id: "child"],
@@ -107,7 +151,8 @@ defmodule MobileAppBackend.Predictions.PubSubTests do
                  "standalone" => %{"p_1" => prediction_1},
                  "parent" => %{"p_2" => prediction_2}
                },
-               trips: %{"trip_1" => trip_1, "trip_2" => trip_2}
+               trips: %{"trip_1" => trip_1, "trip_2" => trip_2},
+               vehicles: %{"v_1" => vehicle_1, "v_2" => vehicle_2}
              } ==
                PubSub.subscribe_for_stops(["parent", "standalone"])
     end
@@ -125,23 +170,24 @@ defmodule MobileAppBackend.Predictions.PubSubTests do
     end
 
     test ":broadcast sends message to subscribed pid", state do
-      prediction_1 = build(:prediction, stop_id: "12345", trip_id: "trip_1")
-      prediction_2 = build(:prediction, stop_id: "12345", trip_id: "trip_1")
-      prediction_3 = build(:prediction, stop_id: "12345", trip_id: "trip_1")
+      prediction_1 = build(:prediction, stop_id: "12345", trip_id: "trip_1", vehicle_id: "v_1")
+      prediction_2 = build(:prediction, stop_id: "12345", trip_id: "trip_1", vehicle_id: "v_1")
+      prediction_3 = build(:prediction, stop_id: "12345", trip_id: "trip_1", vehicle_id: "v_1")
       trip_1 = build(:trip, id: "trip_1")
+      vehicle_1 = build(:vehicle, id: "v_1")
 
       PredictionsStoreMock
       # Subscribe
       |> expect(:fetch_with_associations, fn _ ->
-        JsonApi.Object.to_full_map([prediction_1, trip_1])
+        JsonApi.Object.to_full_map([prediction_1, trip_1, vehicle_1])
       end)
       # 1st and 2nd broadcast
       |> expect(:fetch_with_associations, 2, fn _ ->
-        JsonApi.Object.to_full_map([prediction_2, trip_1])
+        JsonApi.Object.to_full_map([prediction_2, trip_1, vehicle_1])
       end)
       # 3rd broadcast
       |> expect(:fetch_with_associations, fn _ ->
-        JsonApi.Object.to_full_map([prediction_3, trip_1])
+        JsonApi.Object.to_full_map([prediction_3, trip_1, vehicle_1])
       end)
 
       RepositoryMock
@@ -154,10 +200,13 @@ defmodule MobileAppBackend.Predictions.PubSubTests do
       PubSub.subscribe_for_stop("12345")
 
       PubSub.handle_info(:broadcast, state)
-      assert_receive {:new_predictions, %{"12345" => %{predictions: predictions, trips: trips}}}
+
+      assert_receive {:new_predictions,
+                      %{"12345" => %{predictions: predictions, trips: trips, vehicles: vehicles}}}
 
       assert %{prediction_2.id => prediction_2} == predictions
       assert %{trip_1.id => trip_1} == trips
+      assert %{vehicle_1.id => vehicle_1} == vehicles
 
       # Doesn't re-send the same predictions that have already been seen
       PubSub.handle_info(:broadcast, state)
@@ -173,13 +222,29 @@ defmodule MobileAppBackend.Predictions.PubSubTests do
     end
 
     test "pid can be subscribed to multiple keys", state do
-      prediction_1 = build(:prediction, id: "prediction_1", stop_id: "12345", trip_id: "trip_1")
-      prediction_2 = build(:prediction, id: "prediction_2", stop_id: "6789", trip_id: "trip_2")
+      prediction_1 =
+        build(:prediction,
+          id: "prediction_1",
+          stop_id: "12345",
+          trip_id: "trip_1",
+          vehicle_id: "v_1"
+        )
+
+      prediction_2 =
+        build(:prediction,
+          id: "prediction_2",
+          stop_id: "6789",
+          trip_id: "trip_2",
+          vehicle_id: "v_2"
+        )
+
       trip_1 = build(:trip, id: "trip_1")
       trip_2 = build(:trip, id: "trip_2")
+      vehicle_1 = build(:vehicle, id: "v_1")
+      vehicle_2 = build(:vehicle, id: "v_2")
 
-      full_map_12345 = JsonApi.Object.to_full_map([prediction_1, trip_1])
-      full_map_6789 = JsonApi.Object.to_full_map([prediction_2, trip_2])
+      full_map_12345 = JsonApi.Object.to_full_map([prediction_1, trip_1, vehicle_1])
+      full_map_6789 = JsonApi.Object.to_full_map([prediction_2, trip_2, vehicle_2])
 
       PredictionsStoreMock
       |> expect(:fetch_with_associations, fn [[stop_id: "12345"]] ->
@@ -211,7 +276,8 @@ defmodule MobileAppBackend.Predictions.PubSubTests do
       assert %{
                "12345" => %{
                  predictions: %{"prediction_1" => ^prediction_1},
-                 trips: %{"trip_1" => ^trip_1}
+                 trips: %{"trip_1" => ^trip_1},
+                 vehicles: %{"v_1" => ^vehicle_1}
                }
              } = new_predictions
 
@@ -220,7 +286,8 @@ defmodule MobileAppBackend.Predictions.PubSubTests do
       assert %{
                "6789" => %{
                  predictions: %{"prediction_2" => ^prediction_2},
-                 trips: %{"trip_2" => ^trip_2}
+                 trips: %{"trip_2" => ^trip_2},
+                 vehicles: %{"v_2" => ^vehicle_2}
                }
              } = new_predictions
     end

--- a/test/mobile_app_backend/predictions/stream_subscriber_test.exs
+++ b/test/mobile_app_backend/predictions/stream_subscriber_test.exs
@@ -13,16 +13,18 @@ defmodule MobileAppBackend.Predictions.StreamSubscriberTest do
       reassign_env(:mobile_app_backend, MBTAV3API.Repository, RepositoryMock)
     end
 
-    test "subscribes to the routes served at the given stops" do
+    test "starts streams for to the routes served at the given stops and vehicles" do
       expect(RepositoryMock, :routes, fn _, _ ->
         ok_response([build(:route, id: "66"), build(:route, id: "39")])
       end)
 
       StaticInstanceMock
-      |> expect(:subscribe, fn "predictions:route:to_store:66", include_current_data: false ->
+      |> expect(:ensure_stream_started, fn "predictions:route:to_store:66",
+                                           include_current_data: false ->
         {:ok, :no_data}
       end)
-      |> expect(:subscribe, fn "predictions:route:to_store:39", include_current_data: false ->
+      |> expect(:ensure_stream_started, fn "predictions:route:to_store:39",
+                                           include_current_data: false ->
         {:ok, :no_data}
       end)
       |> expect(:ensure_stream_started, fn "vehicles:to_store", include_current_data: false ->

--- a/test/mobile_app_backend/predictions/stream_subscriber_test.exs
+++ b/test/mobile_app_backend/predictions/stream_subscriber_test.exs
@@ -25,9 +25,6 @@ defmodule MobileAppBackend.Predictions.StreamSubscriberTest do
       |> expect(:subscribe, fn "predictions:route:to_store:39", include_current_data: false ->
         {:ok, :no_data}
       end)
-      |> expect(:subscribe, fn "vehicles:to_store", include_current_data: false ->
-        {:ok, :no_data}
-      end)
 
       StreamSubscriber.subscribe_for_stops([1, 2])
     end

--- a/test/mobile_app_backend/predictions/stream_subscriber_test.exs
+++ b/test/mobile_app_backend/predictions/stream_subscriber_test.exs
@@ -25,6 +25,9 @@ defmodule MobileAppBackend.Predictions.StreamSubscriberTest do
       |> expect(:subscribe, fn "predictions:route:to_store:39", include_current_data: false ->
         {:ok, :no_data}
       end)
+      |> expect(:subscribe, fn "vehicles:to_store", include_current_data: false ->
+        {:ok, :no_data}
+      end)
 
       StreamSubscriber.subscribe_for_stops([1, 2])
     end

--- a/test/mobile_app_backend/predictions/stream_subscriber_test.exs
+++ b/test/mobile_app_backend/predictions/stream_subscriber_test.exs
@@ -25,6 +25,9 @@ defmodule MobileAppBackend.Predictions.StreamSubscriberTest do
       |> expect(:subscribe, fn "predictions:route:to_store:39", include_current_data: false ->
         {:ok, :no_data}
       end)
+      |> expect(:ensure_stream_started, fn "vehicles:to_store", include_current_data: false ->
+        {:ok, :no_data}
+      end)
 
       StreamSubscriber.subscribe_for_stops([1, 2])
     end

--- a/test/mobile_app_backend_web/channels/predictions_for_stops_v2_channel_test.exs
+++ b/test/mobile_app_backend_web/channels/predictions_for_stops_v2_channel_test.exs
@@ -18,16 +18,23 @@ defmodule MobileAppBackendWeb.PredictionsForStopsV2ChannelTest do
   end
 
   test "joins and leaves ok", %{socket: socket} do
-    prediction_1 = build(:prediction, id: "p_1", trip_id: "trip_1", stop_id: "12345")
-    prediction_2 = build(:prediction, id: "p_2", trip_id: "trip_2", stop_id: "67890")
+    prediction_1 =
+      build(:prediction, id: "p_1", trip_id: "trip_1", stop_id: "12345", vehicle_id: "v_1")
+
+    prediction_2 =
+      build(:prediction, id: "p_2", trip_id: "trip_2", stop_id: "67890", vehicle_id: "v_2")
 
     trip_1 = build(:trip, id: "trip_1")
     trip_2 = build(:trip, id: "trip_2")
 
+    vehicle_1 = build(:vehicle, id: "v_1")
+    vehicle_2 = build(:vehicle, id: "v_2")
+
     response = %{
       predictions_by_stop: %{
         "12345" => %{"p_1" => prediction_1, "p_2" => prediction_2},
-        trips: %{"trip_1" => trip_1, "trip_2" => trip_2}
+        trips: %{"trip_1" => trip_1, "trip_2" => trip_2},
+        vehicles: %{"v_1" => vehicle_1, "v_2" => vehicle_2}
       }
     }
 
@@ -52,16 +59,28 @@ defmodule MobileAppBackendWeb.PredictionsForStopsV2ChannelTest do
     {:ok, _reply, socket} =
       subscribe_and_join(socket, "predictions:stops:v2:12345")
 
-    prediction = build(:prediction, id: "prediction_1", stop_id: "12345", trip_id: "trip_1")
+    prediction =
+      build(:prediction,
+        id: "prediction_1",
+        stop_id: "12345",
+        trip_id: "trip_1",
+        vehicle_id: "v_1"
+      )
+
     trip = build(:trip, id: "trip_1")
+    vehicle = build(:vehicle, id: "v_1")
 
     PredictionsForStopsV2Channel.handle_info(
-      {:new_predictions, %{"12345" => to_full_map([prediction, trip])}},
+      {:new_predictions, %{"12345" => to_full_map([prediction, trip, vehicle])}},
       socket
     )
 
     assert_push "stream_data", %{
-      "12345" => %{predictions: %{"prediction_1" => ^prediction}, trips: %{"trip_1" => ^trip}}
+      "12345" => %{
+        predictions: %{"prediction_1" => ^prediction},
+        trips: %{"trip_1" => ^trip},
+        vehicles: %{"v_1" => ^vehicle}
+      }
     }
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,6 +6,8 @@ Mox.defmock(MobileAppBackend.HTTPMock, for: MobileAppBackend.HTTP)
 Mox.defmock(StreamSubscriberMock, for: MobileAppBackend.Predictions.StreamSubscriber)
 Mox.defmock(PredictionsPubSubMock, for: MobileAppBackend.Predictions.PubSub.Behaviour)
 Mox.defmock(PredictionsStoreMock, for: MBTAV3API.Store)
+Mox.defmock(VehiclesStoreMock, for: MBTAV3API.Store)
+
 Application.put_env(:mobile_app_backend, MobileAppBackend.HTTP, MobileAppBackend.HTTPMock)
 
 case Test.Support.Data.start_link() do


### PR DESCRIPTION
### Summary

_Ticket:_ [Predictions Scalability: new channel that publishes predictions updates in chunks](https://app.asana.com/0/1205732265579288/1207791938443975/f)

What is this PR for?

This PR adds a new Vehicle store that is updated by a single stream for all vehicles. 
Those vehicles are fetched as part of fetching predictions for parity with the existing predictions channel.
