### PR TITLE
tmp(Alerts.Store): Override GL diversion informed entities

### DIFF
--- a/lib/mbta_v3_api/store/alerts.ex
+++ b/lib/mbta_v3_api/store/alerts.ex
@@ -76,7 +76,7 @@ defmodule MBTAV3API.Store.Alerts.Impl do
     }
   end
 
-  # Conver the struct to a record for ETS
+  # override alert 611483 behavior to temporarily address GL Park St alert boundary issue
   defp to_record(
          %Alert{
            id: "611483"
@@ -85,16 +85,10 @@ defmodule MBTAV3API.Store.Alerts.Impl do
     entities =
       alert.informed_entity
       |> Enum.reject(fn entity ->
-        entity.stop == "70196" && entity.route != "Green-B"
-      end)
-      |> Enum.reject(fn entity ->
-        entity.stop == "70197" && entity.route != "Green-C"
-      end)
-      |> Enum.reject(fn entity ->
-        entity.stop == "70198" && entity.route != "Green-D"
-      end)
-      |> Enum.reject(fn entity ->
-        entity.stop == "70199" && entity.route != "Green-E"
+        (entity.stop == "70196" && entity.route != "Green-B") ||
+          (entity.stop == "70197" && entity.route != "Green-C") ||
+          (entity.stop == "70198" && entity.route != "Green-D") ||
+          (entity.stop == "70199" && entity.route != "Green-E")
       end)
 
     {
@@ -103,6 +97,7 @@ defmodule MBTAV3API.Store.Alerts.Impl do
     }
   end
 
+  # Convert the struct to a record for ETS
   defp to_record(
          %Alert{
            id: id

--- a/lib/mbta_v3_api/store/alerts.ex
+++ b/lib/mbta_v3_api/store/alerts.ex
@@ -79,6 +79,32 @@ defmodule MBTAV3API.Store.Alerts.Impl do
   # Conver the struct to a record for ETS
   defp to_record(
          %Alert{
+           id: "611483"
+         } = alert
+       ) do
+    entities =
+      alert.informed_entity
+      |> Enum.reject(fn entity ->
+        entity.stop == "70196" && entity.route != "Green-B"
+      end)
+      |> Enum.reject(fn entity ->
+        entity.stop == "70197" && entity.route != "Green-C"
+      end)
+      |> Enum.reject(fn entity ->
+        entity.stop == "70198" && entity.route != "Green-D"
+      end)
+      |> Enum.reject(fn entity ->
+        entity.stop == "70199" && entity.route != "Green-E"
+      end)
+
+    {
+      "611483",
+      %{alert | informed_entity: entities}
+    }
+  end
+
+  defp to_record(
+         %Alert{
            id: id
          } = alert
        ) do


### PR DESCRIPTION
### Summary

No ticket. Hotfix to address GL alert boundary issue at Park St [discussed in Slack](https://mbta.slack.com/archives/C03K6NLKKD1/p1733499406012269).

What is this PR for?
Removes unnecessary affected entities that are causing the app to show a Westbound suspension at Park St, when really there is only an Eastbound suspension.

Before & after: 
![image](https://github.com/user-attachments/assets/32ca95bf-1f4e-4635-9a64-9600bbb0ff8f)
![image](https://github.com/user-attachments/assets/0b9e2976-fddc-4fd5-b771-bfeb76914483)

