### PR TITLE
chore: disable code coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,8 @@ jobs:
       - name: Run tests
         run: mix test --cover
       - name: Report test coverage
+        # Disabled due to dependency issues
+        if: false
         uses: mbta/github-actions-report-lcov@v1
         with:
           coverage-files: cover/lcov.info


### PR DESCRIPTION
### Summary

What is this PR for?
No ticket, currently blocking merging fixes like https://github.com/mbta/mobile_app_backend/pull/217.
As @boringcactus pointed out, likely related to `ubuntu-latest` bump from 22.04 to 24.04

