### PR TITLE
feat: Add route stops endpoint

### DIFF
--- a/lib/mobile_app_backend_web/controllers/route_controller.ex
+++ b/lib/mobile_app_backend_web/controllers/route_controller.ex
@@ -1,0 +1,14 @@
+defmodule MobileAppBackendWeb.RouteController do
+  alias MBTAV3API.Repository
+  use MobileAppBackendWeb, :controller
+
+  def stops(conn, %{"route_id" => route_id, "direction_id" => direction_id}) do
+    {:ok, %{data: stops}} =
+      Repository.stops(
+        filter: [route: route_id, direction_id: direction_id],
+        fields: [stop: [:id]]
+      )
+
+    json(conn, %{stop_ids: stops |> Enum.map(fn stop -> stop.id end)})
+  end
+end

--- a/lib/mobile_app_backend_web/router.ex
+++ b/lib/mobile_app_backend_web/router.ex
@@ -33,15 +33,16 @@ defmodule MobileAppBackendWeb.Router do
   # Other scopes may use custom stacks.
   scope "/api", MobileAppBackendWeb do
     pipe_through :api
-    get("/nearby", NearbyController, :show)
     get("/global", GlobalController, :show)
+    get("/nearby", NearbyController, :show)
+    get("/route/stops", RouteController, :stops)
+    get("/schedules", ScheduleController, :schedules)
     get("/search/query", SearchController, :query)
-    get("/shapes/rail", ShapesController, :rail)
     get("/shapes/map-friendly/rail", ShapesController, :rail)
+    get("/shapes/rail", ShapesController, :rail)
     get("/stop/map", StopController, :map)
     get("/trip", TripController, :trip)
     get("/trip/map", TripController, :map)
-    get("/schedules", ScheduleController, :schedules)
   end
 
   # Enable LiveDashboard in development

--- a/test/mobile_app_backend_web/controllers/route_controller_test.exs
+++ b/test/mobile_app_backend_web/controllers/route_controller_test.exs
@@ -1,0 +1,58 @@
+defmodule MobileAppBackendWeb.RouteControllerTest do
+  use HttpStub.Case
+  use MobileAppBackendWeb.ConnCase
+  import Mox
+  import Test.Support.Helpers
+  import MobileAppBackend.Factory
+
+  describe "GET /api/route/stops unit tests" do
+    setup do
+      verify_on_exit!()
+      reassign_env(:mobile_app_backend, MBTAV3API.Repository, RepositoryMock)
+    end
+
+    defp mock_route_data do
+      andrew = build(:stop, id: "andrew")
+      jfk = build(:stop, id: "jfk/umass")
+      savin = build(:stop, id: "savin_hill")
+      north_quincy = build(:stop, id: "north_quincy")
+
+      RepositoryMock
+      |> expect(:stops, 1, fn params, _opts ->
+        case params
+             |> Keyword.get(:filter) do
+          [route: "Red", direction_id: "0"] ->
+            ok_response([andrew, jfk, savin, north_quincy])
+        end
+      end)
+
+      RepositoryMock
+      |> expect(:stops, 1, fn params, _opts ->
+        case params
+             |> Keyword.get(:filter) do
+          [route: "Red", direction_id: "1"] ->
+            ok_response([north_quincy, savin, jfk, andrew])
+        end
+      end)
+    end
+
+    test "list of stop IDs is returned in a direction along a route",
+         %{conn: conn} do
+      mock_route_data()
+
+      conn0 =
+        get(conn, "/api/route/stops", %{"route_id" => "Red", "direction_id" => 0})
+
+      data0 = json_response(conn0, 200)
+
+      assert %{"stop_ids" => ["andrew", "jfk/umass", "savin_hill", "north_quincy"]} = data0
+
+      conn1 =
+        get(conn, "/api/route/stops", %{"route_id" => "Red", "direction_id" => 1})
+
+      data1 = json_response(conn1, 200)
+
+      assert %{"stop_ids" => ["north_quincy", "savin_hill", "jfk/umass", "andrew"]} = data1
+    end
+  end
+end

--- a/test/mobile_app_backend_web/controllers/route_controller_test.exs
+++ b/test/mobile_app_backend_web/controllers/route_controller_test.exs
@@ -18,21 +18,25 @@ defmodule MobileAppBackendWeb.RouteControllerTest do
       north_quincy = build(:stop, id: "north_quincy")
 
       RepositoryMock
-      |> expect(:stops, 1, fn params, _opts ->
-        case params
-             |> Keyword.get(:filter) do
-          [route: "Red", direction_id: "0"] ->
-            ok_response([andrew, jfk, savin, north_quincy])
-        end
+      |> expect(:stops, 2, fn
+        [filter: [route: "Red", direction_id: "0"], fields: _], _opts ->
+          ok_response([andrew, jfk, savin, north_quincy])
+
+        [filter: [route: "Red", direction_id: "1"], fields: _], _opts ->
+          ok_response([north_quincy, savin, jfk, andrew])
       end)
+    end
+
+    defp mock_multi_route_data do
+      stop_a = build(:stop, id: "stopA")
+      stop_b = build(:stop, id: "stopB")
+      stop_c = build(:stop, id: "stopC")
+      stop_d = build(:stop, id: "stopD")
 
       RepositoryMock
-      |> expect(:stops, 1, fn params, _opts ->
-        case params
-             |> Keyword.get(:filter) do
-          [route: "Red", direction_id: "1"] ->
-            ok_response([north_quincy, savin, jfk, andrew])
-        end
+      |> expect(:stops, 1, fn
+        [filter: [route: "route1,route2", direction_id: "0"], fields: _], _opts ->
+          ok_response([stop_a, stop_b, stop_c, stop_d])
       end)
     end
 
@@ -53,6 +57,18 @@ defmodule MobileAppBackendWeb.RouteControllerTest do
       data1 = json_response(conn1, 200)
 
       assert %{"stop_ids" => ["north_quincy", "savin_hill", "jfk/umass", "andrew"]} = data1
+    end
+
+    test "joined list of stop IDs is returned when multiple routes are passed in",
+         %{conn: conn} do
+      mock_multi_route_data()
+
+      conn =
+        get(conn, "/api/route/stops", %{"route_id" => "route1,route2", "direction_id" => 0})
+
+      data = json_response(conn, 200)
+
+      assert %{"stop_ids" => ["stopA", "stopB", "stopC", "stopD"]} = data
     end
   end
 end


### PR DESCRIPTION
### Summary

_Ticket:_ [Favorites | Route details - ordered list of stops endpoint](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209816289542478?focus=true)

Add a new endpoint `/api/route/stops` which returns a list of stop ids for each of the stops served along that route. This list will include stops that are only on uncommon route patterns or on different branches, ordered in a sort of coherent way (which is determined by the v3 API).
