### PR TITLE
feat: Add a new alert channel with new causes

### DIFF
--- a/lib/mbta_v3_api/alert.ex
+++ b/lib/mbta_v3_api/alert.ex
@@ -22,12 +22,14 @@ defmodule MBTAV3API.Alert do
     Util.enum_values(:uppercase_string, [
       :accident,
       :amtrak,
+      :amtrak_train_traffic,
       :an_earlier_mechanical_problem,
       :an_earlier_signal_problem,
       :autos_impeding_service,
       :coast_guard_restriction,
       :congestion,
       :construction,
+      :crossing_issue,
       :crossing_malfunction,
       :demonstration,
       :disabled_bus,
@@ -46,6 +48,7 @@ defmodule MBTAV3API.Alert do
       :hurricane,
       :ice_in_harbor,
       :maintenance,
+      :mechanical_issue,
       :mechanical_problem,
       :medical_emergency,
       :other_cause,
@@ -53,19 +56,24 @@ defmodule MBTAV3API.Alert do
       :police_action,
       :police_activity,
       :power_problem,
+      :rail_defect,
       :severe_weather,
+      :signal_issue,
       :signal_problem,
+      :single_tracking,
       :slippery_rail,
       :snow,
       :special_event,
       :speed_restriction,
       :strike,
+      :switch_issue,
       :switch_problem,
       :technical_problem,
       :tie_replacement,
       :track_problem,
       :track_work,
       :traffic,
+      :train_traffic,
       :unruly_passenger,
       :unknown_cause,
       :weather
@@ -182,5 +190,25 @@ defmodule MBTAV3API.Alert do
       lifecycle: parse_lifecycle!(item.attributes["lifecycle"]),
       updated_at: Util.parse_datetime!(item.attributes["updated_at"])
     }
+  end
+
+  @doc """
+  These are newly added causes that were not included in the initial release, we filter them out of the original
+  alert channel so users who haven't upgraded the app don't get crashes when an alert contains one.
+  Any clients using the v2 alert channel also have handling for unknown cause and effect types, so any future
+  causes can be added here as well.
+  """
+  @spec v2_causes :: MapSet.t(cause())
+  def v2_causes do
+    MapSet.new([
+      :amtrak_train_traffic,
+      :crossing_issue,
+      :mechanical_issue,
+      :rail_defect,
+      :signal_issue,
+      :single_tracking,
+      :switch_issue,
+      :train_traffic
+    ])
   end
 end

--- a/lib/mobile_app_backend_web/channels/alerts_channel.ex
+++ b/lib/mobile_app_backend_web/channels/alerts_channel.ex
@@ -10,7 +10,20 @@ defmodule MobileAppBackendWeb.AlertsChannel do
         MobileAppBackend.Alerts.PubSub
       )
 
-    data = pubsub_module.subscribe()
+    data = pubsub_module.subscribe(legacy_compatibility: true)
+    {:ok, data, socket}
+  end
+
+  @impl true
+  def join("alerts:v2", _payload, socket) do
+    pubsub_module =
+      Application.get_env(
+        :mobile_app_backend,
+        MobileAppBackend.Alerts.PubSub,
+        MobileAppBackend.Alerts.PubSub
+      )
+
+    data = pubsub_module.subscribe(legacy_compatibility: false)
     {:ok, data, socket}
   end
 

--- a/lib/mobile_app_backend_web/channels/user_socket.ex
+++ b/lib/mobile_app_backend_web/channels/user_socket.ex
@@ -13,6 +13,7 @@ defmodule MobileAppBackendWeb.UserSocket do
 
   channel "predictions:trip:*", MobileAppBackendWeb.PredictionsForTripChannel
   channel "alerts", MobileAppBackendWeb.AlertsChannel
+  channel "alerts:v2", MobileAppBackendWeb.AlertsChannel
   channel "vehicles:*", MobileAppBackendWeb.VehiclesForRouteChannel
   channel "vehicle:id:*", MobileAppBackendWeb.VehicleChannel
 

--- a/test/mobile_app_backend_web/channels/alerts_channel_test.exs
+++ b/test/mobile_app_backend_web/channels/alerts_channel_test.exs
@@ -56,10 +56,60 @@ defmodule MobileAppBackendWeb.AlertsChannelTest do
 
     data1 = to_full_map([alert1, alert2])
 
-    expect(AlertsPubSubMock, :subscribe, 1, fn -> data1 end)
+    expect(AlertsPubSubMock, :subscribe, 1, fn _ -> data1 end)
 
     {:ok, ^data1, socket} =
       subscribe_and_join(socket, "alerts")
+
+    data2 = to_full_map([alert1])
+
+    AlertsChannel.handle_info({:new_alerts, data2}, socket)
+
+    assert_push("stream_data", ^data2)
+  end
+
+  test "joins and subscribes v2 correctly", %{socket: socket} do
+    alert1 = %Alert{
+      id: "501047",
+      active_period: [%Alert.ActivePeriod{start: ~B[2023-05-26 16:46:13]}],
+      effect: :station_issue,
+      effect_name: nil,
+      informed_entity: [
+        %Alert.InformedEntity{
+          activities: [:board],
+          route: "Green-D",
+          route_type: :light_rail,
+          stop: "70511"
+        },
+        %Alert.InformedEntity{
+          activities: [:board],
+          route: "88",
+          route_type: :bus,
+          stop: "place-lech"
+        }
+      ],
+      lifecycle: :ongoing
+    }
+
+    alert2 = %Alert{
+      id: "559018",
+      active_period: [
+        %Alert.ActivePeriod{start: ~B[2024-03-14 16:12:00], end: ~B[2024-03-14 18:13:39]}
+      ],
+      effect: :delay,
+      effect_name: nil,
+      informed_entity: [
+        %Alert.InformedEntity{activities: [:board, :exit, :ride], route: "120", route_type: :bus}
+      ],
+      lifecycle: :new
+    }
+
+    data1 = to_full_map([alert1, alert2])
+
+    expect(AlertsPubSubMock, :subscribe, 1, fn _ -> data1 end)
+
+    {:ok, ^data1, socket} =
+      subscribe_and_join(socket, "alerts:v2")
 
     data2 = to_full_map([alert1])
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Update backend to handle new alert causes/effects](https://app.asana.com/0/1205732265579288/1209561344386983)

[Frontend PR](https://github.com/mbta/mobile_app/pull/814)

This creates a new `alerts:v2` channel which will serve alerts containing the causes which were newly added in this PR.

The existing `alerts` channel now replaces any of these causes with `:unknown_cause`, not doing so would cause any <=1.2.0 versions of the app to break entirely if an alert with one of these causes existed in the feed.

## Testing

Added unit tests for the new alert behavior, and did some manual testing connected to the app, ensuring that when it was pointed at each channel it either did or didn't contain the new causes.
