### PR TITLE
feat: cache global data instead of recomputing on demand

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -31,6 +31,8 @@ config :mobile_app_backend, MobileAppBackend.Search.Algolia,
   route_index: "routes_test",
   stop_index: "stops_test"
 
+config :mobile_app_backend, MobileAppBackend.GlobalDataCache, update_ms: :timer.minutes(5)
+
 config :mobile_app_backend, :logger, [
   {:handler, :sentry_handler, Sentry.LoggerHandler,
    %{

--- a/lib/mobile_app_backend/application.ex
+++ b/lib/mobile_app_backend/application.ex
@@ -24,6 +24,7 @@ defmodule MobileAppBackend.Application do
       MobileAppBackend.MapboxTokenRotator,
       MobileAppBackend.Predictions.Registry,
       MobileAppBackend.Predictions.PubSub,
+      MobileAppBackend.GlobalDataCache,
       # Start to serve requests, typically the last entry
       MobileAppBackendWeb.Endpoint
     ]

--- a/lib/mobile_app_backend/global_data_cache.ex
+++ b/lib/mobile_app_backend/global_data_cache.ex
@@ -1,0 +1,125 @@
+defmodule MobileAppBackend.GlobalDataCache do
+  use GenServer
+  alias MBTAV3API.{JsonApi, Repository}
+  alias MBTAV3API.JsonApi.Object
+
+  @typedoc """
+  A key to disambiguate other persistent_term entries from the one owned by this cache instance.
+  Defaults to the module name.
+  """
+  @type key :: term()
+
+  @type data :: %{
+          lines: Object.line_map(),
+          pattern_ids_by_stop: %{
+            (stop_id :: String.t()) => route_pattern_ids :: [String.t()]
+          },
+          routes: Object.route_map(),
+          route_patterns: Object.route_pattern_map(),
+          stops: Object.stop_map(),
+          trips: Object.trip_map()
+        }
+
+  defmodule State do
+    defstruct [:key, :update_ms]
+  end
+
+  def default_key, do: __MODULE__
+
+  def start_link(opts) do
+    opts = Keyword.merge([key: default_key()], opts)
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @spec get_data(key()) :: data()
+  def get_data(key \\ default_key()) do
+    :persistent_term.get(key)
+  end
+
+  @impl GenServer
+  def init(opts) do
+    opts = Keyword.merge(Application.get_env(:mobile_app_backend, __MODULE__), opts)
+
+    state = %State{
+      key: opts[:key],
+      update_ms: opts[:update_ms] || :timer.minutes(5)
+    }
+
+    update_data(state.key)
+
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_info(:recalculate, %State{} = state) do
+    update_data(state.key)
+
+    Process.send_after(self(), :recalculate, state.update_ms)
+
+    {:noreply, state}
+  end
+
+  @spec update_data(key()) :: :ok
+  defp update_data(key) do
+    stops = fetch_stops()
+
+    %{
+      lines: lines,
+      routes: routes,
+      route_patterns: route_patterns,
+      trips: trips,
+      pattern_ids_by_stop: pattern_ids_by_stop
+    } = fetch_route_patterns()
+
+    :persistent_term.put(key, %{
+      lines: lines,
+      pattern_ids_by_stop: pattern_ids_by_stop,
+      routes: routes,
+      route_patterns: route_patterns,
+      stops: stops,
+      trips: trips
+    })
+  end
+
+  @spec fetch_stops() :: JsonApi.Object.stop_map()
+  defp fetch_stops do
+    {:ok, %{data: stops}} =
+      Repository.stops(
+        filter: [
+          location_type: [:stop, :station]
+        ],
+        include: [:child_stops, :connecting_stops, :parent_station]
+      )
+
+    Map.new(stops, &{&1.id, &1})
+  end
+
+  @spec fetch_route_patterns() :: %{
+          lines: JsonApi.Object.line_map(),
+          routes: JsonApi.Object.route_map(),
+          route_patterns: JsonApi.Object.route_pattern_map(),
+          trips: JsonApi.Object.trip_map(),
+          pattern_ids_by_stop: %{(stop_id :: String.t()) => route_pattern_ids :: [String.t()]}
+        }
+  defp fetch_route_patterns do
+    {:ok, %{data: route_patterns, included: %{lines: lines, routes: routes, trips: trips}}} =
+      Repository.route_patterns(
+        include: [route: :line, representative_trip: :stops],
+        fields: [stop: []]
+      )
+
+    pattern_ids_by_stop = MBTAV3API.RoutePattern.get_pattern_ids_by_stop(route_patterns, trips)
+
+    trips = Map.new(trips, fn {trip_id, trip} -> {trip_id, trip} end)
+
+    route_patterns = Map.new(route_patterns, &{&1.id, &1})
+
+    %{
+      lines: lines,
+      routes: routes,
+      route_patterns: route_patterns,
+      trips: trips,
+      pattern_ids_by_stop: pattern_ids_by_stop
+    }
+  end
+end

--- a/lib/mobile_app_backend_web/controllers/global_controller.ex
+++ b/lib/mobile_app_backend_web/controllers/global_controller.ex
@@ -1,67 +1,13 @@
 defmodule MobileAppBackendWeb.GlobalController do
-  alias MBTAV3API.{JsonApi, Repository}
   use MobileAppBackendWeb, :controller
+  alias MobileAppBackend.GlobalDataCache
 
   def show(conn, _params) do
-    stops = fetch_stops()
+    cache_key =
+      Map.get(conn.assigns, :global_cache_key_for_testing, GlobalDataCache.default_key())
 
-    %{
-      lines: lines,
-      routes: routes,
-      route_patterns: route_patterns,
-      trips: trips,
-      pattern_ids_by_stop: pattern_ids_by_stop
-    } = fetch_route_patterns()
+    global_data = GlobalDataCache.get_data(cache_key)
 
-    json(conn, %{
-      lines: lines,
-      pattern_ids_by_stop: pattern_ids_by_stop,
-      routes: routes,
-      route_patterns: route_patterns,
-      stops: stops,
-      trips: trips
-    })
-  end
-
-  @spec fetch_stops() :: JsonApi.Object.stop_map()
-  defp fetch_stops do
-    {:ok, %{data: stops}} =
-      Repository.stops(
-        filter: [
-          location_type: [:stop, :station]
-        ],
-        include: [:child_stops, :connecting_stops, :parent_station]
-      )
-
-    Map.new(stops, &{&1.id, &1})
-  end
-
-  @spec fetch_route_patterns() :: %{
-          lines: JsonApi.Object.line_map(),
-          routes: JsonApi.Object.route_map(),
-          route_patterns: JsonApi.Object.route_pattern_map(),
-          trips: JsonApi.Object.trip_map(),
-          pattern_ids_by_stop: %{(stop_id :: String.t()) => route_pattern_ids :: [String.t()]}
-        }
-  defp fetch_route_patterns do
-    {:ok, %{data: route_patterns, included: %{lines: lines, routes: routes, trips: trips}}} =
-      Repository.route_patterns(
-        include: [route: :line, representative_trip: :stops],
-        fields: [stop: []]
-      )
-
-    pattern_ids_by_stop = MBTAV3API.RoutePattern.get_pattern_ids_by_stop(route_patterns, trips)
-
-    trips = Map.new(trips, fn {trip_id, trip} -> {trip_id, trip} end)
-
-    route_patterns = Map.new(route_patterns, &{&1.id, &1})
-
-    %{
-      lines: lines,
-      routes: routes,
-      route_patterns: route_patterns,
-      trips: trips,
-      pattern_ids_by_stop: pattern_ids_by_stop
-    }
+    json(conn, global_data)
   end
 end

--- a/test/mobile_app_backend/global_data_cache_test.exs
+++ b/test/mobile_app_backend/global_data_cache_test.exs
@@ -1,0 +1,92 @@
+defmodule MobileAppBackend.GlobalDataCacheTest do
+  use HttpStub.Case, async: false
+  import Mox
+  alias MobileAppBackend.GlobalDataCache
+
+  setup :set_mox_global
+
+  test "gets data" do
+    cache_key = make_ref()
+
+    start_link_supervised!({GlobalDataCache, key: cache_key})
+
+    retrieved_data = GlobalDataCache.get_data(cache_key)
+
+    assert %{
+             lines: lines,
+             pattern_ids_by_stop: pattern_ids,
+             routes: routes,
+             route_patterns: route_patterns,
+             stops: stops,
+             trips: trips
+           } = retrieved_data
+
+    park_st_station = stops["place-pktrm"]
+
+    assert %{
+             id: "place-pktrm",
+             name: "Park Street",
+             location_type: :station,
+             latitude: 42.356395,
+             longitude: -71.062424,
+             child_stop_ids: child_ids,
+             connecting_stop_ids: connecting_ids
+           } = park_st_station
+
+    park_st_rl_platform = stops["70076"]
+
+    assert %{
+             id: "70076",
+             name: "Park Street",
+             location_type: :stop,
+             parent_station_id: "place-pktrm"
+           } = park_st_rl_platform
+
+    assert child_ids |> Enum.member?("70076")
+    assert connecting_ids |> Enum.member?("10000")
+
+    park_st_rl_patterns = Map.get(pattern_ids, park_st_rl_platform.id)
+
+    assert Enum.any?(park_st_rl_patterns, &(&1 == "Red-1-1"))
+    assert Enum.any?(park_st_rl_patterns, &(&1 == "Red-3-1"))
+
+    red_line_pattern = Map.get(route_patterns, "Red-1-1")
+
+    assert %{
+             direction_id: 1,
+             id: "Red-1-1",
+             name: "Ashmont - Alewife",
+             representative_trip_id: red_line_trip_id,
+             route_id: "Red",
+             sort_order: 100_101_001
+           } = red_line_pattern
+
+    assert %{headsign: "Alewife", stop_ids: trip_stop_ids} = trips[red_line_trip_id]
+
+    assert Enum.count(trip_stop_ids) == 17
+    assert trip_stop_ids |> Enum.member?("70070")
+
+    assert %{
+             "Red" => %{
+               color: "DA291C",
+               direction_destinations: ["Ashmont/Braintree", "Alewife"],
+               direction_names: ["South", "North"],
+               id: "Red",
+               line_id: "line-Red",
+               long_name: "Red Line",
+               type: :heavy_rail
+             }
+           } = routes
+
+    assert %{
+             "line-Red" => %{
+               color: "DA291C",
+               id: "line-Red",
+               long_name: "Red Line",
+               short_name: "",
+               sort_order: 10_010,
+               text_color: "FFFFFF"
+             }
+           } = lines
+  end
+end

--- a/test/mobile_app_backend/global_data_cache_test.exs
+++ b/test/mobile_app_backend/global_data_cache_test.exs
@@ -1,15 +1,13 @@
 defmodule MobileAppBackend.GlobalDataCacheTest do
-  use HttpStub.Case, async: false
-  import Mox
+  use HttpStub.Case, async: true
   alias MobileAppBackend.GlobalDataCache
-
-  setup :set_mox_global
 
   test "gets data" do
     cache_key = make_ref()
 
     start_link_supervised!({GlobalDataCache, key: cache_key})
 
+    # makes HTTP requests from the current process, so Mox will behave correctly automatically
     retrieved_data = GlobalDataCache.get_data(cache_key)
 
     assert %{

--- a/test/mobile_app_backend_web/controllers/global_controller_test.exs
+++ b/test/mobile_app_backend_web/controllers/global_controller_test.exs
@@ -4,6 +4,68 @@ defmodule MobileAppBackendWeb.GlobalControllerTest do
 
   describe "GET /api/global" do
     test "retrieves all stop and route info from the V3 API", %{conn: conn} do
+      cache_key = make_ref()
+
+      :persistent_term.put(cache_key, %{
+        lines: %{
+          "line-Red" => %MBTAV3API.Line{
+            id: "line-Red",
+            color: "DA291C",
+            long_name: "Red Line",
+            short_name: "",
+            sort_order: 10_010,
+            text_color: "FFFFFF"
+          }
+        },
+        pattern_ids_by_stop: %{"70076" => ["Red-1-1", "Red-3-1"]},
+        routes: %{
+          "Red" => %MBTAV3API.Route{
+            id: "Red",
+            color: "DA291C",
+            direction_destinations: ["Ashmont/Braintree", "Alewife"],
+            direction_names: ["South", "North"],
+            line_id: "line-Red",
+            long_name: "Red Line",
+            type: :heavy_rail
+          }
+        },
+        route_patterns: %{
+          "Red-1-1" => %MBTAV3API.RoutePattern{
+            id: "Red-1-1",
+            direction_id: 1,
+            name: "Ashmont - Alewife",
+            representative_trip_id: "canonical-Red-C2-1",
+            route_id: "Red",
+            sort_order: 100_101_001
+          }
+        },
+        stops: %{
+          "place-pktrm" => %MBTAV3API.Stop{
+            id: "place-pktrm",
+            latitude: 42.356395,
+            location_type: :station,
+            longitude: -71.062424,
+            name: "Park Street",
+            child_stop_ids: ["70076"],
+            connecting_stop_ids: ["10000"]
+          },
+          "70076" => %MBTAV3API.Stop{
+            id: "70076",
+            name: "Park Street",
+            location_type: :stop,
+            parent_station_id: "place-pktrm"
+          }
+        },
+        trips: %{
+          "canonical-Red-C2-1" => %MBTAV3API.Trip{
+            headsign: "Alewife",
+            stop_ids: 70_094..70_062//-2 |> Enum.map(&to_string/1)
+          }
+        }
+      })
+
+      conn = Plug.Conn.assign(conn, :global_cache_key_for_testing, cache_key)
+
       conn = get(conn, "/api/global")
       stop_response = json_response(conn, 200)
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Cache global data in backend instead of recomputing on demand](https://app.asana.com/0/1205732265579288/1208354000423233/f)

Stores the global data in `:persistent_term` and refreshes it every five minutes. Per the persistent_term docs, we don't need to check if the new data is the same as the old data, because it'll be ignored automatically if it's the same.