### PR TITLE
fix(Store.Predictions): insert trips before predictions

### DIFF
--- a/lib/mbta_v3_api/store/predictions.ex
+++ b/lib/mbta_v3_api/store/predictions.ex
@@ -210,8 +210,8 @@ defmodule MBTAV3API.Store.Predictions.Impl do
         fn data -> to_record(data) end
       )
 
-    :ets.insert(@predictions_table_name, Map.get(records_by_type, Prediction, []))
     :ets.insert(@trips_table_name, Map.get(records_by_type, Trip, []))
+    :ets.insert(@predictions_table_name, Map.get(records_by_type, Prediction, []))
   end
 
   defp clear_data(keys) do


### PR DESCRIPTION
### Summary

Fix for [Predictions Scalability: new channel that publishes predictions updates in chunks](https://app.asana.com/0/1205732265579288/1207791938443975/f)

What is this PR for?

A possible fix for[ this sentry error
](https://mbtace.sentry.io/issues/5917860189/?project=4506321052172288), where the client received data for a prediction without a corresponding trip. This could happen if they received data after the predictions were inserted into ETS before trips. Thanks to @boringcactus for the suggestion for the simple solution to this: insert trips before predictions. 