### PR TITLE
fix: draw less-typical canonical patterns on map

### DIFF
--- a/lib/mbta_v3_api/route_pattern.ex
+++ b/lib/mbta_v3_api/route_pattern.ex
@@ -80,26 +80,26 @@ defmodule MBTAV3API.RoutePattern do
     |> Enum.group_by(& &1.stop_id, & &1.route_pattern_id)
   end
 
-  @spec most_canonical_or_typical_per_route([t()]) :: [t()]
+  @spec canonical_or_most_typical_per_route([t()]) :: [t()]
   @doc """
-  Filter the list of route patterns to include only the most canonical or most typical patterns for each route.
-  Where there are multiple canonical patterns, returns the canonical patterns with the lowest typicality (ignoring undefined).
+  Filter the list of route patterns to include only the canonical or most typical patterns for each route.
+  Where there are multiple canonical patterns, returns the canonical patterns.
   When there are no canonical route patterns for a route, returns the ones with the lowest typicality.
   """
-  def most_canonical_or_typical_per_route(route_patterns) do
+  def canonical_or_most_typical_per_route(route_patterns) do
     route_patterns
     |> Enum.group_by(& &1.route_id)
-    |> Enum.flat_map(fn {_route_id, patterns} -> most_canonical_or_typical(patterns) end)
+    |> Enum.flat_map(fn {_route_id, patterns} -> canonical_or_most_typical(patterns) end)
   end
 
-  @spec most_canonical_or_typical([t()]) :: [t()]
-  # Filter the list of route patterns to include only the most canonical or most typical patterns
-  defp most_canonical_or_typical(route_patterns) do
+  @spec canonical_or_most_typical([t()]) :: [t()]
+  # Filter the list of route patterns to include only the canonical or most typical patterns
+  defp canonical_or_most_typical(route_patterns) do
     canonical_patterns = Enum.filter(route_patterns, & &1.canonical)
 
     case canonical_patterns do
       [] -> most_typical(route_patterns)
-      canonical_patterns -> most_typical(canonical_patterns)
+      canonical_patterns -> canonical_patterns
     end
   end
 

--- a/lib/mobile_app_backend_web/controllers/shapes_controller.ex
+++ b/lib/mobile_app_backend_web/controllers/shapes_controller.ex
@@ -85,7 +85,7 @@ defmodule MobileAppBackendWeb.ShapesController do
       route_patterns_by_id
       |> Map.values()
       |> Enum.filter(&(&1.direction_id == 0))
-      |> RoutePattern.most_canonical_or_typical_per_route()
+      |> RoutePattern.canonical_or_most_typical_per_route()
 
     trip_ids =
       patterns

--- a/test/mbta_v3_api/route_pattern_test.exs
+++ b/test/mbta_v3_api/route_pattern_test.exs
@@ -29,7 +29,7 @@ defmodule MBTAV3API.RoutePatternTest do
            }
   end
 
-  describe "most_canonical_or_typical_per_route/1" do
+  describe "canonical_or_most_typical_per_route/1" do
     test "when no canonical routes, returns all patterns with the lowest non-nil typicality" do
       [nil, :typical, :deviation, :atypical, :diversion, :canonical_only]
 
@@ -41,7 +41,7 @@ defmodule MBTAV3API.RoutePatternTest do
       rps_5 = build_list(2, :route_pattern, %{typicality: :canonical_only})
 
       assert ^rps_1 =
-               RoutePattern.most_canonical_or_typical_per_route(
+               RoutePattern.canonical_or_most_typical_per_route(
                  rps_5 ++ rps_0 ++ rps_4 ++ rps_1 ++ rps_3 ++ rps_2
                )
     end
@@ -56,8 +56,8 @@ defmodule MBTAV3API.RoutePatternTest do
       rps_4 = build_list(2, :route_pattern, %{typicality: :diversion})
       rps_5 = build_list(2, :route_pattern, %{typicality: :canonical_only, canonical: true})
 
-      assert ^rps_1 =
-               RoutePattern.most_canonical_or_typical_per_route(
+      assert rps_5 ++ rps_1 ==
+               RoutePattern.canonical_or_most_typical_per_route(
                  rps_5 ++ rps_0 ++ rps_4 ++ rps_1 ++ rps_3 ++ rps_2
                )
     end
@@ -73,7 +73,7 @@ defmodule MBTAV3API.RoutePatternTest do
       rps_5 = build_list(2, :route_pattern, %{typicality: :canonical_only, canonical: true})
 
       assert ^rps_5 =
-               RoutePattern.most_canonical_or_typical_per_route(
+               RoutePattern.canonical_or_most_typical_per_route(
                  rps_0 ++ rps_1 ++ rps_2 ++ rps_3 ++ rps_4 ++ rps_5
                )
     end

--- a/test/mobile_app_backend_web/controllers/shapes_controller_test.exs
+++ b/test/mobile_app_backend_web/controllers/shapes_controller_test.exs
@@ -11,7 +11,7 @@ defmodule MobileAppBackendWeb.ShapeControllerTest do
       reassign_env(:mobile_app_backend, MBTAV3API.Repository, RepositoryMock)
     end
 
-    test "when separate_overlapping_segments is true, returns non-overlapping segments for the most canonical direction 0 route patterns with the associated shape",
+    test "when separate_overlapping_segments is true, returns non-overlapping segments for the canonical direction 0 route patterns with the associated shape",
          %{conn: conn} do
       red_route = build(:route, id: "Red")
       andrew = build(:stop, id: "andrew", location_type: :station)
@@ -164,7 +164,7 @@ defmodule MobileAppBackendWeb.ShapeControllerTest do
                map_friendly_route_shapes
     end
 
-    test "when separate_overlapping_segments is not set, returns a segment per route pattern for the most canonical direction 0 route patterns with the associated shape",
+    test "when separate_overlapping_segments is not set, returns a segment per route pattern for the canonical direction 0 route patterns with the associated shape",
          %{conn: conn} do
       red_route = build(:route, id: "Red")
       andrew = build(:stop, id: "andrew", location_type: :station)


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix: Newburyport branch isn't drawn on map](https://app.asana.com/0/1205732265579288/1208493978668470/f)

Checked locally that this causes Newburyport to be drawn correctly, and checked with `dbg/2` that nothing else will be newly included or excluded as a result of this change.