### PR TITLE
test: fix some flaky tests

### DIFF
--- a/test/mbta_v3_api/mbta_v3_api_test.exs
+++ b/test/mbta_v3_api/mbta_v3_api_test.exs
@@ -1,5 +1,5 @@
 defmodule MBTAV3APITest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   import Mox
   import Test.Support.Helpers

--- a/test/mbta_v3_api/stream/consumer_test.exs
+++ b/test/mbta_v3_api/stream/consumer_test.exs
@@ -1,5 +1,5 @@
 defmodule MBTAV3API.Stream.ConsumerTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias MBTAV3API.JsonApi
   alias MBTAV3API.Route


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix flaky backend data streaming tests](https://app.asana.com/0/1206699228703698/1206951180399064/f)

Turns out, if you mention a flaky test you don't care enough to also fix, you are invoking it.

If these were this easy the whole time, I feel really silly for not just fixing them in March.