### PR TITLE
chore: disable SentryUptimeBot

### DIFF
--- a/priv/static/robots.txt
+++ b/priv/static/robots.txt
@@ -3,3 +3,5 @@
 # To ban all spiders from the entire site uncomment the next two lines:
 # User-agent: *
 # Disallow: /
+User-agent: SentryUptimeBot
+Disallow: *


### PR DESCRIPTION
### Summary

No ticket

What is this PR for?
Follows the request from this[ slack thread](https://mbta.slack.com/archives/G01E809HUF2/p1748528790162219) pointing to the Sentry doc for [disabling automatic uptime detection ](https://docs.sentry.io/product/alerts/uptime-monitoring/automatic-detection/#disabling-automatic-detection). 

Will merge pending further discussion as to whether this is needed on a project-by-project basis.