### PR TITLE
fix(GlobalDataCache): trigger timed fetch on startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,9 @@ jobs:
         run: docker compose build
       - name: docker compose up
         run: docker compose up --wait
+        env:
+          API_KEY: ${{secrets.API_KEY}}
+          API_URL: ${{secrets.API_URL}}
       - name: ensure running properly
         run: docker compose exec --no-TTY mobile-app-backend wget --spider -S http://localhost:4000/
       - name: show docker container logs

--- a/config/test.exs
+++ b/config/test.exs
@@ -11,6 +11,8 @@ config :mobile_app_backend, MobileAppBackendWeb.Endpoint,
 # isolated fake processes
 config :mobile_app_backend, start_stream_stores?: false
 
+config :mobile_app_backend, stat_global_cache?: false
+
 # Print only warnings and errors during test
 config :logger, level: :warning
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -11,7 +11,7 @@ config :mobile_app_backend, MobileAppBackendWeb.Endpoint,
 # isolated fake processes
 config :mobile_app_backend, start_stream_stores?: false
 
-config :mobile_app_backend, stat_global_cache?: false
+config :mobile_app_backend, start_global_cache?: false
 
 # Print only warnings and errors during test
 config :logger, level: :warning

--- a/lib/mobile_app_backend/application.ex
+++ b/lib/mobile_app_backend/application.ex
@@ -10,7 +10,7 @@ defmodule MobileAppBackend.Application do
     Logger.add_handlers(:mobile_app_backend)
 
     start_global_cache? =
-      Application.get_env(:mobile_app_backend, :stat_global_cache?, true)
+      Application.get_env(:mobile_app_backend, :start_global_cache?, true)
 
     children =
       [

--- a/lib/mobile_app_backend/global_data_cache.ex
+++ b/lib/mobile_app_backend/global_data_cache.ex
@@ -1,7 +1,5 @@
 defmodule MobileAppBackend.GlobalDataCache do
   use GenServer
-  alias MBTAV3API.Route
-  alias MBTAV3API.Stop
   alias MBTAV3API.{JsonApi, Repository}
   alias MBTAV3API.JsonApi.Object
 

--- a/lib/mobile_app_backend/global_data_cache.ex
+++ b/lib/mobile_app_backend/global_data_cache.ex
@@ -1,5 +1,7 @@
 defmodule MobileAppBackend.GlobalDataCache do
   use GenServer
+  alias MBTAV3API.Route
+  alias MBTAV3API.Stop
   alias MBTAV3API.{JsonApi, Repository}
   alias MBTAV3API.JsonApi.Object
 
@@ -21,43 +23,105 @@ defmodule MobileAppBackend.GlobalDataCache do
         }
 
   defmodule State do
-    defstruct [:key, :update_ms]
+    defstruct [:key, :update_ms, :first_update_ms]
   end
 
-  def default_key, do: __MODULE__
+  @callback default_key :: key()
+  @callback get_data(key()) :: data()
 
-  def start_link(opts) do
+  def start_link(opts \\ []) do
+    Application.get_env(
+      :mobile_app_backend,
+      MobileAppBackend.GlobalDataCache.Module,
+      MobileAppBackend.GlobalDataCache.Impl
+    ).start_link(opts)
+  end
+
+  def handle_info(msg, state) do
+    Application.get_env(
+      :mobile_app_backend,
+      MobileAppBackend.GlobalDataCache.Module,
+      MobileAppBackend.GlobalDataCache.Impl
+    ).handle_info(msg, state)
+  end
+
+  def init(opts \\ []) do
+    Application.get_env(
+      :mobile_app_backend,
+      MobileAppBackend.GlobalDataCache.Module,
+      MobileAppBackend.GlobalDataCache.Impl
+    ).init(opts)
+  end
+
+  def default_key do
+    Application.get_env(
+      :mobile_app_backend,
+      MobileAppBackend.GlobalDataCache.Module,
+      MobileAppBackend.GlobalDataCache.Impl
+    ).default_key()
+  end
+
+  def get_data(key \\ default_key()) do
+    Application.get_env(
+      :mobile_app_backend,
+      MobileAppBackend.GlobalDataCache.Module,
+      MobileAppBackend.GlobalDataCache.Impl
+    ).get_data(key)
+  end
+end
+
+defmodule MobileAppBackend.GlobalDataCache.Impl do
+  use GenServer
+  alias MBTAV3API.{JsonApi, Repository}
+  alias MobileAppBackend.GlobalDataCache
+  alias MobileAppBackend.GlobalDataCache.State
+
+  @behaviour GlobalDataCache
+
+  @impl true
+  def default_key, do: MobileAppBackend.GlobalDataCache
+
+  @spec start_link(keyword()) :: :ignore | {:error, any()} | {:ok, pid()}
+  def start_link(opts \\ []) do
     opts = Keyword.merge([key: default_key()], opts)
-    GenServer.start_link(__MODULE__, opts)
+    GenServer.start_link(GlobalDataCache, opts)
   end
 
-  @spec get_data(key()) :: data()
+  @impl true
   def get_data(key \\ default_key()) do
     :persistent_term.get(key, nil) || update_data(key)
   end
 
   @impl GenServer
-  def init(opts) do
-    opts = Keyword.merge(Application.get_env(:mobile_app_backend, __MODULE__), opts)
+  def init(opts \\ []) do
+    opts = Keyword.merge(Application.get_env(:mobile_app_backend, GlobalDataCache), opts)
+    first_update_ms = opts[:first_update_ms] || :timer.seconds(1)
 
     state = %State{
       key: opts[:key],
       update_ms: opts[:update_ms] || :timer.minutes(5)
     }
 
+    Process.send_after(self(), :recalculate, first_update_ms)
+
     {:ok, state}
   end
 
   @impl GenServer
-  def handle_info(:recalculate, %State{} = state) do
+  def handle_info(:recalculate, %State{update_ms: update_ms} = state) do
     update_data(state.key)
 
-    Process.send_after(self(), :recalculate, state.update_ms)
+    if :persistent_term.get(state.key, nil) do
+      Process.send_after(self(), :recalculate, update_ms)
+    else
+      # no data yet, try again sooner
+      Process.send_after(self(), :recalculate, state.first_update_ms)
+    end
 
     {:noreply, state}
   end
 
-  @spec update_data(key()) :: data()
+  @spec update_data(GlobalDataCache.key()) :: GlobalDataCache.data()
   defp update_data(key) do
     stops = fetch_stops()
 

--- a/lib/mobile_app_backend/global_data_cache.ex
+++ b/lib/mobile_app_backend/global_data_cache.ex
@@ -109,12 +109,7 @@ defmodule MobileAppBackend.GlobalDataCache.Impl do
   def handle_info(:recalculate, %State{update_ms: update_ms} = state) do
     update_data(state.key)
 
-    if :persistent_term.get(state.key, nil) do
-      Process.send_after(self(), :recalculate, update_ms)
-    else
-      # no data yet, try again sooner
-      Process.send_after(self(), :recalculate, state.first_update_ms)
-    end
+    Process.send_after(self(), :recalculate, update_ms)
 
     {:noreply, state}
   end

--- a/lib/mobile_app_backend_web/controllers/global_controller.ex
+++ b/lib/mobile_app_backend_web/controllers/global_controller.ex
@@ -3,10 +3,7 @@ defmodule MobileAppBackendWeb.GlobalController do
   alias MobileAppBackend.GlobalDataCache
 
   def show(conn, _params) do
-    cache_key =
-      Map.get(conn.assigns, :global_cache_key_for_testing, GlobalDataCache.default_key())
-
-    global_data = GlobalDataCache.get_data(cache_key)
+    global_data = GlobalDataCache.get_data()
 
     json(conn, global_data)
   end

--- a/test/mobile_app_backend/global_data_cache_test.exs
+++ b/test/mobile_app_backend/global_data_cache_test.exs
@@ -1,6 +1,5 @@
 defmodule MobileAppBackend.GlobalDataCacheTest do
   use HttpStub.Case
-  import MobileAppBackend.Factory
   alias MobileAppBackend.GlobalDataCache
 
   test "gets data" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,7 +1,7 @@
+Mox.defmock(GlobalDataCacheMock, for: MobileAppBackend.GlobalDataCache)
 Mox.defmock(JwksApiMock, for: MobileAppBackend.AppCheck.JwksApi)
 Mox.defmock(RepositoryMock, for: MBTAV3API.Repository)
 Mox.defmock(StaticInstanceMock, for: MBTAV3API.Stream.StaticInstance)
-
 Mox.defmock(MobileAppBackend.HTTPMock, for: MobileAppBackend.HTTP)
 Mox.defmock(StreamSubscriberMock, for: MobileAppBackend.Predictions.StreamSubscriber)
 Mox.defmock(PredictionsPubSubMock, for: MobileAppBackend.Predictions.PubSub.Behaviour)


### PR DESCRIPTION
### Summary

No ticket, a fix found in https://github.com/mbta/mobile_app_backend/pull/206

What is this PR for?
This ensures that the global data cache will periodically check for updated data from the V3 API. Since this involves making a network request shortly after application startup, this also ensures that the docker build has the V3 API URL configured and that it can be skipped during testing.