### PR TITLE
feat(RepositoryCache): No hashing in cache key

### DIFF
--- a/lib/mbta_v3_api/repository_cache.ex
+++ b/lib/mbta_v3_api/repository_cache.ex
@@ -14,11 +14,7 @@ defmodule MBTAV3API.RepositoryCache do
     "#{mod}|#{fun}"
   end
 
-  def generate(mod, fun, [arg]) do
-    "#{mod}|#{fun}|#{:erlang.phash2(arg)}"
-  end
-
   def generate(mod, fun, args) do
-    "#{mod}|#{fun}|#{:erlang.phash2(args)}"
+    "#{mod}|#{fun}|#{inspect(args)}"
   end
 end


### PR DESCRIPTION
### Summary

No ticket. Hotfix to address GL alert boundary issue at Park St [discussed in Slack](https://mbta.slack.com/archives/C03K6NLKKD1/p1733499406012269).

What is this PR for?
Removes unnecessary affected entities that are causing the app to show a Westbound suspension at Park St, when really there is only an Eastbound suspension.

Before & after: 
![image](https://github.com/user-attachments/assets/32ca95bf-1f4e-4635-9a64-9600bbb0ff8f)
![image](https://github.com/user-attachments/assets/0b9e2976-fddc-4fd5-b771-bfeb76914483)

