### PR TITLE
fix(Store.Predictions): If there are no associated vehicles, return no vehicles

### DIFF
--- a/lib/mbta_v3_api/store/predictions.ex
+++ b/lib/mbta_v3_api/store/predictions.ex
@@ -89,13 +89,19 @@ defmodule MBTAV3API.Store.Predictions.Impl do
     trip_match_specs = Enum.map(trip_fetch_keys_list, &{trip_match_spec(&1), [], [:"$1"]})
 
     trips =
-      Store.timed_fetch(
-        @trips_table_name,
-        trip_match_specs,
-        "fetch_keys=#{inspect(trip_fetch_keys_list)}"
-      )
+      if Enum.empty?(trip_fetch_keys_list),
+        do: [],
+        else:
+          Store.timed_fetch(
+            @trips_table_name,
+            trip_match_specs,
+            "fetch_keys=#{inspect(trip_fetch_keys_list)}"
+          )
 
-    vehicles = Store.Vehicles.fetch(vehicle_fetch_keys_list)
+    vehicles =
+      if Enum.empty?(vehicle_fetch_keys_list),
+        do: [],
+        else: Store.Vehicles.fetch(vehicle_fetch_keys_list)
 
     JsonApi.Object.to_full_map(predictions ++ trips ++ vehicles)
   end

--- a/test/mbta_v3_api/store/predictions_test.exs
+++ b/test/mbta_v3_api/store/predictions_test.exs
@@ -221,5 +221,19 @@ defmodule MBTAV3API.Store.PredictionsTest do
              ]) ==
                Store.Predictions.fetch_with_associations([[stop_id: "12345"], [stop_id: "other"]])
     end
+
+    test "when prediction has no associations, returns no associations" do
+      prediction = build(:prediction, id: "p_1", stop_id: "12345", vehicle_id: nil, trip_id: nil)
+      trip = build(:trip, id: "t_1")
+      vehicle = build(:vehicle)
+
+      Store.Predictions.process_upsert(:add, [prediction, trip])
+      Store.Vehicles.process_upsert(:add, [vehicle])
+
+      assert JsonApi.Object.to_full_map([
+               prediction
+             ]) ==
+               Store.Predictions.fetch_with_associations([[stop_id: "12345"]])
+    end
   end
 end


### PR DESCRIPTION
### Summary

What is this PR for?
Follow up from https://github.com/mbta/mobile_app_backend/pull/198 with an edge case I hadn't tested.

I was re-running load testing and noticed the avg message size for `stream_data` was greater than the avg message size for the join response.

When there are no vehicles associated with any predictions for a stop (or there were no predictions at all), the full set of vehicles would be returned. This guards against that by not fetching any vehicles when there are no vehicle Ids for the list of predictions. Adds a guard for trips too for safe measure.