### PR TITLE
feat(AlertsChannel): Subscribe to PubSub instead of reading from GenServer

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -10,6 +10,7 @@ import Config
 config :mobile_app_backend,
   generators: [timestamp_type: :utc_datetime]
 
+config :mobile_app_backend, alerts_broadcast_interval_ms: 500
 config :mobile_app_backend, predictions_broadcast_interval_ms: 5_000
 config :mobile_app_backend, vehicles_broadcast_interval_ms: 500
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -13,7 +13,7 @@ config :mobile_app_backend, start_stream_stores?: false
 
 config :mobile_app_backend, start_global_cache?: false
 
-config :mobile_app_backend, start_vehicle_pub_sub?: false
+config :mobile_app_backend, start_pub_subs?: false
 
 # Print only warnings and errors during test
 config :logger, level: :warning

--- a/lib/mbta_v3_api/store/alerts.ex
+++ b/lib/mbta_v3_api/store/alerts.ex
@@ -1,0 +1,125 @@
+defmodule MBTAV3API.Store.Alerts do
+  use GenServer
+  use MBTAV3API.Store, implementation_module: MBTAV3API.Store.Alerts.Impl
+  require Logger
+  alias MBTAV3API.Alert
+end
+
+defmodule MBTAV3API.Store.Alerts.Impl do
+  @moduledoc """
+  Store of alerts. Store is written to by a single `MBTAV3API.Stream.ConsumerToStore`
+  and can be read in parallel by other processes.
+  """
+  use GenServer
+  require Logger
+  alias MBTAV3API.JsonApi
+  alias MBTAV3API.Store
+  alias MBTAV3API.Alert
+
+  @behaviour MBTAV3API.Store
+
+  @alerts_table_name :alerts_from_stream
+
+  @spec start_link(Keyword.t()) :: GenServer.on_start()
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @impl true
+  def init(_) do
+    _table = :ets.new(@alerts_table_name, [:named_table, :public, read_concurrency: true])
+    {:ok, %{}}
+  end
+
+  @impl true
+  def fetch(fetch_keys) do
+    if Keyword.keyword?(fetch_keys) do
+      match_spec = alert_match_spec(fetch_keys)
+
+      Store.timed_fetch(
+        @alerts_table_name,
+        [{match_spec, [], [:"$1"]}],
+        "fetch_keys=#{inspect(fetch_keys)}"
+      )
+    else
+      fetch_any(fetch_keys)
+    end
+  end
+
+  defp fetch_any(fetch_keys_list) do
+    match_specs =
+      fetch_keys_list
+      |> Enum.map(&alert_match_spec(&1))
+      |> Enum.map(&{&1, [], [:"$1"]})
+
+    Store.timed_fetch(
+      @alerts_table_name,
+      match_specs,
+      "multi_fetch=true fetch_keys=#{inspect(fetch_keys_list)}"
+    )
+  end
+
+  @impl true
+  def fetch_with_associations(fetch_keys) do
+    data = fetch(fetch_keys)
+    JsonApi.Object.to_full_map(data)
+  end
+
+  defp alert_match_spec(fetch_keys) do
+    # https://www.erlang.org/doc/apps/erts/match_spec.html
+    # Match the fields specified in the fetch_keys and return the full alerts
+    # see to_record/1 for the defined order of fields
+    {
+      Keyword.get(fetch_keys, :id) || :_,
+      :"$1"
+    }
+  end
+
+  # Conver the struct to a record for ETS
+  defp to_record(
+         %Alert{
+           id: id
+         } = alert
+       ) do
+    {
+      id,
+      alert
+    }
+  end
+
+  @impl true
+  def process_upsert(_event, data) do
+    upsert_data(data)
+    :ok
+  end
+
+  @impl true
+  def process_reset(data, scope) do
+    clear_data(scope)
+    upsert_data(data)
+    :ok
+  end
+
+  @impl true
+  def process_remove(references) do
+    for reference <- references do
+      case reference do
+        %{type: "alert", id: id} -> :ets.delete(@alerts_table_name, id)
+        _ -> :ok
+      end
+    end
+
+    :ok
+  end
+
+  defp upsert_data(api_records) do
+    records = Enum.map(api_records, &to_record(&1))
+
+    :ets.insert(@alerts_table_name, records)
+  end
+
+  defp clear_data(keys) do
+    match_pattern = alert_match_spec(keys)
+    :ets.select_delete(@alerts_table_name, [{match_pattern, [], [true]}])
+  end
+end

--- a/lib/mbta_v3_api/store/alerts.ex
+++ b/lib/mbta_v3_api/store/alerts.ex
@@ -12,9 +12,10 @@ defmodule MBTAV3API.Store.Alerts.Impl do
   """
   use GenServer
   require Logger
+  alias MBTAV3API.Alert
+
   alias MBTAV3API.JsonApi
   alias MBTAV3API.Store
-  alias MBTAV3API.Alert
 
   @behaviour MBTAV3API.Store
 

--- a/lib/mbta_v3_api/stream/static_instance.ex
+++ b/lib/mbta_v3_api/stream/static_instance.ex
@@ -94,6 +94,20 @@ defmodule MBTAV3API.Stream.StaticInstance.Impl do
   end
 
   @spec args_for_topic(Phoenix.PubSub.topic()) :: Stream.Instance.opts()
+
+  defp args_for_topic("alerts:to_store") do
+    [
+      type: MBTAV3API.Alert,
+      url: "/alerts",
+      topic: "alerts:to_store",
+      consumer: %{
+        store: MBTAV3API.Store.Alerts,
+        # Single stream for all alerts
+        scope: []
+      }
+    ]
+  end
+
   defp args_for_topic("alerts") do
     [type: MBTAV3API.Alert, url: "/alerts", topic: "alerts"]
   end
@@ -130,9 +144,6 @@ defmodule MBTAV3API.Stream.StaticInstance.Impl do
     [
       type: MBTAV3API.Vehicle,
       url: "/vehicles",
-      # `:topic` is unique to a route because we stream predictions separately by route
-      # `:destination` is the same across all routes because all predictions
-      # are unified in `Store.Predictions`
       topic: "vehicles:to_store",
       consumer: %{
         store: MBTAV3API.Store.Vehicles,

--- a/lib/mbta_v3_api/stream/static_instance.ex
+++ b/lib/mbta_v3_api/stream/static_instance.ex
@@ -108,10 +108,6 @@ defmodule MBTAV3API.Stream.StaticInstance.Impl do
     ]
   end
 
-  defp args_for_topic("alerts") do
-    [type: MBTAV3API.Alert, url: "/alerts", topic: "alerts"]
-  end
-
   defp args_for_topic("predictions:route:to_store:" <> route_id) do
     [
       type: MBTAV3API.Prediction,

--- a/lib/mbta_v3_api/supervisor.ex
+++ b/lib/mbta_v3_api/supervisor.ex
@@ -12,10 +12,7 @@ defmodule MBTAV3API.Supervisor do
 
     children =
       if start_stream_stores? do
-        [MBTAV3API.Store.Alerts,
-         MBTAV3API.Store.Predictions,
-         MBTAV3API.Store.Vehicles
-        ]
+        [MBTAV3API.Store.Alerts, MBTAV3API.Store.Predictions, MBTAV3API.Store.Vehicles]
       else
         []
       end ++

--- a/lib/mbta_v3_api/supervisor.ex
+++ b/lib/mbta_v3_api/supervisor.ex
@@ -12,7 +12,10 @@ defmodule MBTAV3API.Supervisor do
 
     children =
       if start_stream_stores? do
-        [MBTAV3API.Store.Predictions, MBTAV3API.Store.Vehicles]
+        [MBTAV3API.Store.Alerts,
+         MBTAV3API.Store.Predictions,
+         MBTAV3API.Store.Vehicles
+        ]
       else
         []
       end ++

--- a/lib/mobile_app_backend/alerts/pub_sub.ex
+++ b/lib/mobile_app_backend/alerts/pub_sub.ex
@@ -1,6 +1,5 @@
 defmodule MobileAppBackend.Alerts.PubSub.Behaviour do
   alias MBTAV3API.JsonApi.Object
-  alias MBTAV3API.Alert
 
   @doc """
   Subscribe to updates for all alerts
@@ -48,7 +47,7 @@ defmodule MobileAppBackend.Alerts.PubSub do
   end
 
   @impl true
-  def subscribe() do
+  def subscribe do
     fetch_keys = []
 
     format_fn = fn data -> JsonApi.Object.to_full_map(data) end
@@ -162,7 +161,7 @@ defmodule MobileAppBackend.Alerts.PubSub do
       pids,
       &send(
         &1,
-        {:stream_data, data}
+        {:new_alerts, data}
       )
     )
   end

--- a/lib/mobile_app_backend/alerts/pub_sub.ex
+++ b/lib/mobile_app_backend/alerts/pub_sub.ex
@@ -1,0 +1,180 @@
+defmodule MobileAppBackend.Alerts.PubSub.Behaviour do
+  alias MBTAV3API.JsonApi.Object
+  alias MBTAV3API.Alert
+
+  @doc """
+  Subscribe to updates for all alerts
+  """
+  @callback subscribe() :: Object.full_map()
+end
+
+defmodule MobileAppBackend.Alerts.PubSub do
+  @moduledoc """
+  Allows channels to subscribe to alerts data and receive updates as the data changes.
+
+  This broadcasts the latest state of the world (if it has changed) to
+  registered consumers in two circumstances:
+  1. Regularly scheduled interval - configured by `:alerts_broadcast_interval_ms`
+  2. When there is a reset event of the underlying alert stream.
+  """
+  use GenServer
+  alias MBTAV3API.{JsonApi, Store, Stream}
+  alias MobileAppBackend.Alerts.PubSub
+
+  @behaviour PubSub.Behaviour
+
+  require Logger
+
+  @fetch_registry_key :fetch_registry_key
+
+  @typedoc """
+  tuple {fetch_keys, format_fn} where format_fn transforms the data returned
+  into the format expected by subscribers.
+  """
+  @type registry_value :: {Store.fetch_keys(), function()}
+
+  @type state :: %{last_dispatched_table_name: atom()}
+
+  @spec start_link(Keyword.t()) :: GenServer.on_start()
+  @spec start_link() :: :ignore | {:error, any()} | {:ok, pid()}
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+
+    GenServer.start_link(
+      __MODULE__,
+      opts,
+      name: name
+    )
+  end
+
+  @impl true
+  def subscribe() do
+    fetch_keys = []
+
+    format_fn = fn data -> JsonApi.Object.to_full_map(data) end
+
+    Registry.register(
+      MobileAppBackend.Alerts.Registry,
+      @fetch_registry_key,
+      {fetch_keys, format_fn}
+    )
+
+    fetch_keys
+    |> Store.Alerts.fetch()
+    |> format_fn.()
+  end
+
+  @impl GenServer
+  def init(opts \\ []) do
+    Stream.StaticInstance.subscribe("alerts:to_store")
+
+    broadcast_timer(50)
+
+    create_table_fn =
+      Keyword.get(opts, :create_table_fn, fn ->
+        :ets.new(:last_dispatched_alerts, [:set, :named_table])
+        {:ok, %{last_dispatched_table_name: :last_dispatched_alerts}}
+      end)
+
+    create_table_fn.()
+  end
+
+  @impl true
+  # Any time there is a reset_event, broadcast so that subscribers are immediately
+  # notified of the changes. This way, when the stream first starts,
+  # consumers don't have to wait `:alerts_broadcast_interval_ms` to receive their first message.
+  def handle_info(:reset_event, state) do
+    send(self(), :broadcast)
+    {:noreply, state, :hibernate}
+  end
+
+  def handle_info(:timed_broadcast, state) do
+    send(self(), :broadcast)
+    broadcast_timer()
+    {:noreply, state, :hibernate}
+  end
+
+  @impl GenServer
+  def handle_info(:broadcast, %{last_dispatched_table_name: last_dispatched} = state) do
+    Registry.dispatch(MobileAppBackend.Alerts.Registry, @fetch_registry_key, fn entries ->
+      Enum.group_by(
+        entries,
+        fn {_, {fetch_keys, format_fn}} -> {fetch_keys, format_fn} end,
+        fn {pid, _} -> pid end
+      )
+      |> Enum.each(fn {registry_value, pids} ->
+        broadcast_new_alerts(registry_value, pids, last_dispatched)
+      end)
+    end)
+
+    {:noreply, state, :hibernate}
+  end
+
+  defp broadcast_new_alerts(
+         {fetch_keys, format_fn} = registry_value,
+         pids,
+         last_dispatched_table_name
+       ) do
+    latest_data =
+      fetch_keys
+      |> Store.Alerts.fetch()
+      |> format_fn.()
+
+    last_dispatched_entry = :ets.lookup(last_dispatched_table_name, registry_value)
+
+    if !already_broadcast(last_dispatched_entry, latest_data) do
+      broadcast(pids, latest_data, registry_value, last_dispatched_table_name)
+    end
+  end
+
+  defp broadcast(
+         pids,
+         data,
+         {fetch_keys, _format_fn} = registry_value,
+         last_dispatched_table_name
+       ) do
+    Logger.info("#{__MODULE__} broadcasting to pids len=#{length(pids)}")
+
+    {time_micros, _result} =
+      :timer.tc(__MODULE__, :broadcast_to_pids, [
+        pids,
+        data
+      ])
+
+    Logger.info(
+      "#{__MODULE__} broadcast_to_pids fetch_keys=#{inspect(fetch_keys)} duration=#{time_micros / 1000}"
+    )
+
+    :ets.insert(last_dispatched_table_name, {registry_value, data})
+  end
+
+  defp already_broadcast([], _latest_data) do
+    # Nothing has been broadcast yet
+    false
+  end
+
+  defp already_broadcast([{_registry_key, old_data}], latest_data) do
+    old_data == latest_data
+  end
+
+  def broadcast_to_pids(pids, data) do
+    Enum.each(
+      pids,
+      &send(
+        &1,
+        {:stream_data, data}
+      )
+    )
+  end
+
+  defp broadcast_timer do
+    interval =
+      Application.get_env(:mobile_app_backend, :alerts_broadcast_interval_ms, 500)
+
+    broadcast_timer(interval)
+  end
+
+  defp broadcast_timer(interval) do
+    Process.send_after(self(), :timed_broadcast, interval)
+  end
+end

--- a/lib/mobile_app_backend/alerts/registry.ex
+++ b/lib/mobile_app_backend/alerts/registry.ex
@@ -1,0 +1,16 @@
+defmodule MobileAppBackend.Alerts.Registry do
+  def child_spec(_) do
+    Registry.child_spec(keys: :duplicate, name: __MODULE__)
+  end
+
+  @spec via_name(term()) :: GenServer.name()
+  def via_name(key), do: {:via, Registry, {__MODULE__, key}}
+
+  @spec find_pid(term()) :: pid() | nil
+  def find_pid(key) do
+    case Registry.lookup(__MODULE__, key) do
+      [{pid, _}] -> pid
+      [] -> nil
+    end
+  end
+end

--- a/lib/mobile_app_backend/application.ex
+++ b/lib/mobile_app_backend/application.ex
@@ -30,6 +30,8 @@ defmodule MobileAppBackend.Application do
         MBTAV3API.Supervisor,
         {MobileAppBackend.FinchPoolHealth, pool_name: Finch.CustomPool},
         MobileAppBackend.MapboxTokenRotator,
+        MobileAppBackend.Alerts.Registry,
+        MobileAppBackend.Alerts.PubSub,
         MobileAppBackend.Predictions.Registry,
         MobileAppBackend.Predictions.PubSub,
         MobileAppBackend.Vehicles.Registry

--- a/lib/mobile_app_backend/application.ex
+++ b/lib/mobile_app_backend/application.ex
@@ -31,13 +31,15 @@ defmodule MobileAppBackend.Application do
         {MobileAppBackend.FinchPoolHealth, pool_name: Finch.CustomPool},
         MobileAppBackend.MapboxTokenRotator,
         MobileAppBackend.Alerts.Registry,
-        MobileAppBackend.Alerts.PubSub,
         MobileAppBackend.Predictions.Registry,
-        MobileAppBackend.Predictions.PubSub,
         MobileAppBackend.Vehicles.Registry
       ] ++
-        if Application.get_env(:mobile_app_backend, :start_vehicle_pub_sub?, true) do
-          [MobileAppBackend.Vehicles.PubSub]
+        if Application.get_env(:mobile_app_backend, :start_pub_subs?, true) do
+          [
+            MobileAppBackend.Alerts.PubSub,
+            MobileAppBackend.Vehicles.PubSub,
+            MobileAppBackend.Predictions.PubSub
+          ]
         else
           []
         end ++

--- a/lib/mobile_app_backend_web/channels/alerts_channel.ex
+++ b/lib/mobile_app_backend_web/channels/alerts_channel.ex
@@ -1,12 +1,11 @@
 defmodule MobileAppBackendWeb.AlertsChannel do
+  alias MobileAppBackend.Alerts
   use MobileAppBackendWeb, :channel
 
   @impl true
   def join("alerts", _payload, socket) do
-    case MBTAV3API.Stream.StaticInstance.subscribe("alerts") do
-      {:ok, data} -> {:ok, data, socket}
-      {:error, error} -> {:error, %{code: error}}
-    end
+    alerts_data = Alerts.PubSub.subscribe()
+    {:ok, alerts_data, socket}
   end
 
   @impl true

--- a/lib/mobile_app_backend_web/channels/alerts_channel.ex
+++ b/lib/mobile_app_backend_web/channels/alerts_channel.ex
@@ -1,15 +1,21 @@
 defmodule MobileAppBackendWeb.AlertsChannel do
-  alias MobileAppBackend.Alerts
   use MobileAppBackendWeb, :channel
 
   @impl true
   def join("alerts", _payload, socket) do
-    alerts_data = Alerts.PubSub.subscribe()
-    {:ok, alerts_data, socket}
+    pubsub_module =
+      Application.get_env(
+        :mobile_app_backend,
+        MobileAppBackend.Alerts.PubSub,
+        MobileAppBackend.Alerts.PubSub
+      )
+
+    data = pubsub_module.subscribe()
+    {:ok, data, socket}
   end
 
   @impl true
-  def handle_info({:stream_data, "alerts", data}, socket) do
+  def handle_info({:new_alerts, data}, socket) do
     :ok = push(socket, "stream_data", data)
     {:noreply, socket}
   end

--- a/test/mbta_v3_api/store/alerts_test.exs
+++ b/test/mbta_v3_api/store/alerts_test.exs
@@ -1,0 +1,93 @@
+defmodule MBTAV3API.Store.AlertsTest do
+  use ExUnit.Case
+  import ExUnit.CaptureLog
+  import MobileAppBackend.Factory
+  import Test.Support.Helpers
+
+  alias MBTAV3API.{JsonApi.Reference, Store}
+
+  setup do
+    start_link_supervised!(Store.Alerts)
+    alert_1 = build(:alert, id: "a_1", effect: :shuttle)
+    alert_2 = build(:alert, id: "a_2", effect: :detour)
+
+    %{
+      alert_1: alert_1,
+      alert_2: alert_2
+    }
+  end
+
+  describe "process_events" do
+    test "process_upsert when add", %{
+      alert_1: alert_1,
+      alert_2: alert_2
+    } do
+      Store.Alerts.process_upsert(:add, [alert_1, alert_2])
+
+      assert [alert_1, alert_2] == fetch_all_sorted()
+    end
+
+    test "process_upsert when update", %{
+      alert_1: alert_1,
+      alert_2: alert_2
+    } do
+      Store.Alerts.process_upsert(:add, [alert_1, alert_2])
+
+      alert_1_updated = %{alert_1 | description: "new_description"}
+
+      Store.Alerts.process_upsert(:update, [alert_1_updated])
+
+      assert [alert_1_updated, alert_2] == fetch_all_sorted()
+    end
+
+    test "process_remove", %{
+      alert_1: alert_1,
+      alert_2: alert_2
+    } do
+      Store.Alerts.process_upsert(:add, [alert_1, alert_2])
+
+      Store.Alerts.process_remove([
+        %Reference{type: "alert", id: alert_1.id}
+      ])
+
+      assert [alert_2] == fetch_all_sorted()
+    end
+
+    test "process_reset", %{
+      alert_1: alert_1,
+      alert_2: alert_2
+    } do
+      Store.Alerts.process_upsert(:add, [alert_1, alert_2])
+
+      alert_1_updated = %{alert_1 | description: "new_description"}
+
+      Store.Alerts.process_reset([alert_1_updated], [])
+
+      assert [alert_1_updated] == fetch_all_sorted()
+    end
+  end
+
+  describe "fetch" do
+    test "by id", %{alert_1: alert_1, alert_2: alert_2} do
+      Store.Alerts.process_upsert(:add, [alert_1, alert_2])
+
+      assert [alert_1] == Store.Alerts.fetch(id: "a_1")
+    end
+
+    test "logs duration", %{alert_1: alert_1} do
+      set_log_level(:info)
+
+      Store.Alerts.process_upsert(:add, [alert_1])
+      msg = capture_log([level: :info], fn -> Store.Alerts.fetch(id: "a_1") end)
+
+      assert msg =~
+               "fetch table_name=alerts_from_stream fetch_keys=[id: \"a_1\"] duration="
+    end
+  end
+
+  defp fetch_all_sorted do
+    []
+    |> Store.Alerts.fetch()
+    |> Enum.sort_by(& &1.id)
+  end
+end

--- a/test/mobile_app_backend/alerts/pub_sub_test.exs
+++ b/test/mobile_app_backend/alerts/pub_sub_test.exs
@@ -1,0 +1,97 @@
+defmodule MobileAppBackend.Alerts.PubSubTests do
+  use ExUnit.Case
+
+  alias MBTAV3API.JsonApi.Object
+  alias MBTAV3API.{Store, Stream}
+  alias MobileAppBackend.Alerts.PubSub
+  import Mox
+  import Test.Support.Helpers
+  import MobileAppBackend.Factory
+
+  setup do
+    verify_on_exit!()
+    reassign_env(:mobile_app_backend, Store.Alerts, AlertsStoreMock)
+    :ok
+  end
+
+  # make sure mocks are globally accessible, including from the PubSub genserver
+  setup :set_mox_from_context
+
+  describe "init/1" do
+    test "subscribes to alert events" do
+      expect(AlertsStoreMock, :fetch, fn _ ->
+        []
+      end)
+
+      PubSub.init(create_table_fn: fn -> :no_op end)
+
+      Stream.PubSub.broadcast!("alerts:to_store", :reset_event)
+      assert_receive :reset_event
+    end
+  end
+
+  describe "subscribe/1" do
+    test "returns initial data" do
+      alert_1 = build(:alert, id: "a_1")
+
+      expect(AlertsStoreMock, :fetch, fn [] ->
+        [alert_1]
+      end)
+
+      assert Object.to_full_map([alert_1]) == PubSub.subscribe()
+    end
+
+    test "returns empty list when no alerts" do
+      expect(AlertsStoreMock, :fetch, fn [] ->
+        []
+      end)
+
+      assert Object.to_full_map([]) == PubSub.subscribe()
+    end
+  end
+
+  describe "handle_info" do
+    setup do
+      _dispatched_table = :ets.new(:test_last_dispatched, [:set, :named_table])
+      {:ok, %{last_dispatched_table_name: :test_last_dispatched}}
+    end
+
+    test "broadcasts on :reset_event" do
+      PubSub.handle_info(:reset_event, %{last_dispatched_table_name: :test_last_dispatched})
+      assert_receive :broadcast
+    end
+
+    test ":broadcast sends message to subscribed pid", state do
+      alert_1 = build(:alert, id: "a_1")
+      alert_2 = build(:alert, id: "a_2")
+
+      AlertsStoreMock
+      # Subscribe
+      |> expect(:fetch, fn _ -> [alert_1] end)
+      # 1st and 2nd broadcast
+      |> expect(:fetch, 2, fn _ -> [alert_2] end)
+      # 3rd broadcast
+      |> expect(:fetch, fn _ -> [alert_1] end)
+
+      PubSub.subscribe()
+
+      PubSub.handle_info(:broadcast, state)
+
+      assert_receive {:new_alerts, new_alerts}
+
+      assert Object.to_full_map([alert_2]) == new_alerts
+
+      # Doesn't re-send the same alerts that have already been seen
+      PubSub.handle_info(:broadcast, state)
+
+      refute_receive _
+
+      # Sends new alerts
+      PubSub.handle_info(:broadcast, state)
+
+      assert_receive {:new_alerts, new_alerts}
+
+      assert Object.to_full_map([alert_1]) == new_alerts
+    end
+  end
+end

--- a/test/mobile_app_backend/predictions/pub_sub_test.exs
+++ b/test/mobile_app_backend/predictions/pub_sub_test.exs
@@ -1,9 +1,9 @@
 defmodule MobileAppBackend.Predictions.PubSubTests do
   use ExUnit.Case
 
-  alias MobileAppBackend.Predictions
   alias MBTAV3API.JsonApi
   alias MBTAV3API.{Store, Stream}
+  alias MobileAppBackend.Predictions
   alias MobileAppBackend.Predictions.{PubSub, StreamSubscriber}
   import Mox
   import Test.Support.Helpers

--- a/test/mobile_app_backend/predictions/pub_sub_test.exs
+++ b/test/mobile_app_backend/predictions/pub_sub_test.exs
@@ -1,6 +1,7 @@
 defmodule MobileAppBackend.Predictions.PubSubTests do
   use ExUnit.Case
 
+  alias MobileAppBackend.Predictions
   alias MBTAV3API.JsonApi
   alias MBTAV3API.{Store, Stream}
   alias MobileAppBackend.Predictions.{PubSub, StreamSubscriber}
@@ -384,6 +385,7 @@ defmodule MobileAppBackend.Predictions.PubSubTests do
 
   describe "reset event e2e" do
     test "when a reset event is broadcast, subscribers are pushed latest predictions" do
+      {:ok, _server} = start_supervised(Predictions.PubSub)
       prediction_1 = build(:prediction, stop_id: "12345", trip_id: "trip_1")
       trip_1 = build(:trip, id: "trip_1")
 

--- a/test/mobile_app_backend_web/channels/alerts_channel_test.exs
+++ b/test/mobile_app_backend_web/channels/alerts_channel_test.exs
@@ -4,8 +4,9 @@ defmodule MobileAppBackendWeb.AlertsChannelTest do
   import Mox
   import Test.Support.Helpers
   import Test.Support.Sigils
-  alias MobileAppBackendWeb.AlertsChannel
   alias MBTAV3API.Alert
+
+  alias MobileAppBackendWeb.AlertsChannel
 
   setup do
     reassign_env(:mobile_app_backend, MobileAppBackend.Alerts.PubSub, AlertsPubSubMock)

--- a/test/mobile_app_backend_web/channels/alerts_channel_test.exs
+++ b/test/mobile_app_backend_web/channels/alerts_channel_test.exs
@@ -1,16 +1,21 @@
 defmodule MobileAppBackendWeb.AlertsChannelTest do
   use MobileAppBackendWeb.ChannelCase
   import MBTAV3API.JsonApi.Object, only: [to_full_map: 1]
+  import Mox
   import Test.Support.Helpers
   import Test.Support.Sigils
+  alias MobileAppBackendWeb.AlertsChannel
   alias MBTAV3API.Alert
-  alias Test.Support.FakeStaticInstance
 
   setup do
+    reassign_env(:mobile_app_backend, MobileAppBackend.Alerts.PubSub, AlertsPubSubMock)
+
     {:ok, socket} = connect(MobileAppBackendWeb.UserSocket, %{})
 
     %{socket: socket}
   end
+
+  setup :verify_on_exit!
 
   test "joins and subscribes correctly", %{socket: socket} do
     alert1 = %Alert{
@@ -50,14 +55,14 @@ defmodule MobileAppBackendWeb.AlertsChannelTest do
 
     data1 = to_full_map([alert1, alert2])
 
-    start_supervised_replacing!({FakeStaticInstance, topic: "alerts", data: data1})
+    expect(AlertsPubSubMock, :subscribe, 1, fn -> data1 end)
 
-    {:ok, ^data1, _socket} =
-      subscribe_and_join(socket, MobileAppBackendWeb.AlertsChannel, "alerts")
+    {:ok, ^data1, socket} =
+      subscribe_and_join(socket, "alerts")
 
     data2 = to_full_map([alert1])
 
-    MBTAV3API.Stream.PubSub.broadcast!("alerts", {:stream_data, "alerts", data2})
+    AlertsChannel.handle_info({:new_alerts, data2}, socket)
 
     assert_push("stream_data", ^data2)
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,5 @@
+Mox.defmock(AlertsStoreMock, for: MBTAV3API.Store)
+Mox.defmock(AlertsPubSubMock, for: MobileAppBackend.Alerts.PubSub.Behaviour)
 Mox.defmock(GlobalDataCacheMock, for: MobileAppBackend.GlobalDataCache)
 Mox.defmock(RepositoryMock, for: MBTAV3API.Repository)
 Mox.defmock(StaticInstanceMock, for: MBTAV3API.Stream.StaticInstance)


### PR DESCRIPTION
### Summary

_Ticket:_ [Remove alert streaming bottleneck](https://app.asana.com/0/1205732265579288/1208690341598921/f)

What is this PR for?

This PR moves from storing the state of alerts in a GenServer to storing it in an ETS so that subscribers can read in parallel. Updates are published to subscribers every 0.5 seconds.

I timeboxed doing some reduction of code duplication here using a macro, but couldn't quite get it to work and the duplication seems minimal enough to not block getting this change out over.