### PR TITLE
feat(RepositoryCache): No hashing in cache key

### DIFF
--- a/lib/mbta_v3_api/repository_cache.ex
+++ b/lib/mbta_v3_api/repository_cache.ex
@@ -14,11 +14,7 @@ defmodule MBTAV3API.RepositoryCache do
     "#{mod}|#{fun}"
   end
 
-  def generate(mod, fun, [arg]) do
-    "#{mod}|#{fun}|#{:erlang.phash2(arg)}"
-  end
-
   def generate(mod, fun, args) do
-    "#{mod}|#{fun}|#{:erlang.phash2(args)}"
+    "#{mod}|#{fun}|#{inspect(args)}"
   end
 end


### PR DESCRIPTION
### Summary

No ticket, follow up to https://github.com/mbta/mobile_app_backend/pull/247. 

What is this PR for?

@boringcactus [pointed out in slack ](https://mbta.slack.com/archives/C05QMG9GS9M/p1732562811606739?thread_ts=1732561776.880189&cid=C05QMG9GS9M) that the previous fix doesn't entirely eliminate the possibility of cache collisions. We can prevent them entirely by including the entire contents of args without hashing them. Based on splunk results for our existing queries, the longest expected value for inspect(args) is 891.