### PR TITLE
fix: return no schedules for no stops

### DIFF
--- a/lib/mobile_app_backend_web/controllers/schedule_controller.ex
+++ b/lib/mobile_app_backend_web/controllers/schedule_controller.ex
@@ -4,11 +4,15 @@ defmodule MobileAppBackendWeb.ScheduleController do
   alias MBTAV3API.Repository
 
   def schedules(conn, %{"stop_ids" => stop_ids, "date_time" => date_time}) do
-    {:ok, data} =
-      get_filter(stop_ids, date_time)
-      |> fetch_schedules()
+    if stop_ids == "" do
+      json(conn, %{schedules: [], trips: %{}})
+    else
+      {:ok, data} =
+        get_filter(stop_ids, date_time)
+        |> fetch_schedules()
 
-    json(conn, data)
+      json(conn, data)
+    end
   end
 
   def schedules(conn, %{"trip_id" => trip_id}) do

--- a/test/mobile_app_backend_web/controllers/schedule_controller_test.exs
+++ b/test/mobile_app_backend_web/controllers/schedule_controller_test.exs
@@ -93,6 +93,11 @@ defmodule MobileAppBackendWeb.ScheduleControllerTest do
            } = json_response(conn, 200)
   end
 
+  test "gracefully handles empty stops", %{conn: conn} do
+    conn = get(conn, "/api/schedules", %{stop_ids: "", date_time: "2024-10-28T15:29:06-04:00"})
+    assert json_response(conn, 200) == %{"schedules" => [], "trips" => %{}}
+  end
+
   test "finds individual trip schedules if available", %{conn: conn} do
     trip = %MBTAV3API.Trip{
       id: "61723264",


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix schedule request with no stops](https://app.asana.com/0/1205732265579288/1208436662720170/f)

Tested this locally and the error banner no longer appears when outside the service area.