### PR TITLE
fix: don't crash if Mapbox token renewal fails

### DIFF
--- a/test/mobile_app_backend/mapbox_token_rotator_test.exs
+++ b/test/mobile_app_backend/mapbox_token_rotator_test.exs
@@ -80,6 +80,67 @@ defmodule MobileAppBackend.MapboxTokenRotatorTest do
     assert MapboxTokenRotator.get_public_token(rotator) == fake_temporary_token
   end
 
+  test "does not crash if token rotation fails" do
+    fake_primary_token = "sk.fake"
+    fake_username = "fakeusername"
+
+    expiration_interval = :timer.seconds(10)
+
+    approximate_expiration_time =
+      DateTime.utc_now()
+      |> DateTime.add(expiration_interval, :millisecond)
+
+    test_pid = self()
+
+    expect(
+      MobileAppBackend.HTTPMock,
+      :request,
+      fn %Req.Request{
+           method: :post,
+           url: %URI{path: "/tokens/v2/fakeusername"},
+           options: %{
+             params: %{
+               access_token: ^fake_primary_token
+             },
+             json: %{expires: actual_expiration_time, scopes: ["styles:read", "fonts:read"]}
+           }
+         } = request ->
+        {:ok, actual_expiration_time, _} = actual_expiration_time |> DateTime.from_iso8601()
+
+        expiration_time_drift =
+          DateTime.diff(actual_expiration_time, approximate_expiration_time, :millisecond)
+
+        assert expiration_time_drift in 0..100
+
+        send(test_pid, :request_made)
+
+        # use Req.request to still run the JSON decoding step
+        Req.request(request,
+          adapter: fn request ->
+            {request,
+             Req.Response.new(status: 401) |> Req.Response.json(%{error: :everything_is_bad})}
+          end
+        )
+      end
+    )
+
+    reassign_env(:mobile_app_backend, MobileAppBackend.ClientConfig,
+      mapbox_primary_token: fake_primary_token,
+      mapbox_username: fake_username,
+      token_expiration: expiration_interval,
+      token_renewal: :timer.minutes(3)
+    )
+
+    rotator = start_link_supervised!({MapboxTokenRotator, name: nil})
+    MobileAppBackend.HTTPMock |> allow(self(), rotator)
+
+    receive do
+      :request_made -> :ok
+    end
+
+    assert MapboxTokenRotator.get_public_token(rotator) == ""
+  end
+
   test "refreshes token on interval" do
     refresh_interval = 100
 


### PR DESCRIPTION
### Summary

_Ticket:_ none

The Erlang philosophy of "let it crash" gives you bad habits, because sometimes (like on application startup) you can't just let it crash.