### PR TITLE
perf(VehiclesForRouteChannel): Use vehicles from PubSub instead of GenServer

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -14,6 +14,7 @@ config :mobile_app_backend, MobileAppBackend.AppCheck,
   jwks_url: "https://firebaseappcheck.googleapis.com/v1/jwks"
 
 config :mobile_app_backend, predictions_broadcast_interval_ms: 5_000
+config :mobile_app_backend, vehicles_broadcast_interval_ms: 500
 
 config :mobile_app_backend, MBTAV3API.ResponseCache,
   gc_interval: :timer.hours(1),

--- a/config/test.exs
+++ b/config/test.exs
@@ -15,6 +15,10 @@ config :mobile_app_backend, start_global_cache?: false
 
 config :mobile_app_backend, start_vehicle_stream?: false
 
+# sufficiently long so that there are not timed broadcasts during tests
+config :mobile_app_backend, vehicles_broadcast_interval_ms: 60_000
+
+
 # Print only warnings and errors during test
 config :logger, level: :warning
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -13,6 +13,8 @@ config :mobile_app_backend, start_stream_stores?: false
 
 config :mobile_app_backend, start_global_cache?: false
 
+config :mobile_app_backend, start_vehicle_stream?: false
+
 # Print only warnings and errors during test
 config :logger, level: :warning
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -13,11 +13,7 @@ config :mobile_app_backend, start_stream_stores?: false
 
 config :mobile_app_backend, start_global_cache?: false
 
-config :mobile_app_backend, start_vehicle_stream?: false
-
-# sufficiently long so that there are not timed broadcasts during tests
-config :mobile_app_backend, vehicles_broadcast_interval_ms: 60_000
-
+config :mobile_app_backend, start_vehicle_pub_sub?: false
 
 # Print only warnings and errors during test
 config :logger, level: :warning

--- a/lib/mbta_v3_api/stream/static_instance.ex
+++ b/lib/mbta_v3_api/stream/static_instance.ex
@@ -141,8 +141,4 @@ defmodule MBTAV3API.Stream.StaticInstance.Impl do
       }
     ]
   end
-
-  defp args_for_topic("vehicles") do
-    [type: MBTAV3API.Vehicle, url: "/vehicles", topic: "vehicles"]
-  end
 end

--- a/lib/mobile_app_backend/application.ex
+++ b/lib/mobile_app_backend/application.ex
@@ -30,7 +30,10 @@ defmodule MobileAppBackend.Application do
         {MobileAppBackend.FinchPoolHealth, pool_name: Finch.CustomPool},
         MobileAppBackend.MapboxTokenRotator,
         MobileAppBackend.Predictions.Registry,
-        MobileAppBackend.Predictions.PubSub
+        MobileAppBackend.Predictions.PubSub,
+        MobileAppBackend.Vehicles.Registry,
+        {MobileAppBackend.Vehicles.PubSub,
+         start_stream?: Application.get_env(:mobile_app_backend, :start_vehicle_stream?, true)}
       ] ++
         if start_global_cache? do
           [MobileAppBackend.GlobalDataCache]

--- a/lib/mobile_app_backend/application.ex
+++ b/lib/mobile_app_backend/application.ex
@@ -31,10 +31,13 @@ defmodule MobileAppBackend.Application do
         MobileAppBackend.MapboxTokenRotator,
         MobileAppBackend.Predictions.Registry,
         MobileAppBackend.Predictions.PubSub,
-        MobileAppBackend.Vehicles.Registry,
-        {MobileAppBackend.Vehicles.PubSub,
-         start_stream?: Application.get_env(:mobile_app_backend, :start_vehicle_stream?, true)}
+        MobileAppBackend.Vehicles.Registry
       ] ++
+        if Application.get_env(:mobile_app_backend, :start_vehicle_pub_sub?, true) do
+          [MobileAppBackend.Vehicles.PubSub]
+        else
+          []
+        end ++
         if start_global_cache? do
           [MobileAppBackend.GlobalDataCache]
         else

--- a/lib/mobile_app_backend/vehicles/pub_sub.ex
+++ b/lib/mobile_app_backend/vehicles/pub_sub.ex
@@ -1,0 +1,169 @@
+defmodule MobileAppBackend.Vehicles.PubSub.Behaviour do
+  alias MBTAV3API.JsonApi
+  alias MBTAV3API.Vehicle
+
+  @doc """
+  Subscribe to vehicle updates for the given routes & direction
+  """
+  @callback subscribe_for_routes([Route.id()], 0 | 1) :: [Vehicle.t()]
+end
+
+defmodule MobileAppBackend.Vehicles.PubSub do
+  @moduledoc """
+  Allows channels to subscribe to the subset of vehicles they are interested
+  in and receive updates as the vehicles data changes.
+
+  For each subset of vehicles that channels are actively subscribed to, this broadcasts
+  the latest state of the world (if it has changed) to the registered consumer in two circumstances
+  1. Regularly scheduled interval - configured by `:vehicles_broadcast_interval_ms`
+  2. When there is a reset event of the underlying vehicle stream.
+  """
+  use GenServer
+  alias MBTAV3API.{JsonApi, Store, Stream}
+  alias MobileAppBackend.Vehicles.PubSub
+
+  @behaviour PubSub.Behaviour
+
+  require Logger
+
+  @fetch_registry_key :fetch_registry_key
+
+  @type registry_value :: Store.fetch_keys()
+  @type broadcast_message :: {:stream_data, JsonApi.Object.vehicle_map()}
+
+  @type state :: %{last_dispatched_table_name: atom()}
+
+  @spec start_link(Keyword.t()) :: GenServer.on_start()
+  @spec start_link() :: :ignore | {:error, any()} | {:ok, pid()}
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+
+    GenServer.start_link(
+      __MODULE__,
+      opts,
+      name: name
+    )
+  end
+
+  @impl true
+  def subscribe_for_routes(route_ids, direction_id) do
+    route_fetch_key_pairs = Enum.map(route_ids, &[route_id: &1, direction_id: direction_id])
+
+    Registry.register(
+      MobileAppBackend.Vehicles.Registry,
+      @fetch_registry_key,
+      route_fetch_key_pairs
+    )
+
+    Store.Vehicles.fetch(route_fetch_key_pairs)
+  end
+
+  @impl GenServer
+  def init(opts \\ []) do
+    if Keyword.get(opts, :start_stream?, true) do
+      Logger.error("STARTING STREAM")
+      Stream.StaticInstance.subscribe("vehicles:to_store")
+    end
+
+    broadcast_timer(50)
+
+    create_table_fn =
+      Keyword.get(opts, :create_table_fn, fn ->
+        :ets.new(:last_dispatched_vehicles, [:set, :named_table])
+        {:ok, %{last_dispatched_table_name: :last_dispatched_vehicles}}
+      end)
+
+    create_table_fn.()
+  end
+
+  @impl true
+  # Any time there is a reset_event, broadcast so that subscribers are immediately
+  # notified of the changes. This way, when the vehicle stream first starts,
+  # consumers don't have to wait `:vehicles_broadcast_interval_ms` to receive their first message.
+  def handle_info(:reset_event, state) do
+    send(self(), :broadcast)
+    {:noreply, state, :hibernate}
+  end
+
+  def handle_info(:timed_broadcast, state) do
+    send(self(), :broadcast)
+    broadcast_timer()
+    {:noreply, state, :hibernate}
+  end
+
+  @impl GenServer
+  def handle_info(:broadcast, %{last_dispatched_table_name: last_dispatched} = state) do
+    Registry.dispatch(MobileAppBackend.Vehicles.Registry, @fetch_registry_key, fn entries ->
+      Enum.group_by(
+        entries,
+        fn {_, fetch_keys} -> fetch_keys end,
+        fn {pid, _} -> pid end
+      )
+      |> Enum.each(fn {registry_value, pids} ->
+        broadcast_new_vehicles(registry_value, pids, last_dispatched)
+      end)
+    end)
+
+    {:noreply, state, :hibernate}
+  end
+
+  defp broadcast_new_vehicles(
+         fetch_keys,
+         pids,
+         last_dispatched_table_name
+       ) do
+    new_vehicles = Store.Vehicles.fetch(fetch_keys)
+
+    last_dispatched_entry = :ets.lookup(last_dispatched_table_name, fetch_keys)
+
+    if !vehicles_already_broadcast(last_dispatched_entry, new_vehicles) do
+      broadcast_vehicles(pids, new_vehicles, fetch_keys, last_dispatched_table_name)
+    end
+  end
+
+  defp broadcast_vehicles(pids, vehicles, fetch_keys, last_dispatched_table_name) do
+    Logger.info("#{__MODULE__} broadcasting to pids len=#{length(pids)}")
+
+    {time_micros, _result} =
+      :timer.tc(__MODULE__, :broadcast_to_pids, [
+        pids,
+        vehicles
+      ])
+
+    Logger.info(
+      "#{__MODULE__} broadcast_to_pids fetch_keys=#{inspect(fetch_keys)} duration=#{time_micros / 1000}"
+    )
+
+    :ets.insert(last_dispatched_table_name, {fetch_keys, vehicles})
+  end
+
+  defp vehicles_already_broadcast([], _new_vehicles) do
+    # Nothing has been broadcast yet
+    false
+  end
+
+  defp vehicles_already_broadcast([{_registry_key, last_vehicles}], new_vehicles) do
+    last_vehicles == new_vehicles
+  end
+
+  def broadcast_to_pids(pids, vehicles) do
+    Enum.each(
+      pids,
+      &send(
+        &1,
+        {:new_vehicles, vehicles}
+      )
+    )
+  end
+
+  defp broadcast_timer do
+    interval =
+      Application.get_env(:mobile_app_backend, :vehicles_broadcast_interval_ms, 500)
+
+    broadcast_timer(interval)
+  end
+
+  defp broadcast_timer(interval) do
+    Process.send_after(self(), :timed_broadcast, interval)
+  end
+end

--- a/lib/mobile_app_backend/vehicles/pub_sub.ex
+++ b/lib/mobile_app_backend/vehicles/pub_sub.ex
@@ -89,9 +89,7 @@ defmodule MobileAppBackend.Vehicles.PubSub do
 
   @impl GenServer
   def init(opts \\ []) do
-    if Keyword.get(opts, :start_stream?, true) do
-      Stream.StaticInstance.subscribe("vehicles:to_store")
-    end
+    Stream.StaticInstance.subscribe("vehicles:to_store")
 
     broadcast_timer(50)
 

--- a/lib/mobile_app_backend/vehicles/pub_sub.ex
+++ b/lib/mobile_app_backend/vehicles/pub_sub.ex
@@ -61,7 +61,6 @@ defmodule MobileAppBackend.Vehicles.PubSub do
   @impl GenServer
   def init(opts \\ []) do
     if Keyword.get(opts, :start_stream?, true) do
-      Logger.error("STARTING STREAM")
       Stream.StaticInstance.subscribe("vehicles:to_store")
     end
 

--- a/lib/mobile_app_backend/vehicles/registry.ex
+++ b/lib/mobile_app_backend/vehicles/registry.ex
@@ -1,0 +1,16 @@
+defmodule MobileAppBackend.Vehicles.Registry do
+  def child_spec(_) do
+    Registry.child_spec(keys: :duplicate, name: __MODULE__)
+  end
+
+  @spec via_name(term()) :: GenServer.name()
+  def via_name(key), do: {:via, Registry, {__MODULE__, key}}
+
+  @spec find_pid(term()) :: pid() | nil
+  def find_pid(key) do
+    case Registry.lookup(__MODULE__, key) do
+      [{pid, _}] -> pid
+      [] -> nil
+    end
+  end
+end

--- a/lib/mobile_app_backend_web/channels/predictions_for_stops_v2_channel.ex
+++ b/lib/mobile_app_backend_web/channels/predictions_for_stops_v2_channel.ex
@@ -31,14 +31,7 @@ defmodule MobileAppBackendWeb.PredictionsForStopsV2Channel do
   @spec handle_info({:new_predictions, any()}, Phoenix.Socket.t()) ::
           {:noreply, Phoenix.Socket.t()}
   def handle_info({:new_predictions, new_predictions_for_stop}, socket) do
-    {time_micros, _result} =
-      :timer.tc(fn ->
-        :ok = push(socket, "stream_data", new_predictions_for_stop)
-      end)
-
-    Logger.info("#{__MODULE__} push duration=#{time_micros / 1000}")
-
-    require Logger
+    :ok = push(socket, "stream_data", new_predictions_for_stop)
     {:noreply, socket}
   end
 end

--- a/lib/mobile_app_backend_web/channels/vehicle_channel.ex
+++ b/lib/mobile_app_backend_web/channels/vehicle_channel.ex
@@ -1,49 +1,23 @@
 defmodule MobileAppBackendWeb.VehicleChannel do
   use MobileAppBackendWeb, :channel
 
-  alias MBTAV3API.JsonApi
-  alias MBTAV3API.Vehicle
-
-  @throttle_ms 500
-
   @impl true
   def join("vehicle:id:" <> vehicle_id, _payload, socket) do
-    {:ok, throttler} =
-      MobileAppBackend.Throttler.start_link(target: self(), cast: :send_data, ms: @throttle_ms)
+    pubsub_module =
+      Application.get_env(
+        :mobile_app_backend,
+        MobileAppBackend.Vehicles.PubSub,
+        MobileAppBackend.Vehicles.PubSub
+      )
 
-    {:ok, vehicle_data} = MBTAV3API.Stream.StaticInstance.subscribe("vehicles")
+    vehicle = pubsub_module.subscribe(vehicle_id)
 
-    vehicle_data = filter_data(vehicle_data, vehicle_id)
-
-    {:ok, vehicle_data,
-     assign(socket,
-       data: vehicle_data,
-       vehicle_id: vehicle_id,
-       throttler: throttler
-     )}
+    {:ok, %{vehicle: vehicle}, socket}
   end
 
   @impl true
-  def handle_info({:stream_data, "vehicles", all_vehicles_data}, socket) do
-    old_data = socket.assigns.data
-    new_data = filter_data(all_vehicles_data, socket.assigns.vehicle_id)
-
-    if old_data != new_data do
-      MobileAppBackend.Throttler.request(socket.assigns.throttler)
-    end
-
-    socket = assign(socket, data: new_data)
+  def handle_info({:new_vehicles, vehicle}, socket) do
+    :ok = push(socket, "stream_data", %{vehicle: vehicle})
     {:noreply, socket}
-  end
-
-  @impl true
-  def handle_cast(:send_data, socket) do
-    :ok = push(socket, "stream_data", socket.assigns.data)
-    {:noreply, socket}
-  end
-
-  @spec filter_data(JsonApi.Object.full_map(), String.t()) :: %{vehicle: Vehicle.t() | nil}
-  defp filter_data(all_vehicles_data, vehicle_id) do
-    %{vehicle: Map.get(all_vehicles_data.vehicles, vehicle_id)}
   end
 end

--- a/load_testing/locustfile.py
+++ b/load_testing/locustfile.py
@@ -128,7 +128,7 @@ class MobileAppUser(HttpUser, PhoenixChannelUser):
             self.stop_id = random.choice(all_stop_ids)
         predictions_for_stop = requests.get(
             "https://api-v3.mbta.com/predictions", 
-            params={"stop": self.stop_id}, v3_api_headers=self.v3_api_headers).json()["data"]
+            params={"stop": self.stop_id}, headers=self.v3_api_headers).json()["data"]
         if (len(predictions_for_stop) != 0):
             prediction = predictions_for_stop[0]
             trip_id = prediction["relationships"]["trip"]["data"]["id"]

--- a/test/mobile_app_backend/vehicles/pub_sub_test.exs
+++ b/test/mobile_app_backend/vehicles/pub_sub_test.exs
@@ -29,7 +29,7 @@ defmodule MobileAppBackend.Vehicles.PubSubTests do
     end
   end
 
-  describe "subscribe_for_routes/1" do
+  describe "subscribe_for_routes/2" do
     test "returns initial data for the given routes" do
       vehicle_1 = build(:vehicle, id: "v_1")
       vehicle_2 = build(:vehicle, id: "v_2")
@@ -42,6 +42,26 @@ defmodule MobileAppBackend.Vehicles.PubSubTests do
       end)
 
       assert [vehicle_1, vehicle_2] == PubSub.subscribe_for_routes(["123", "456"], 1)
+    end
+  end
+
+  describe "subscribe/1" do
+    test "returns initial data for the given vehicle" do
+      vehicle_1 = build(:vehicle, id: "v_1")
+
+      expect(VehiclesStoreMock, :fetch, fn [id: "v_1"] ->
+        [vehicle_1]
+      end)
+
+      assert vehicle_1 == PubSub.subscribe("v_1")
+    end
+
+    test "returns nil when no vehicle" do
+      expect(VehiclesStoreMock, :fetch, fn [id: "v_1"] ->
+        []
+      end)
+
+      assert nil == PubSub.subscribe("v_1")
     end
   end
 

--- a/test/mobile_app_backend/vehicles/pub_sub_test.exs
+++ b/test/mobile_app_backend/vehicles/pub_sub_test.exs
@@ -1,0 +1,88 @@
+defmodule MobileAppBackend.Vehicles.PubSubTests do
+  use ExUnit.Case
+
+  alias MBTAV3API.{Store, Stream}
+  alias MobileAppBackend.Vehicles.PubSub
+  import Mox
+  import Test.Support.Helpers
+  import MobileAppBackend.Factory
+
+  setup do
+    verify_on_exit!()
+    reassign_env(:mobile_app_backend, Store.Vehicles, VehiclesStoreMock)
+    :ok
+  end
+
+  # make sure mocks are globally accessible, including from the PubSub genserver
+  setup :set_mox_from_context
+
+  describe "init/1" do
+    test "subscribes to vehicle events" do
+      expect(VehiclesStoreMock, :fetch, fn _ ->
+        []
+      end)
+
+      PubSub.init(create_table_fn: fn -> :no_op end)
+
+      Stream.PubSub.broadcast!("vehicles:to_store", :reset_event)
+      assert_receive :reset_event
+    end
+  end
+
+  describe "subscribe_for_routes/1" do
+    test "returns initial data for the given routes" do
+      vehicle_1 = build(:vehicle, id: "v_1")
+      vehicle_2 = build(:vehicle, id: "v_2")
+
+      expect(VehiclesStoreMock, :fetch, fn [
+                                             [route_id: "123", direction_id: 1],
+                                             [route_id: "456", direction_id: 1]
+                                           ] ->
+        [vehicle_1, vehicle_2]
+      end)
+
+      assert [vehicle_1, vehicle_2] == PubSub.subscribe_for_routes(["123", "456"], 1)
+    end
+  end
+
+  describe "handle_info" do
+    setup do
+      _dispatched_table = :ets.new(:test_last_dispatched, [:set, :named_table])
+      {:ok, %{last_dispatched_table_name: :test_last_dispatched}}
+    end
+
+    test "broadcasts on :reset_event" do
+      PubSub.handle_info(:reset_event, %{last_dispatched_table_name: :test_last_dispatched})
+      assert_receive :broadcast
+    end
+
+    test ":broadcast sends message to subscribed pid", state do
+      vehicle_1 = build(:vehicle, id: "v_1")
+      vehicle_2 = build(:vehicle, id: "v_2")
+
+      VehiclesStoreMock
+      # Subscribe
+      |> expect(:fetch, fn _ -> [vehicle_1] end)
+      # 1st and 2nd broadcast
+      |> expect(:fetch, 2, fn _ -> [vehicle_2] end)
+      # 3rd broadcast
+      |> expect(:fetch, fn _ -> [vehicle_1] end)
+
+      PubSub.subscribe_for_routes(["123"], 1)
+
+      PubSub.handle_info(:broadcast, state)
+
+      assert_receive {:new_vehicles, [^vehicle_2]}
+
+      # Doesn't re-send the same vehicle that have already been seen
+      PubSub.handle_info(:broadcast, state)
+
+      refute_receive _
+
+      # Sends new vehicles
+      PubSub.handle_info(:broadcast, state)
+
+      assert_receive {:new_vehicles, [^vehicle_1]}
+    end
+  end
+end

--- a/test/mobile_app_backend_web/channels/vehicles_for_route_channel_test.exs
+++ b/test/mobile_app_backend_web/channels/vehicles_for_route_channel_test.exs
@@ -3,12 +3,15 @@ defmodule MobileAppBackendWeb.VehiclesForRouteChannelTest do
 
   import MBTAV3API.JsonApi.Object, only: [to_full_map: 1]
   import MobileAppBackend.Factory
-  alias MBTAV3API.Stream
-  alias Test.Support.FakeStaticInstance
+  import Mox
+  import Test.Support.Helpers
+
+  alias MobileAppBackendWeb.VehiclesForRouteChannel
 
   setup do
-    {:ok, socket} = connect(MobileAppBackendWeb.UserSocket, %{})
+    reassign_env(:mobile_app_backend, MobileAppBackend.Vehicles.PubSub, VehiclesPubSubMock)
 
+    {:ok, socket} = connect(MobileAppBackendWeb.UserSocket, %{})
     %{socket: socket}
   end
 
@@ -17,7 +20,9 @@ defmodule MobileAppBackendWeb.VehiclesForRouteChannelTest do
     direction_id = 0
     vehicle = build(:vehicle, route_id: route_id, direction_id: direction_id)
 
-    start_link_supervised!({FakeStaticInstance, topic: "vehicles", data: to_full_map([vehicle])})
+    expect(VehiclesPubSubMock, :subscribe_for_routes, 1, fn ["123"], 0 ->
+      [vehicle]
+    end)
 
     {:ok, reply, _socket} =
       subscribe_and_join(socket, "vehicles:route", %{
@@ -28,44 +33,24 @@ defmodule MobileAppBackendWeb.VehiclesForRouteChannelTest do
     assert reply == to_full_map([vehicle])
   end
 
-  test "filters to requested data", %{socket: socket} do
+  test "handles new vehicles", %{socket: socket} do
     route_id = "123"
     direction_id = 0
-    good_vehicle1 = build(:vehicle, route_id: route_id, direction_id: direction_id)
-    good_vehicle2 = build(:vehicle, route_id: route_id, direction_id: direction_id)
-    bad_vehicle1 = build(:vehicle, route_id: "NOT-#{route_id}", direction_id: direction_id)
-    bad_vehicle2 = build(:vehicle, route_id: route_id, direction_id: 1 - direction_id)
-    bad_vehicle3 = build(:vehicle, route_id: "NOT-#{route_id}", direction_id: 1 - direction_id)
+    vehicle = build(:vehicle, route_id: route_id, direction_id: direction_id)
+    vehicle2 = build(:vehicle, route_id: route_id, direction_id: direction_id)
 
-    start_link_supervised!(
-      {FakeStaticInstance,
-       topic: "vehicles",
-       data: to_full_map([good_vehicle1, good_vehicle2, bad_vehicle1, bad_vehicle2, bad_vehicle3])}
+    expect(VehiclesPubSubMock, :subscribe_for_routes, 1, fn ["123"], 0 -> [] end)
+
+    {:ok, _reply, socket} =
+      subscribe_and_join(socket, "vehicles:routes:123:0")
+
+    VehiclesForRouteChannel.handle_info(
+      {:new_vehicles, [vehicle, vehicle2]},
+      socket
     )
 
-    {:ok, reply, _socket} =
-      subscribe_and_join(socket, "vehicles:route", %{
-        "route_id" => route_id,
-        "direction_id" => direction_id
-      })
-
-    assert reply == to_full_map([good_vehicle1, good_vehicle2])
-
-    Stream.PubSub.broadcast!(
-      "vehicles",
-      {:stream_data, "vehicles",
-       to_full_map([good_vehicle1, good_vehicle2, bad_vehicle1, bad_vehicle2])}
-    )
-
-    refute_push "stream_data", _
-
-    Stream.PubSub.broadcast!(
-      "vehicles",
-      {:stream_data, "vehicles", to_full_map([good_vehicle1, bad_vehicle2])}
-    )
-
-    assert_push "stream_data", data
-    assert data == to_full_map([good_vehicle1])
+    assert_push "stream_data", data_map
+    assert to_full_map([vehicle, vehicle2]) == data_map
   end
 
   test "joins multi route ok", %{socket: socket} do
@@ -75,9 +60,9 @@ defmodule MobileAppBackendWeb.VehiclesForRouteChannelTest do
     vehicle2 = build(:vehicle, route_id: Enum.at(route_ids, 1), direction_id: direction_id)
     vehicle3 = build(:vehicle, route_id: Enum.at(route_ids, 2), direction_id: direction_id)
 
-    start_link_supervised!(
-      {FakeStaticInstance, topic: "vehicles", data: to_full_map([vehicle1, vehicle2, vehicle3])}
-    )
+    expect(VehiclesPubSubMock, :subscribe_for_routes, 1, fn ["123", "456", "789"], 1 ->
+      [vehicle1, vehicle2, vehicle3]
+    end)
 
     {:ok, reply, _socket} =
       subscribe_and_join(
@@ -87,48 +72,5 @@ defmodule MobileAppBackendWeb.VehiclesForRouteChannelTest do
       )
 
     assert reply == to_full_map([vehicle1, vehicle2, vehicle3])
-  end
-
-  test "filters multi route to requested data", %{socket: socket} do
-    route_id_1 = "123"
-    route_id_2 = "456"
-    route_ids = [route_id_1, route_id_2]
-    direction_id = 0
-    good_vehicle1 = build(:vehicle, route_id: route_id_1, direction_id: direction_id)
-    good_vehicle2 = build(:vehicle, route_id: route_id_2, direction_id: direction_id)
-    bad_vehicle1 = build(:vehicle, route_id: "NOT-#{route_id_1}", direction_id: direction_id)
-    bad_vehicle2 = build(:vehicle, route_id: route_id_1, direction_id: 1 - direction_id)
-    bad_vehicle3 = build(:vehicle, route_id: "NOT-#{route_id_2}", direction_id: 1 - direction_id)
-
-    start_link_supervised!(
-      {FakeStaticInstance,
-       topic: "vehicles",
-       data: to_full_map([good_vehicle1, good_vehicle2, bad_vehicle1, bad_vehicle2, bad_vehicle3])}
-    )
-
-    {:ok, reply, _socket} =
-      subscribe_and_join(
-        socket,
-        "vehicles:routes:#{Enum.join(route_ids, ",")}:#{direction_id}",
-        %{}
-      )
-
-    assert reply == to_full_map([good_vehicle1, good_vehicle2])
-
-    Stream.PubSub.broadcast!(
-      "vehicles",
-      {:stream_data, "vehicles",
-       to_full_map([good_vehicle1, good_vehicle2, bad_vehicle1, bad_vehicle2])}
-    )
-
-    refute_push "stream_data", _
-
-    Stream.PubSub.broadcast!(
-      "vehicles",
-      {:stream_data, "vehicles", to_full_map([good_vehicle1, bad_vehicle2])}
-    )
-
-    assert_push "stream_data", data
-    assert data == to_full_map([good_vehicle1])
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -7,6 +7,7 @@ Mox.defmock(StreamSubscriberMock, for: MobileAppBackend.Predictions.StreamSubscr
 Mox.defmock(PredictionsPubSubMock, for: MobileAppBackend.Predictions.PubSub.Behaviour)
 Mox.defmock(PredictionsStoreMock, for: MBTAV3API.Store)
 Mox.defmock(VehiclesStoreMock, for: MBTAV3API.Store)
+Mox.defmock(VehiclesPubSubMock, for: MobileAppBackend.Vehicles.PubSub.Behaviour)
 
 Application.put_env(:mobile_app_backend, MobileAppBackend.HTTP, MobileAppBackend.HTTPMock)
 


### PR DESCRIPTION
### Summary

_Ticket:_ [[Name](https://app.asana.com/0/1205732265579288/1208619681848095/f)](https://app.asana.com/0/1205732265579288/1208619681848095/f)

What is this PR for?

Addresses the bottleneck found in Load Testing when many users are joining vehicles channels at once. 

`Vehicles.PubSub` is largely a copy of `Predictions.PubSub` - there is probably a good basis for extracting out common pieces, but I think it is worth saving that for a separate ticket. 

This does switch `VehicleChannel` to use PubSub as well for consistency.

Testing:
* Added & updated unit tests
* Ran locally on phone pointing to dev-orange deployiment
* Confirmed logs for new PubSub module in Splunk as expected