### PR TITLE
fix(Store.Predictions): Only remove trips if there are no other predictions

### DIFF
--- a/lib/mbta_v3_api/store/predictions.ex
+++ b/lib/mbta_v3_api/store/predictions.ex
@@ -189,11 +189,25 @@ defmodule MBTAV3API.Store.Predictions.Impl do
   @impl true
   def process_remove(references) do
     for reference <- references do
-      Logger.info("#{__MODULE__} process_remove #{inspect(reference)}")
-
       case reference do
-        %{type: "prediction", id: id} -> :ets.delete(@predictions_table_name, id)
-        _ -> :ok
+        %{type: "prediction", id: id} ->
+          Logger.info("#{__MODULE__} process_remove type=prediction id=#{id}")
+          :ets.delete(@predictions_table_name, id)
+
+        %{type: "trip", id: id} ->
+          exsiting_predictions_for_trip = fetch(trip_id: id)
+
+          if Enum.empty?(exsiting_predictions_for_trip) do
+            Logger.info("#{__MODULE__} process_remove type=trip id=#{id}")
+            :ets.delete(@trips_table_name, id)
+          else
+            Logger.info(
+              "#{__MODULE__} process_remove skipping removal type=trip id=#{id} remaining_prediction_count=#{length(exsiting_predictions_for_trip)}"
+            )
+          end
+
+        _ ->
+          :ok
       end
     end
 

--- a/lib/mbta_v3_api/store/predictions.ex
+++ b/lib/mbta_v3_api/store/predictions.ex
@@ -95,7 +95,7 @@ defmodule MBTAV3API.Store.Predictions.Impl do
           Store.timed_fetch(
             @trips_table_name,
             trip_match_specs,
-            "fetch_keys=#{inspect(trip_fetch_keys_list)}"
+            "trip_count=#{inspect(length(trip_fetch_keys_list))}"
           )
 
     vehicles =
@@ -193,7 +193,6 @@ defmodule MBTAV3API.Store.Predictions.Impl do
 
       case reference do
         %{type: "prediction", id: id} -> :ets.delete(@predictions_table_name, id)
-        %{type: "trip", id: id} -> :ets.delete(@trips_table_name, id)
         _ -> :ok
       end
     end


### PR DESCRIPTION
### Summary

_Ticket:_ [Predictions crash due to missing trip](https://app.asana.com/0/1205425564113216/1208510328404939/f)

What is this PR for?

This fixes a bug due to trips being included in the prediction stream for multiple routes, for multi-route trips (SL, some CR, GL added trips, and others. See [full investigation](https://www.notion.so/mbta-downtown-crossing/Missing-Trip-Crash-120f5d8d11ea80ce9537e9e6102881ab)).

This adds a simple measure to only delete a trip record if there are no associated predictions for that trip. Note: as far as I can tell, the trip record from different route streams would all share a route ID, and not necessarily match the route of the associated prediction, so this doesn't try to factor route ID into knowing when to delete a trip record.