### PR TITLE
fix(load_testing): Set timezone to America/New_York

### DIFF
--- a/load_testing/locustfile.py
+++ b/load_testing/locustfile.py
@@ -1,10 +1,11 @@
 import datetime
 import random
-
 import requests
-from locust import HttpUser, between, events, task
 
+from locust import HttpUser, between, events, task
 from phoenix_channel import PhoenixChannel, PhoenixChannelUser
+from zoneinfo import ZoneInfo
+
 
 all_stop_ids: list[str] = list(map(lambda stop: stop["id"],requests.get(
     "https://api-v3.mbta.com/stops",
@@ -57,7 +58,7 @@ class MobileAppUser(HttpUser, PhoenixChannelUser):
         self.v3_api_headers = {"x-api-key" : self.environment.parsed_options.api_key}
         self.app_reload()
 
-    @task(1)
+  #  @task(1)
     def app_reload(self):
         self.client.get("/api/global")
         self.client.get("/api/shapes/map-friendly/rail")
@@ -72,7 +73,7 @@ class MobileAppUser(HttpUser, PhoenixChannelUser):
         self.did_initial_load = True
 
 
-    @task(10)
+  #  @task(10)
     def nearby_transit(self):
         nearby_rail_ids = random.sample(rail_stop_ids, random.randint(2,8))
         nearby_cr_ids = random.sample(cr_stop_ids, random.randint(0,14))
@@ -96,7 +97,7 @@ class MobileAppUser(HttpUser, PhoenixChannelUser):
     @task(5)
     def stop_details(self):
         self.stop_id = random.choice(all_stop_ids)
-        self.client.get(f'/api/schedules?stop_ids={self.stop_id}&date_time={datetime.datetime.now().astimezone().replace(microsecond=0).isoformat()}' , name="/api/schedules",)
+        self.client.get(f'/api/schedules?stop_ids={self.stop_id}&date_time={datetime.datetime.now().astimezone(ZoneInfo("America/New_York")).replace(microsecond=0).isoformat()}' , name="/api/schedules",)
         self.client.get(f'/api/stop/map?stop_id={self.stop_id}', name = "/api/stop/map")
        
         if (
@@ -122,7 +123,7 @@ class MobileAppUser(HttpUser, PhoenixChannelUser):
             )
             self.vehicles_channel.join()
 
-    @task(5)
+ #   @task(5)
     def trip_details(self):
         if self.stop_id is None:
             self.stop_id = random.choice(all_stop_ids)

--- a/load_testing/locustfile.py
+++ b/load_testing/locustfile.py
@@ -1,11 +1,11 @@
 import datetime
 import random
-import requests
-
-from locust import HttpUser, between, events, task
-from phoenix_channel import PhoenixChannel, PhoenixChannelUser
 from zoneinfo import ZoneInfo
 
+import requests
+from locust import HttpUser, between, events, task
+
+from phoenix_channel import PhoenixChannel, PhoenixChannelUser
 
 all_stop_ids: list[str] = list(map(lambda stop: stop["id"],requests.get(
     "https://api-v3.mbta.com/stops",

--- a/load_testing/locustfile.py
+++ b/load_testing/locustfile.py
@@ -58,7 +58,7 @@ class MobileAppUser(HttpUser, PhoenixChannelUser):
         self.v3_api_headers = {"x-api-key" : self.environment.parsed_options.api_key}
         self.app_reload()
 
-  #  @task(1)
+    @task(1)
     def app_reload(self):
         self.client.get("/api/global")
         self.client.get("/api/shapes/map-friendly/rail")
@@ -73,7 +73,7 @@ class MobileAppUser(HttpUser, PhoenixChannelUser):
         self.did_initial_load = True
 
 
-  #  @task(10)
+    @task(10)
     def nearby_transit(self):
         nearby_rail_ids = random.sample(rail_stop_ids, random.randint(2,8))
         nearby_cr_ids = random.sample(cr_stop_ids, random.randint(0,14))
@@ -123,7 +123,7 @@ class MobileAppUser(HttpUser, PhoenixChannelUser):
             )
             self.vehicles_channel.join()
 
- #   @task(5)
+    @task(5)
     def trip_details(self):
         if self.stop_id is None:
             self.stop_id = random.choice(all_stop_ids)


### PR DESCRIPTION
### Summary

What is this PR for?

No ticket - small fix to https://github.com/mbta/mobile_app_backend/pull/224.

Load tests run from Github Actions were failing because of invalid date format [here](https://github.com/mbta/mobile_app_backend/actions/runs/11520245289/job/32071109640#step:12:528). Setting the timezone to America/New_York resolves the issue, as confirmed by [this passing run](https://github.com/mbta/mobile_app_backend/actions/runs/11521337677). 