### PR TITLE
feat(Alert): Include severity attribute

### DIFF
--- a/lib/mbta_v3_api/alert.ex
+++ b/lib/mbta_v3_api/alert.ex
@@ -15,6 +15,7 @@ defmodule MBTAV3API.Alert do
           header: String.t() | nil,
           informed_entity: [InformedEntity.t()],
           lifecycle: lifecycle(),
+          severity: integer(),
           updated_at: DateTime.t()
         }
 
@@ -146,6 +147,7 @@ defmodule MBTAV3API.Alert do
     :header,
     :informed_entity,
     :lifecycle,
+    :severity,
     :updated_at
   ]
 
@@ -161,6 +163,7 @@ defmodule MBTAV3API.Alert do
       :header,
       :informed_entity,
       :lifecycle,
+      :severity,
       :updated_at
     ]
   end
@@ -198,6 +201,7 @@ defmodule MBTAV3API.Alert do
       header: item.attributes["header"],
       informed_entity: Enum.map(item.attributes["informed_entity"], &InformedEntity.parse!/1),
       lifecycle: parse_lifecycle!(item.attributes["lifecycle"]),
+      severity: item.attributes["severity"],
       updated_at: Util.parse_datetime!(item.attributes["updated_at"])
     }
   end

--- a/test/mbta_v3_api/alert_test.exs
+++ b/test/mbta_v3_api/alert_test.exs
@@ -90,6 +90,7 @@ defmodule MBTAV3API.AlertTest do
                  %{"activities" => ["BOARD", "EXIT", "RIDE"], "route" => "39", "route_type" => 3}
                ],
                "lifecycle" => "NEW",
+               "severity" => 7,
                "updated_at" => "2024-02-12T11:49:00-05:00"
              }
            }) == %Alert{
@@ -110,6 +111,7 @@ defmodule MBTAV3API.AlertTest do
                }
              ],
              lifecycle: :new,
+             severity: 7,
              updated_at: ~B[2024-02-12 11:49:00]
            }
   end


### PR DESCRIPTION
### Summary

_Ticket:_ [Display subway delays](https://app.asana.com/0/1205732265579288/1208643635656244/f)

What is this PR for?
* Expose alert severity so that we can use it to determine which subway delays to show
