### PR TITLE
tmp(Alerts.Store): Remove RTR functionality alert

### DIFF
--- a/lib/mbta_v3_api/store/alerts.ex
+++ b/lib/mbta_v3_api/store/alerts.ex
@@ -114,7 +114,10 @@ defmodule MBTAV3API.Store.Alerts.Impl do
   end
 
   defp upsert_data(api_records) do
-    records = Enum.map(api_records, &to_record(&1))
+    records =
+      api_records
+      |> Enum.reject(fn alert -> alert.id == "636777" end)
+      |> Enum.map(&to_record(&1))
 
     :ets.insert(@alerts_table_name, records)
   end


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket

[Slack thread](https://mbta.slack.com/archives/C05QMG9GS9M/p1744143556538009)

This alert is necessary to work around some strange service realities that would cause RTR to generate invalid predictions. It would show up to riders as a duplicate of the proper user facing alert though, so we're suppressing it.
