### PR TITLE
feat: add stop_headsign to schedules

### DIFF
--- a/lib/mbta_v3_api/schedule.ex
+++ b/lib/mbta_v3_api/schedule.ex
@@ -8,6 +8,7 @@ defmodule MBTAV3API.Schedule do
           departure_time: DateTime.t() | nil,
           drop_off_type: stop_edge_type(),
           pick_up_type: stop_edge_type(),
+          stop_headsign: String.t() | nil,
           stop_sequence: integer(),
           route_id: String.t(),
           stop_id: String.t() | nil,
@@ -26,6 +27,7 @@ defmodule MBTAV3API.Schedule do
     :departure_time,
     :drop_off_type,
     :pick_up_type,
+    :stop_headsign,
     :stop_sequence,
     :route_id,
     :stop_id,
@@ -33,7 +35,15 @@ defmodule MBTAV3API.Schedule do
   ]
 
   @impl JsonApi.Object
-  def fields, do: [:arrival_time, :departure_time, :drop_off_type, :pickup_type, :stop_sequence]
+  def fields,
+    do: [
+      :arrival_time,
+      :departure_time,
+      :drop_off_type,
+      :pickup_type,
+      :stop_headsign,
+      :stop_sequence
+    ]
 
   @impl JsonApi.Object
   def includes, do: %{route: MBTAV3API.Route, stop: MBTAV3API.Stop, trip: MBTAV3API.Trip}
@@ -46,6 +56,7 @@ defmodule MBTAV3API.Schedule do
       departure_time: Util.parse_optional_datetime!(item.attributes["departure_time"]),
       drop_off_type: parse_stop_edge_type(item.attributes["drop_off_type"]),
       pick_up_type: parse_stop_edge_type(item.attributes["pickup_type"]),
+      stop_headsign: item.attributes["stop_headsign"],
       stop_sequence: item.attributes["stop_sequence"],
       route_id: JsonApi.Object.get_one_id(item.relationships["route"]),
       stop_id: JsonApi.Object.get_one_id(item.relationships["stop"]),

--- a/test/mbta_v3_api/repository_test.exs
+++ b/test/mbta_v3_api/repository_test.exs
@@ -323,6 +323,7 @@ defmodule MBTAV3API.RepositoryTest do
                    "id" => "schedule-60565179-70159-90",
                    "pickup_type" => 0,
                    "route_id" => "Green-B",
+                   "stop_headsign" => nil,
                    "stop_id" => "70159",
                    "stop_sequence" => 90,
                    "trip_id" => "trip_1"
@@ -390,6 +391,7 @@ defmodule MBTAV3API.RepositoryTest do
                    "id" => "schedule-60565179-70159-90",
                    "pickup_type" => 0,
                    "route_id" => "Green-B",
+                   "stop_headsign" => nil,
                    "stop_id" => "70159",
                    "stop_sequence" => 90,
                    "trip_id" => "trip_1"

--- a/test/mbta_v3_api/schedule_test.exs
+++ b/test/mbta_v3_api/schedule_test.exs
@@ -13,6 +13,7 @@ defmodule MBTAV3API.ScheduleTest do
                "departure_time" => "2024-03-13T01:07:00-04:00",
                "drop_off_type" => 0,
                "pickup_type" => 0,
+               "stop_headsign" => "abc",
                "stop_sequence" => 90
              },
              relationships: %{
@@ -26,6 +27,7 @@ defmodule MBTAV3API.ScheduleTest do
              departure_time: ~B[2024-03-13 01:07:00],
              drop_off_type: :regular,
              pick_up_type: :regular,
+             stop_headsign: "abc",
              stop_sequence: 90,
              route_id: "Green-D",
              stop_id: "70159",


### PR DESCRIPTION
### Summary

_Ticket:_ [Use stop_headsign values when available](https://app.asana.com/0/1208621177839510/1208148875230005/f) (not yet refined)

May as well toss this in so we are more prepared to implement that ticket once we actually pick it up.

Found a schedule in GTFS that has a stop_headsign set and verified locally that the correct value is returned.