### PR TITLE
fix: gracefully handle predictions v2 for empty stop list

### DIFF
--- a/lib/mobile_app_backend_web/channels/predictions_for_stops_v2_channel.ex
+++ b/lib/mobile_app_backend_web/channels/predictions_for_stops_v2_channel.ex
@@ -12,7 +12,12 @@ defmodule MobileAppBackendWeb.PredictionsForStopsV2Channel do
       )
 
     if stop_id_concat == "" do
-      {:error, %{code: :no_stop_ids}}
+      {:ok,
+       %{
+         predictions_by_stop: %{},
+         trips: %{},
+         vehicles: %{}
+       }, socket}
     else
       {time_micros, initial_data} =
         :timer.tc(fn ->

--- a/test/mobile_app_backend_web/channels/predictions_for_stops_v2_channel_test.exs
+++ b/test/mobile_app_backend_web/channels/predictions_for_stops_v2_channel_test.exs
@@ -32,10 +32,10 @@ defmodule MobileAppBackendWeb.PredictionsForStopsV2ChannelTest do
 
     response = %{
       predictions_by_stop: %{
-        "12345" => %{"p_1" => prediction_1, "p_2" => prediction_2},
-        trips: %{"trip_1" => trip_1, "trip_2" => trip_2},
-        vehicles: %{"v_1" => vehicle_1, "v_2" => vehicle_2}
-      }
+        "12345" => %{"p_1" => prediction_1, "p_2" => prediction_2}
+      },
+      trips: %{"trip_1" => trip_1, "trip_2" => trip_2},
+      vehicles: %{"v_1" => vehicle_1, "v_2" => vehicle_2}
     }
 
     expect(PredictionsPubSubMock, :subscribe_for_stops, 1, fn _ ->
@@ -48,9 +48,11 @@ defmodule MobileAppBackendWeb.PredictionsForStopsV2ChannelTest do
     assert reply == response
   end
 
-  test "error if missing stop ids in topic", %{socket: socket} do
-    {:error, %{code: :no_stop_ids}} =
-      subscribe_and_join(socket, "predictions:stops:v2:")
+  test "empty data if missing stop ids in topic", %{socket: socket} do
+    assert {:ok, data, _socket} =
+             subscribe_and_join(socket, "predictions:stops:v2:")
+
+    assert data == %{predictions_by_stop: %{}, trips: %{}, vehicles: %{}}
   end
 
   test "handles new predictions", %{socket: socket} do


### PR DESCRIPTION
### Summary

_Ticket:_ none

Fixes the frontend getting stuck loading when outside the service area.
