### PR TITLE
fix: Get diskusage_logger functional

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -13,5 +13,10 @@ config :logger, level: :info
 
 config :ehmon, :report_mf, {:ehmon, :info_report}
 
+# diskusage_logger calls disksup,
+# which by default uses df flags that aren't available on alpine's busybox.
+# this tells disksup to use different df flags
+config :os_mon, disksup_posix_only: true
+
 # Runtime production configuration, including reading
 # of environment variables, is done on config/runtime.exs.


### PR DESCRIPTION
### Summary

_Ticket:_ [backend health monitoring](https://app.asana.com/0/1205732265579288/1207910202706561/f)

This was added in other applications which use `diskusage_logger`, currently no `diskusage_report` logs are being written by the backend, and this looks like the reason why.
