### PR TITLE
chore(Store.Predictions): Add log when record removed for debugging

### DIFF
--- a/lib/mbta_v3_api/store/predictions.ex
+++ b/lib/mbta_v3_api/store/predictions.ex
@@ -189,6 +189,8 @@ defmodule MBTAV3API.Store.Predictions.Impl do
   @impl true
   def process_remove(references) do
     for reference <- references do
+      Logger.info("#{__MODULE__} process_remove #{inspect(reference)}")
+
       case reference do
         %{type: "prediction", id: id} -> :ets.delete(@predictions_table_name, id)
         %{type: "trip", id: id} -> :ets.delete(@trips_table_name, id)


### PR DESCRIPTION
### Summary

_Ticket:_ In support of  [Predictions crash due to missing trip](https://app.asana.com/0/1205425564113216/1208510328404939/f)

What is this PR for?

One possible reason that clients are experiencing missing trips is that the trip could be removed from the ETS store prematurely. By logging when trips & predictions are removed from the store, we can better understand if trips are removed before their corresponding predictions in the backend or if this is a frontend issue.