### PR TITLE
Revert "hotfix: dummy mapbox token rotator (#278)"

### DIFF
--- a/lib/mobile_app_backend/mapbox_token_rotator.ex
+++ b/lib/mobile_app_backend/mapbox_token_rotator.ex
@@ -25,20 +25,23 @@ defmodule MobileAppBackend.MapboxTokenRotator do
 
   @impl GenServer
   def init(_) do
-    # config = Application.get_env(:mobile_app_backend, MobileAppBackend.ClientConfig)
+    config = Application.get_env(:mobile_app_backend, MobileAppBackend.ClientConfig)
 
-    # state =
-    #   case Keyword.fetch(config, :mapbox_primary_token) do
-    #    {:ok, primary_token} ->
-    #      Process.send_after(self(), :rotate_token, 0)
+    state =
+      case Keyword.fetch(config, :mapbox_primary_token) do
+        {:ok, primary_token} ->
+          Process.send_after(self(), :rotate_token, 0)
 
-    state = %State{
-      primary_token: "fake_token",
-      username: "fake_username",
-      current_public_token: "fake_public_token"
-    }
+          %State{
+            primary_token: primary_token,
+            username: config[:mapbox_username],
+            expire_ms: config[:token_expiration],
+            rotate_ms: config[:token_renewal]
+          }
 
-    # end
+        _ ->
+          %State{current_public_token: config[:mapbox_public_token]}
+      end
 
     {:ok, state}
   end
@@ -64,7 +67,7 @@ defmodule MobileAppBackend.MapboxTokenRotator do
       )
       |> MobileAppBackend.HTTP.request()
 
-    #  Process.send_after(self(), :rotate_token, state.rotate_ms)
+    Process.send_after(self(), :rotate_token, state.rotate_ms)
 
     {:noreply, %State{state | current_public_token: public_token}}
   end

--- a/test/mobile_app_backend/mapbox_token_rotator_test.exs
+++ b/test/mobile_app_backend/mapbox_token_rotator_test.exs
@@ -6,137 +6,137 @@ defmodule MobileAppBackend.MapboxTokenRotatorTest do
 
   setup :verify_on_exit!
 
-  # test "uses fixed public token if no primary token available" do
-  #   fake_public_token = "pk.fake"
+  test "uses fixed public token if no primary token available" do
+    fake_public_token = "pk.fake"
 
-  #   reassign_env(:mobile_app_backend, MobileAppBackend.ClientConfig,
-  #     mapbox_public_token: fake_public_token
-  #   )
+    reassign_env(:mobile_app_backend, MobileAppBackend.ClientConfig,
+      mapbox_public_token: fake_public_token
+    )
 
-  #   rotator = start_link_supervised!({MapboxTokenRotator, name: nil})
+    rotator = start_link_supervised!({MapboxTokenRotator, name: nil})
 
-  #   assert MapboxTokenRotator.get_public_token(rotator) == fake_public_token
-  # end
+    assert MapboxTokenRotator.get_public_token(rotator) == fake_public_token
+  end
 
-  # test "creates temporary token if primary token available" do
-  #   fake_primary_token = "sk.fake"
-  #   fake_username = "fakeusername"
-  #   fake_temporary_token = "tk.fake"
+  test "creates temporary token if primary token available" do
+    fake_primary_token = "sk.fake"
+    fake_username = "fakeusername"
+    fake_temporary_token = "tk.fake"
 
-  #   expiration_interval = :timer.seconds(10)
+    expiration_interval = :timer.seconds(10)
 
-  #   approximate_expiration_time =
-  #     DateTime.utc_now()
-  #     |> DateTime.add(expiration_interval, :millisecond)
+    approximate_expiration_time =
+      DateTime.utc_now()
+      |> DateTime.add(expiration_interval, :millisecond)
 
-  #   test_pid = self()
+    test_pid = self()
 
-  #   expect(
-  #     MobileAppBackend.HTTPMock,
-  #     :request,
-  #     fn %Req.Request{
-  #          method: :post,
-  #          url: %URI{path: "/tokens/v2/fakeusername"},
-  #          options: %{
-  #            params: %{
-  #              access_token: ^fake_primary_token
-  #            },
-  #            json: %{expires: actual_expiration_time, scopes: ["styles:read", "fonts:read"]}
-  #          }
-  #        } = request ->
-  #       {:ok, actual_expiration_time, _} = actual_expiration_time |> DateTime.from_iso8601()
+    expect(
+      MobileAppBackend.HTTPMock,
+      :request,
+      fn %Req.Request{
+           method: :post,
+           url: %URI{path: "/tokens/v2/fakeusername"},
+           options: %{
+             params: %{
+               access_token: ^fake_primary_token
+             },
+             json: %{expires: actual_expiration_time, scopes: ["styles:read", "fonts:read"]}
+           }
+         } = request ->
+        {:ok, actual_expiration_time, _} = actual_expiration_time |> DateTime.from_iso8601()
 
-  #       expiration_time_drift =
-  #         DateTime.diff(actual_expiration_time, approximate_expiration_time, :millisecond)
+        expiration_time_drift =
+          DateTime.diff(actual_expiration_time, approximate_expiration_time, :millisecond)
 
-  #       assert expiration_time_drift in 0..100
+        assert expiration_time_drift in 0..100
 
-  #       send(test_pid, :request_made)
+        send(test_pid, :request_made)
 
-  #       # use Req.request to still run the JSON decoding step
-  #       Req.request(request,
-  #         adapter: fn request ->
-  #           {request,
-  #            Req.Response.new(status: 201) |> Req.Response.json(%{token: fake_temporary_token})}
-  #         end
-  #       )
-  #     end
-  #   )
+        # use Req.request to still run the JSON decoding step
+        Req.request(request,
+          adapter: fn request ->
+            {request,
+             Req.Response.new(status: 201) |> Req.Response.json(%{token: fake_temporary_token})}
+          end
+        )
+      end
+    )
 
-  #   reassign_env(:mobile_app_backend, MobileAppBackend.ClientConfig,
-  #     mapbox_primary_token: fake_primary_token,
-  #     mapbox_username: fake_username,
-  #     token_expiration: expiration_interval,
-  #     token_renewal: :timer.minutes(3)
-  #   )
+    reassign_env(:mobile_app_backend, MobileAppBackend.ClientConfig,
+      mapbox_primary_token: fake_primary_token,
+      mapbox_username: fake_username,
+      token_expiration: expiration_interval,
+      token_renewal: :timer.minutes(3)
+    )
 
-  #   rotator = start_link_supervised!({MapboxTokenRotator, name: nil})
-  #   MobileAppBackend.HTTPMock |> allow(self(), rotator)
+    rotator = start_link_supervised!({MapboxTokenRotator, name: nil})
+    MobileAppBackend.HTTPMock |> allow(self(), rotator)
 
-  #   receive do
-  #     :request_made -> :ok
-  #   end
+    receive do
+      :request_made -> :ok
+    end
 
-  #   assert MapboxTokenRotator.get_public_token(rotator) == fake_temporary_token
-  # end
+    assert MapboxTokenRotator.get_public_token(rotator) == fake_temporary_token
+  end
 
-  # test "refreshes token on interval" do
-  #   refresh_interval = 100
+  test "refreshes token on interval" do
+    refresh_interval = 100
 
-  #   test_pid = self()
+    test_pid = self()
 
-  #   MobileAppBackend.HTTPMock
-  #   |> expect(
-  #     :request,
-  #     fn %Req.Request{} = request ->
-  #       send(test_pid, :request_made)
+    MobileAppBackend.HTTPMock
+    |> expect(
+      :request,
+      fn %Req.Request{} = request ->
+        send(test_pid, :request_made)
 
-  #       Req.request(request,
-  #         adapter: fn request ->
-  #           {request, Req.Response.new(status: 201) |> Req.Response.json(%{token: "tk.token1"})}
-  #         end
-  #       )
-  #     end
-  #   )
-  #   |> expect(
-  #     :request,
-  #     fn %Req.Request{} = request ->
-  #       send(test_pid, :request_made)
+        Req.request(request,
+          adapter: fn request ->
+            {request, Req.Response.new(status: 201) |> Req.Response.json(%{token: "tk.token1"})}
+          end
+        )
+      end
+    )
+    |> expect(
+      :request,
+      fn %Req.Request{} = request ->
+        send(test_pid, :request_made)
 
-  #       Req.request(request,
-  #         adapter: fn request ->
-  #           {request, Req.Response.new(status: 201) |> Req.Response.json(%{token: "tk.token2"})}
-  #         end
-  #       )
-  #     end
-  #   )
+        Req.request(request,
+          adapter: fn request ->
+            {request, Req.Response.new(status: 201) |> Req.Response.json(%{token: "tk.token2"})}
+          end
+        )
+      end
+    )
 
-  #   reassign_env(:mobile_app_backend, MobileAppBackend.ClientConfig,
-  #     mapbox_primary_token: "sk.token",
-  #     mapbox_username: "user",
-  #     token_expiration: :timer.minutes(5),
-  #     token_renewal: refresh_interval
-  #   )
+    reassign_env(:mobile_app_backend, MobileAppBackend.ClientConfig,
+      mapbox_primary_token: "sk.token",
+      mapbox_username: "user",
+      token_expiration: :timer.minutes(5),
+      token_renewal: refresh_interval
+    )
 
-  #   rotator = start_link_supervised!({MapboxTokenRotator, name: nil})
-  #   MobileAppBackend.HTTPMock |> allow(self(), rotator)
+    rotator = start_link_supervised!({MapboxTokenRotator, name: nil})
+    MobileAppBackend.HTTPMock |> allow(self(), rotator)
 
-  #   first_token_time =
-  #     receive do
-  #       :request_made -> System.monotonic_time(:millisecond)
-  #     end
+    first_token_time =
+      receive do
+        :request_made -> System.monotonic_time(:millisecond)
+      end
 
-  #   assert MapboxTokenRotator.get_public_token(rotator) == "tk.token1"
+    assert MapboxTokenRotator.get_public_token(rotator) == "tk.token1"
 
-  #   second_token_time =
-  #     receive do
-  #       :request_made -> System.monotonic_time(:millisecond)
-  #     end
+    second_token_time =
+      receive do
+        :request_made -> System.monotonic_time(:millisecond)
+      end
 
-  #   assert MapboxTokenRotator.get_public_token(rotator) == "tk.token2"
+    assert MapboxTokenRotator.get_public_token(rotator) == "tk.token2"
 
-  #   actual_interval = second_token_time - first_token_time
+    actual_interval = second_token_time - first_token_time
 
-  #   assert (actual_interval - refresh_interval) in -50..50
-  # end
+    assert (actual_interval - refresh_interval) in -50..50
+  end
 end


### PR DESCRIPTION
This reverts commit 4ab0acf95b876499aa89a580bf24ade65eaf5233.

### Summary

What is this PR for?
No ticket. Revert PR for https://github.com/mbta/mobile_app_backend/pull/278 so that it is ready when we have a corrected mapbox config.
