### PR TITLE
feat: Add duration_certainty field to Alerts

### DIFF
--- a/lib/mbta_v3_api/alert.ex
+++ b/lib/mbta_v3_api/alert.ex
@@ -9,6 +9,7 @@ defmodule MBTAV3API.Alert do
           active_period: [ActivePeriod.t()],
           cause: cause(),
           description: String.t() | nil,
+          duration_certainty: duration_certainty(),
           effect: effect(),
           effect_name: String.t() | nil,
           header: String.t() | nil,
@@ -82,6 +83,12 @@ defmodule MBTAV3API.Alert do
   )
 
   Util.declare_enum(
+    :duration_certainty,
+    Util.enum_values(:uppercase_string, [:estimated, :known, :unknown]),
+    :unknown
+  )
+
+  Util.declare_enum(
     :effect,
     Util.enum_values(:uppercase_string, [
       :access_issue,
@@ -133,6 +140,7 @@ defmodule MBTAV3API.Alert do
     :active_period,
     :cause,
     :description,
+    :duration_certainty,
     :effect,
     :effect_name,
     :header,
@@ -147,6 +155,7 @@ defmodule MBTAV3API.Alert do
       :active_period,
       :cause,
       :description,
+      :duration_certainty,
       :effect,
       :effect_name,
       :header,
@@ -183,6 +192,7 @@ defmodule MBTAV3API.Alert do
       active_period: Enum.map(item.attributes["active_period"], &ActivePeriod.parse!/1),
       cause: parse_cause(item.attributes["cause"]),
       description: item.attributes["description"],
+      duration_certainty: parse_duration_certainty(item.attributes["duration_certainty"]),
       effect: parse_effect(item.attributes["effect"]),
       effect_name: item.attributes["effect_name"],
       header: item.attributes["header"],

--- a/test/mbta_v3_api/alert_test.exs
+++ b/test/mbta_v3_api/alert_test.exs
@@ -123,7 +123,7 @@ defmodule MBTAV3API.AlertTest do
                ],
                "cause" => "ALIENS",
                "description" => "Description",
-               "duration_certainty" => "UNKNOWABLE",
+               "duration_certainty" => "BEYOND_MORTAL_COMPREHENSION",
                "effect" => "TELEPORTATION",
                "header" => "Header",
                "informed_entity" => [

--- a/test/mbta_v3_api/alert_test.exs
+++ b/test/mbta_v3_api/alert_test.exs
@@ -83,6 +83,7 @@ defmodule MBTAV3API.AlertTest do
                ],
                "cause" => "FIRE",
                "description" => "Description",
+               "duration_certainty" => "ESTIMATED",
                "effect" => "DELAY",
                "header" => "Header",
                "informed_entity" => [
@@ -98,6 +99,7 @@ defmodule MBTAV3API.AlertTest do
              ],
              cause: :fire,
              description: "Description",
+             duration_certainty: :estimated,
              effect: :delay,
              header: "Header",
              informed_entity: [
@@ -121,6 +123,7 @@ defmodule MBTAV3API.AlertTest do
                ],
                "cause" => "ALIENS",
                "description" => "Description",
+               "duration_certainty" => "UNKNOWABLE",
                "effect" => "TELEPORTATION",
                "header" => "Header",
                "informed_entity" => [
@@ -136,6 +139,7 @@ defmodule MBTAV3API.AlertTest do
              ],
              cause: :unknown_cause,
              description: "Description",
+             duration_certainty: :unknown,
              effect: :unknown_effect,
              header: "Header",
              informed_entity: [


### PR DESCRIPTION
### Summary

_Ticket:_ [Alert Details | format later today & start/end of service](https://app.asana.com/0/1205732265579288/1208572284247951)

Adds a new enum field to alerts which tells us how much we should trust the provided active period.