### PR TITLE
fix: improve parsing robustness

### DIFF
--- a/lib/mbta_v3_api/alert.ex
+++ b/lib/mbta_v3_api/alert.ex
@@ -69,7 +69,8 @@ defmodule MBTAV3API.Alert do
       :unruly_passenger,
       :unknown_cause,
       :weather
-    ])
+    ]),
+    :unknown_cause
   )
 
   Util.declare_enum(
@@ -108,12 +109,14 @@ defmodule MBTAV3API.Alert do
       :suspension,
       :track_change,
       :unknown_effect
-    ])
+    ]),
+    :unknown_effect
   )
 
   Util.declare_enum(
     :lifecycle,
-    Util.enum_values(:uppercase_string, [:new, :ongoing, :ongoing_upcoming, :upcoming])
+    Util.enum_values(:uppercase_string, [:new, :ongoing, :ongoing_upcoming, :upcoming]),
+    Util.FailOnUnknown
   )
 
   @derive Jason.Encoder
@@ -149,8 +152,8 @@ defmodule MBTAV3API.Alert do
   def includes, do: %{}
 
   @impl JsonApi.Object
-  def serialize_filter_value(:activity, value), do: InformedEntity.serialize_activity(value)
-  def serialize_filter_value(:lifecycle, value), do: serialize_lifecycle(value)
+  def serialize_filter_value(:activity, value), do: InformedEntity.serialize_activity!(value)
+  def serialize_filter_value(:lifecycle, value), do: serialize_lifecycle!(value)
   def serialize_filter_value(_field, value), do: value
 
   @spec active?(t(), DateTime.t()) :: boolean()
@@ -165,18 +168,18 @@ defmodule MBTAV3API.Alert do
     end)
   end
 
-  @spec parse(JsonApi.Item.t()) :: t()
-  def parse(%JsonApi.Item{} = item) do
+  @spec parse!(JsonApi.Item.t()) :: t()
+  def parse!(%JsonApi.Item{} = item) do
     %__MODULE__{
       id: item.id,
-      active_period: Enum.map(item.attributes["active_period"], &ActivePeriod.parse/1),
-      cause: parse_cause(item.attributes["cause"], :unknown_cause),
+      active_period: Enum.map(item.attributes["active_period"], &ActivePeriod.parse!/1),
+      cause: parse_cause(item.attributes["cause"]),
       description: item.attributes["description"],
-      effect: parse_effect(item.attributes["effect"], :unknown_effect),
+      effect: parse_effect(item.attributes["effect"]),
       effect_name: item.attributes["effect_name"],
       header: item.attributes["header"],
-      informed_entity: Enum.map(item.attributes["informed_entity"], &InformedEntity.parse/1),
-      lifecycle: parse_lifecycle(item.attributes["lifecycle"]),
+      informed_entity: Enum.map(item.attributes["informed_entity"], &InformedEntity.parse!/1),
+      lifecycle: parse_lifecycle!(item.attributes["lifecycle"]),
       updated_at: Util.parse_datetime!(item.attributes["updated_at"])
     }
   end

--- a/lib/mbta_v3_api/alert/active_period.ex
+++ b/lib/mbta_v3_api/alert/active_period.ex
@@ -4,8 +4,8 @@ defmodule MBTAV3API.Alert.ActivePeriod do
   @derive Jason.Encoder
   defstruct [:start, :end]
 
-  @spec parse(map()) :: t()
-  def parse(data) when is_map(data) do
+  @spec parse!(map()) :: t()
+  def parse!(data) when is_map(data) do
     %__MODULE__{
       start: Util.parse_datetime!(data["start"]),
       end: Util.parse_optional_datetime!(data["end"])

--- a/lib/mbta_v3_api/alert/informed_entity.ex
+++ b/lib/mbta_v3_api/alert/informed_entity.ex
@@ -25,22 +25,23 @@ defmodule MBTAV3API.Alert.InformedEntity do
         :using_escalator,
         :using_wheelchair
       ]
-    )
+    ),
+    nil
   )
 
   @derive Jason.Encoder
   defstruct [:activities, :direction_id, :facility, :route, :route_type, :stop, :trip]
 
-  @spec parse(map()) :: t()
-  def parse(data) when is_map(data) do
+  @spec parse!(map()) :: t()
+  def parse!(data) when is_map(data) do
     %__MODULE__{
-      activities: data["activities"] |> Enum.map(&parse_activity/1),
+      activities: data["activities"] |> Enum.map(&parse_activity/1) |> Enum.reject(&is_nil/1),
       direction_id: data["direction_id"],
       facility: data["facility"],
       route: data["route"],
       route_type:
         if route_type = data["route_type"] do
-          MBTAV3API.Route.parse_type(route_type)
+          MBTAV3API.Route.parse_type!(route_type)
         end,
       stop: data["stop"],
       trip: data["trip"]

--- a/lib/mbta_v3_api/json_api/response.ex
+++ b/lib/mbta_v3_api/json_api/response.ex
@@ -8,13 +8,14 @@ defmodule MBTAV3API.JsonApi.Response do
   defstruct [:data, included: JsonApi.Object.to_full_map([])]
 
   @doc """
-  Parses everything in a `t:JsonApi.t/0`.
+  Parses everything in a `t:JsonApi.t/0`, discarding objects which cannot be parsed.
   """
   @spec parse(JsonApi.t()) :: t(JsonApi.Object.t())
   def parse(%JsonApi{data: data, included: included}) do
     %__MODULE__{
-      data: Enum.map(data, &JsonApi.Object.parse(&1, included)),
-      included: included |> Enum.map(&JsonApi.Object.parse(&1, included)) |> to_full_map()
+      data: JsonApi.Object.parse_all_discarding_failures(data, included),
+      included:
+        included |> JsonApi.Object.parse_all_discarding_failures(included) |> to_full_map()
     }
   end
 end

--- a/lib/mbta_v3_api/line.ex
+++ b/lib/mbta_v3_api/line.ex
@@ -34,8 +34,8 @@ defmodule MBTAV3API.Line do
   @impl JsonApi.Object
   def includes, do: %{}
 
-  @spec parse(JsonApi.Item.t()) :: t()
-  def parse(%JsonApi.Item{} = item) do
+  @spec parse!(JsonApi.Item.t()) :: t()
+  def parse!(%JsonApi.Item{} = item) do
     %__MODULE__{
       id: item.id,
       color: item.attributes["color"],

--- a/lib/mbta_v3_api/prediction.ex
+++ b/lib/mbta_v3_api/prediction.ex
@@ -21,7 +21,8 @@ defmodule MBTAV3API.Prediction do
     Util.enum_values(
       :uppercase_string,
       [:added, :cancelled, :no_data, :skipped, :unscheduled]
-    ) ++ [scheduled: nil]
+    ) ++ [scheduled: nil],
+    :scheduled
   )
 
   @derive Jason.Encoder
@@ -61,8 +62,8 @@ defmodule MBTAV3API.Prediction do
     }
   end
 
-  @spec parse(JsonApi.Item.t()) :: t()
-  def parse(%JsonApi.Item{} = item) do
+  @spec parse!(JsonApi.Item.t()) :: t()
+  def parse!(%JsonApi.Item{} = item) do
     %__MODULE__{
       id: item.id,
       arrival_time: Util.parse_optional_datetime!(item.attributes["arrival_time"]),

--- a/lib/mbta_v3_api/route_pattern.ex
+++ b/lib/mbta_v3_api/route_pattern.ex
@@ -26,7 +26,8 @@ defmodule MBTAV3API.RoutePattern do
   """
   Util.declare_enum(
     :typicality,
-    Util.enum_values(:index, [nil, :typical, :deviation, :atypical, :diversion, :canonical_only])
+    Util.enum_values(:index, [nil, :typical, :deviation, :atypical, :diversion, :canonical_only]),
+    nil
   )
 
   @derive Jason.Encoder
@@ -47,8 +48,8 @@ defmodule MBTAV3API.RoutePattern do
   @impl JsonApi.Object
   def includes, do: %{representative_trip: MBTAV3API.Trip, route: MBTAV3API.Route}
 
-  @spec parse(JsonApi.Item.t()) :: t()
-  def parse(%JsonApi.Item{} = item) do
+  @spec parse!(JsonApi.Item.t()) :: t()
+  def parse!(%JsonApi.Item{} = item) do
     %__MODULE__{
       id: item.id,
       canonical: item.attributes["canonical"],
@@ -111,7 +112,7 @@ defmodule MBTAV3API.RoutePattern do
     route_patterns_asc =
       route_patterns
       |> Enum.reject(&is_nil(&1.typicality))
-      |> Enum.sort_by(&serialize_typicality(&1.typicality))
+      |> Enum.sort_by(&serialize_typicality!(&1.typicality))
 
     [%{typicality: lowest_typicality} | _rest] = route_patterns_asc
 

--- a/lib/mbta_v3_api/schedule.ex
+++ b/lib/mbta_v3_api/schedule.ex
@@ -17,7 +17,8 @@ defmodule MBTAV3API.Schedule do
 
   Util.declare_enum(
     :stop_edge_type,
-    Util.enum_values(:index, [:regular, :unavailable, :call_agency, :coordinate_with_driver])
+    Util.enum_values(:index, [:regular, :unavailable, :call_agency, :coordinate_with_driver]),
+    Util.FailOnUnknown
   )
 
   @derive Jason.Encoder
@@ -48,14 +49,14 @@ defmodule MBTAV3API.Schedule do
   @impl JsonApi.Object
   def includes, do: %{route: MBTAV3API.Route, stop: MBTAV3API.Stop, trip: MBTAV3API.Trip}
 
-  @spec parse(JsonApi.Item.t()) :: t()
-  def parse(%JsonApi.Item{} = item) do
+  @spec parse!(JsonApi.Item.t()) :: t()
+  def parse!(%JsonApi.Item{} = item) do
     %__MODULE__{
       id: item.id,
       arrival_time: Util.parse_optional_datetime!(item.attributes["arrival_time"]),
       departure_time: Util.parse_optional_datetime!(item.attributes["departure_time"]),
-      drop_off_type: parse_stop_edge_type(item.attributes["drop_off_type"]),
-      pick_up_type: parse_stop_edge_type(item.attributes["pickup_type"]),
+      drop_off_type: parse_stop_edge_type!(item.attributes["drop_off_type"]),
+      pick_up_type: parse_stop_edge_type!(item.attributes["pickup_type"]),
       stop_headsign: item.attributes["stop_headsign"],
       stop_sequence: item.attributes["stop_sequence"],
       route_id: JsonApi.Object.get_one_id(item.relationships["route"]),

--- a/lib/mbta_v3_api/shape.ex
+++ b/lib/mbta_v3_api/shape.ex
@@ -13,8 +13,8 @@ defmodule MBTAV3API.Shape do
 
   def includes, do: %{}
 
-  @spec parse(JsonApi.Item.t()) :: t()
-  def parse(%JsonApi.Item{} = item) do
+  @spec parse!(JsonApi.Item.t()) :: t()
+  def parse!(%JsonApi.Item{} = item) do
     %__MODULE__{
       id: item.id,
       polyline: item.attributes["polyline"]

--- a/lib/mbta_v3_api/stop.ex
+++ b/lib/mbta_v3_api/stop.ex
@@ -20,12 +20,14 @@ defmodule MBTAV3API.Stop do
 
   Util.declare_enum(
     :location_type,
-    Util.enum_values(:index, [:stop, :station, :entrance_exit, :generic_node, :boarding_area])
+    Util.enum_values(:index, [:stop, :station, :entrance_exit, :generic_node, :boarding_area]),
+    Util.FailOnUnknown
   )
 
   Util.declare_enum(
     :wheelchair_boarding,
-    Util.enum_values(:index, [nil, :accessible, :inaccessible])
+    Util.enum_values(:index, [nil, :accessible, :inaccessible]),
+    nil
   )
 
   defstruct [
@@ -121,17 +123,17 @@ defmodule MBTAV3API.Stop do
 
   @impl JsonApi.Object
   def serialize_filter_value(:route_type, route_type) do
-    MBTAV3API.Route.serialize_type(route_type)
+    MBTAV3API.Route.serialize_type!(route_type)
   end
 
   def serialize_filter_value(:location_type, location_type) do
-    serialize_location_type(location_type)
+    serialize_location_type!(location_type)
   end
 
   def serialize_filter_value(_field, value), do: value
 
-  @spec parse(JsonApi.Item.t()) :: t()
-  def parse(%JsonApi.Item{} = item) do
+  @spec parse!(JsonApi.Item.t()) :: t()
+  def parse!(%JsonApi.Item{} = item) do
     %__MODULE__{
       id: item.id,
       latitude: item.attributes["latitude"],
@@ -139,11 +141,11 @@ defmodule MBTAV3API.Stop do
       name: item.attributes["name"],
       location_type:
         if location_type = item.attributes["location_type"] do
-          parse_location_type(location_type)
+          parse_location_type!(location_type)
         end,
       vehicle_type:
         if vehicle_type = item.attributes["vehicle_type"] do
-          MBTAV3API.Route.parse_type(vehicle_type)
+          MBTAV3API.Route.parse_type!(vehicle_type)
         end,
       description: item.attributes["description"],
       platform_name: item.attributes["platform_name"],

--- a/lib/mbta_v3_api/stream/state.ex
+++ b/lib/mbta_v3_api/stream/state.ex
@@ -23,7 +23,7 @@ defmodule MBTAV3API.Stream.State do
     %ServerSentEventStage.Event{event: event, data: data} = event
 
     %JsonApi{data: raw_data} = JsonApi.parse(data)
-    parsed_data = Enum.map(raw_data, &JsonApi.Object.parse/1)
+    parsed_data = JsonApi.Object.parse_all_discarding_failures(raw_data)
 
     {event_type(event), parsed_data}
   end

--- a/lib/mbta_v3_api/trip.ex
+++ b/lib/mbta_v3_api/trip.ex
@@ -25,8 +25,8 @@ defmodule MBTAV3API.Trip do
     }
   end
 
-  @spec parse(JsonApi.Item.t()) :: t()
-  def parse(%JsonApi.Item{} = item) do
+  @spec parse!(JsonApi.Item.t()) :: t()
+  def parse!(%JsonApi.Item{} = item) do
     %__MODULE__{
       id: item.id,
       direction_id: item.attributes["direction_id"],

--- a/lib/mbta_v3_api/vehicle.ex
+++ b/lib/mbta_v3_api/vehicle.ex
@@ -18,7 +18,8 @@ defmodule MBTAV3API.Vehicle do
         }
   Util.declare_enum(
     :current_status,
-    Util.enum_values(:uppercase_string, [:incoming_at, :stopped_at, :in_transit_to])
+    Util.enum_values(:uppercase_string, [:incoming_at, :stopped_at, :in_transit_to]),
+    Util.FailOnUnknown
   )
 
   Util.declare_enum(
@@ -31,7 +32,8 @@ defmodule MBTAV3API.Vehicle do
       :full,
       :not_accepting_passengers,
       :no_data_available
-    ])
+    ]),
+    :no_data_available
   )
 
   @derive Jason.Encoder
@@ -67,12 +69,12 @@ defmodule MBTAV3API.Vehicle do
   @impl JsonApi.Object
   def includes, do: %{route: MBTAV3API.Route, stop: MBTAV3API.Stop, trip: MBTAV3API.Trip}
 
-  @spec parse(JsonApi.Item.t()) :: t()
-  def parse(%JsonApi.Item{} = item) do
+  @spec parse!(JsonApi.Item.t()) :: t()
+  def parse!(%JsonApi.Item{} = item) do
     %__MODULE__{
       id: item.id,
       bearing: item.attributes["bearing"],
-      current_status: parse_current_status(item.attributes["current_status"]),
+      current_status: parse_current_status!(item.attributes["current_status"]),
       current_stop_sequence: item.attributes["current_stop_sequence"],
       direction_id: item.attributes["direction_id"],
       latitude: item.attributes["latitude"],

--- a/lib/mobile_app_backend/search/algolia/route_result.ex
+++ b/lib/mobile_app_backend/search/algolia/route_result.ex
@@ -22,7 +22,7 @@ defmodule MobileAppBackend.Search.Algolia.RouteResult do
       id: result_response["route"]["id"],
       name: result_response["route"]["name"],
       long_name: result_response["route"]["long_name"],
-      route_type: MBTAV3API.Route.parse_type(result_response["route"]["type"]),
+      route_type: MBTAV3API.Route.parse_type!(result_response["route"]["type"]),
       rank: result_response["rank"]
     }
   end

--- a/lib/mobile_app_backend/search/algolia/stop_result.ex
+++ b/lib/mobile_app_backend/search/algolia/stop_result.ex
@@ -28,7 +28,7 @@ defmodule MobileAppBackend.Search.Algolia.StopResult do
       routes:
         Enum.map(
           result_response["routes"],
-          &%{type: MBTAV3API.Route.parse_type(&1["type"]), icon: &1["icon"]}
+          &%{type: MBTAV3API.Route.parse_type!(&1["type"]), icon: &1["icon"]}
         )
     }
   end

--- a/test/mbta_v3_api/alert_test.exs
+++ b/test/mbta_v3_api/alert_test.exs
@@ -74,8 +74,8 @@ defmodule MBTAV3API.AlertTest do
     end
   end
 
-  test "parse/1" do
-    assert Alert.parse(%JsonApi.Item{
+  test "parse!/1" do
+    assert Alert.parse!(%JsonApi.Item{
              id: "553407",
              attributes: %{
                "active_period" => [
@@ -113,7 +113,7 @@ defmodule MBTAV3API.AlertTest do
   end
 
   test "unexpected enum values fall back" do
-    assert Alert.parse(%JsonApi.Item{
+    assert Alert.parse!(%JsonApi.Item{
              id: "553407",
              attributes: %{
                "active_period" => [

--- a/test/mbta_v3_api/json_api/object_test.exs
+++ b/test/mbta_v3_api/json_api/object_test.exs
@@ -47,14 +47,14 @@ defmodule MBTAV3API.JsonApi.ObjectTest do
     end
   end
 
-  describe "parse/1" do
+  describe "parse!/1" do
     test "dispatches by type" do
-      assert %MBTAV3API.Prediction{} = parse(%JsonApi.Item{type: "prediction"})
-      assert %MBTAV3API.Stop{} = parse(%JsonApi.Item{type: "stop"})
+      assert %MBTAV3API.Prediction{} = parse!(%JsonApi.Item{type: "prediction"})
+      assert %MBTAV3API.Stop{} = parse!(%JsonApi.Item{type: "stop"})
     end
 
     test "preserves reference" do
-      assert %JsonApi.Reference{} = parse(%JsonApi.Reference{})
+      assert %JsonApi.Reference{} = parse!(%JsonApi.Reference{})
     end
   end
 

--- a/test/mbta_v3_api/prediction_test.exs
+++ b/test/mbta_v3_api/prediction_test.exs
@@ -5,8 +5,8 @@ defmodule MBTAV3API.PredictionTest do
   alias MBTAV3API.JsonApi
   alias MBTAV3API.Prediction
 
-  test "parse/1" do
-    assert Prediction.parse(%JsonApi.Item{
+  test "parse!/1" do
+    assert Prediction.parse!(%JsonApi.Item{
              id: "prediction-ADDED-1591587107-70237-440",
              attributes: %{
                "arrival_time" => "2024-01-24T17:08:51-05:00",

--- a/test/mbta_v3_api/route_pattern_test.exs
+++ b/test/mbta_v3_api/route_pattern_test.exs
@@ -5,8 +5,8 @@ defmodule MBTAV3API.RoutePatternTest do
   alias MBTAV3API.RoutePattern
   import MobileAppBackend.Factory
 
-  test "parse/1" do
-    assert RoutePattern.parse(%JsonApi.Item{
+  test "parse!/1" do
+    assert RoutePattern.parse!(%JsonApi.Item{
              id: "Green-C-832-1",
              attributes: %{
                "direction_id" => 1,

--- a/test/mbta_v3_api/route_test.exs
+++ b/test/mbta_v3_api/route_test.exs
@@ -4,9 +4,9 @@ defmodule MBTAV3API.RouteTest do
   alias MBTAV3API.JsonApi
   alias MBTAV3API.Route
 
-  describe "parse/1" do
+  describe "parse!/1" do
     test "parse route only" do
-      assert Route.parse(%JsonApi.Item{
+      assert Route.parse!(%JsonApi.Item{
                id: "Green-C",
                attributes: %{
                  "color" => "00843D",
@@ -48,7 +48,7 @@ defmodule MBTAV3API.RouteTest do
                type: :bus,
                line_id: "line-Orange"
              } ==
-               Route.parse(
+               Route.parse!(
                  %JsonApi.Item{
                    id: "orange-shuttle",
                    attributes: %{

--- a/test/mbta_v3_api/schedule_test.exs
+++ b/test/mbta_v3_api/schedule_test.exs
@@ -4,8 +4,8 @@ defmodule MBTAV3API.ScheduleTest do
   alias MBTAV3API.JsonApi
   alias MBTAV3API.Schedule
 
-  test "parse/1" do
-    assert Schedule.parse(%JsonApi.Item{
+  test "parse!/1" do
+    assert Schedule.parse!(%JsonApi.Item{
              type: "schedule",
              id: "schedule-60565179-70159-90",
              attributes: %{

--- a/test/mbta_v3_api/stop_test.exs
+++ b/test/mbta_v3_api/stop_test.exs
@@ -5,8 +5,8 @@ defmodule MBTAV3API.StopTest do
   alias MBTAV3API.Stop
   import MobileAppBackend.Factory
 
-  test "parse/1" do
-    assert Stop.parse(%JsonApi.Item{
+  test "parse!/1" do
+    assert Stop.parse!(%JsonApi.Item{
              type: "stop",
              id: "70158",
              attributes: %{
@@ -27,7 +27,7 @@ defmodule MBTAV3API.StopTest do
              parent_station_id: "place-boyls"
            }
 
-    assert Stop.parse(%JsonApi.Item{
+    assert Stop.parse!(%JsonApi.Item{
              type: "stop",
              id: "70158",
              attributes: %{

--- a/test/mbta_v3_api/stream/consumer_test.exs
+++ b/test/mbta_v3_api/stream/consumer_test.exs
@@ -13,7 +13,7 @@ defmodule MBTAV3API.Stream.ConsumerTest do
           event: "reset",
           data: """
           [
-            {"attributes":{},"id":"Green-B","type":"route"},
+            {"attributes":{"type":0},"id":"Green-B","type":"route"},
             {"attributes":{"direction_id":0,"name":"Government Center - Boston College","sort_order":100320000,"typicality":1},"id":"Green-B-812-0","links":{"self":"/route_patterns/Green-B-812-0"},"relationships":{"representative_trip":{"data":{"id":"canonical-Green-B-C1-0","type":"trip"}},"route":{"data":{"id":"Green-B","type":"route"}}},"type":"route_pattern"},
             {"attributes":{"direction_id":0,"name":"Government Center - Cleveland Circle","sort_order":100330000,"typicality":1},"id":"Green-C-832-0","links":{"self":"/route_patterns/Green-C-832-0"},"relationships":{"representative_trip":{"data":{"id":"canonical-Green-C-C1-0","type":"trip"}},"route":{"data":{"id":"Green-C","type":"route"}}},"type":"route_pattern"}
           ]
@@ -42,7 +42,7 @@ defmodule MBTAV3API.Stream.ConsumerTest do
 
     def expected_data do
       JsonApi.Object.to_full_map([
-        %Route{id: "Green-B"},
+        %Route{id: "Green-B", type: :light_rail},
         %RoutePattern{
           id: "Green-B-812-1",
           direction_id: 1,

--- a/test/mbta_v3_api/stream/consumer_to_store_test.exs
+++ b/test/mbta_v3_api/stream/consumer_to_store_test.exs
@@ -14,7 +14,7 @@ defmodule Stream.ConsumerToStoreTest do
         event: "reset",
         data: """
         [
-          {"attributes":{},"id":"Green-B","type":"route"},
+          {"attributes":{"type":0},"id":"Green-B","type":"route"},
           {"attributes":{"direction_id":0,"name":"Government Center - Boston College","sort_order":100320000,"typicality":1},"id":"Green-B-812-0","links":{"self":"/route_patterns/Green-B-812-0"},"relationships":{"representative_trip":{"data":{"id":"canonical-Green-B-C1-0","type":"trip"}},"route":{"data":{"id":"Green-B","type":"route"}}},"type":"route_pattern"},
           {"attributes":{"direction_id":0,"name":"Government Center - Cleveland Circle","sort_order":100330000,"typicality":1},"id":"Green-C-832-0","links":{"self":"/route_patterns/Green-C-832-0"},"relationships":{"representative_trip":{"data":{"id":"canonical-Green-C-C1-0","type":"trip"}},"route":{"data":{"id":"Green-C","type":"route"}}},"type":"route_pattern"}
         ]

--- a/test/mbta_v3_api/stream/instance_test.exs
+++ b/test/mbta_v3_api/stream/instance_test.exs
@@ -27,11 +27,11 @@ defmodule MBTAV3API.Stream.InstanceTest do
     SSEStub.push_events(sse_stage, [
       %ServerSentEventStage.Event{
         event: "add",
-        data: ~s({"attributes":{},"id":"1723","type":"route"})
+        data: ~s({"attributes":{"type":3},"id":"1723","type":"route"})
       }
     ])
 
-    assert_receive {:stream_data, %{routes: %{"1723" => %Route{id: "1723"}}}}
+    assert_receive {:stream_data, %{routes: %{"1723" => %Route{id: "1723", type: :bus}}}}
   end
 
   test "logs health" do

--- a/test/mbta_v3_api/stream/state_test.exs
+++ b/test/mbta_v3_api/stream/state_test.exs
@@ -25,6 +25,13 @@ defmodule MBTAV3API.Stream.StateTest do
      }}
   end
 
+  def bad_add_event do
+    %Event{
+      event: "add",
+      data: ~s({"attributes":{"lifecycle":"RETROACTIVE"},"id":"9","type":"alert"})
+    }
+  end
+
   def update_event do
     {
       %Event{
@@ -87,6 +94,12 @@ defmodule MBTAV3API.Stream.StateTest do
       {event, parsed} = reset_event()
 
       assert {:reset, [parsed]} == State.parse_event(event)
+    end
+
+    test "discards invalid" do
+      event = bad_add_event()
+
+      assert {:add, []} == State.parse_event(event)
     end
   end
 

--- a/test/mbta_v3_api/trip_test.exs
+++ b/test/mbta_v3_api/trip_test.exs
@@ -4,7 +4,7 @@ defmodule MBTAV3API.TripTest do
   alias MBTAV3API.JsonApi
   alias MBTAV3API.Trip
 
-  test "parse/1" do
+  test "parse!/1" do
     assert %Trip{
              id: "60451275",
              direction_id: 0,
@@ -12,7 +12,7 @@ defmodule MBTAV3API.TripTest do
              route_pattern_id: "24-2-0",
              stop_ids: ["334", "536"]
            } ==
-             Trip.parse(%JsonApi.Item{
+             Trip.parse!(%JsonApi.Item{
                id: "60451275",
                attributes: %{
                  "direction_id" => 0,

--- a/test/mbta_v3_api/vehicle_test.exs
+++ b/test/mbta_v3_api/vehicle_test.exs
@@ -5,7 +5,7 @@ defmodule MBTAV3API.VehicleTest do
   alias MBTAV3API.JsonApi
   alias MBTAV3API.Vehicle
 
-  test "parse/1" do
+  test "parse!/1" do
     assert %Vehicle{
              id: "y1886",
              bearing: 315,
@@ -20,7 +20,7 @@ defmodule MBTAV3API.VehicleTest do
              trip_id: "61391720",
              updated_at: ~B[2024-01-24 17:08:51]
            } ==
-             Vehicle.parse(%JsonApi.Item{
+             Vehicle.parse!(%JsonApi.Item{
                type: "vehicle",
                id: "y1886",
                attributes: %{
@@ -41,7 +41,7 @@ defmodule MBTAV3API.VehicleTest do
              })
   end
 
-  test "parse/1 with nil occupancy status" do
+  test "parse!/1 with nil occupancy status" do
     assert %Vehicle{
              id: "y1886",
              bearing: 315,
@@ -56,7 +56,7 @@ defmodule MBTAV3API.VehicleTest do
              trip_id: "61391720",
              updated_at: ~B[2024-01-24 17:08:51]
            } ==
-             Vehicle.parse(%JsonApi.Item{
+             Vehicle.parse!(%JsonApi.Item{
                type: "vehicle",
                id: "y1886",
                attributes: %{

--- a/test/open_trip_planner_client_test.exs
+++ b/test/open_trip_planner_client_test.exs
@@ -1,8 +1,9 @@
 defmodule OpenTripPlannerClientTest do
   use HttpStub.Case, async: true
 
-  @tag :skip
   describe "nearby/3" do
+    @describetag :skip
+
     test "handles parent stops" do
       assert {:ok,
               [


### PR DESCRIPTION
### Summary

_Ticket:_ [Investigate: Missing alerts in prod iOS app](https://app.asana.com/0/1205732265579288/1209298415313011)

Sometimes I miss working in languages with real error handling.

I may be doing too much at once here.

Logical changes:
1. Give some enums inherent default values (subsumes #271 but adds recording observed anomalies in Sentry)
2. Use `!` in parse and serialize functions to indicate crashing on error
3. Discard and log in Sentry unparseable values in static and stream responses
4. Make route types non-nullable