### PR TITLE
tmp: rotate mapbox tokens more quickly for debugging purposes

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -26,8 +26,8 @@ case System.get_env("MAPBOX_PRIMARY_TOKEN") do
     config :mobile_app_backend, MobileAppBackend.ClientConfig,
       mapbox_primary_token: primary_token,
       mapbox_username: System.get_env("MAPBOX_USERNAME"),
-      token_expiration: :timer.minutes(30),
-      token_renewal: :timer.minutes(25)
+      token_expiration: :timer.minutes(2),
+      token_renewal: :timer.minutes(1)
 
   _ ->
     config :mobile_app_backend, MobileAppBackend.ClientConfig,


### PR DESCRIPTION
### Summary

What is this PR for?

DO NOT MERGE - just for the purposes of testing mapbox token rotation locally.
