### PR TITLE
feat: Add route filter search endpoint

### DIFF
--- a/lib/mobile_app_backend/search/algolia/query_payload.ex
+++ b/lib/mobile_app_backend/search/algolia/query_payload.ex
@@ -28,6 +28,12 @@ defmodule MobileAppBackend.Search.Algolia.QueryPayload do
     |> with_hit_size(10)
   end
 
+  def for_route_filter(query) do
+    Algolia.Index.index_name(:route)
+    |> new(query)
+    |> with_hit_size(50)
+  end
+
   defp new(index_name, query) do
     track_analytics? =
       Application.get_env(:mobile_app_backend, MobileAppBackend.Search.Algolia)[:track_analytics?] ||

--- a/lib/mobile_app_backend_web/controllers/search_controller.ex
+++ b/lib/mobile_app_backend_web/controllers/search_controller.ex
@@ -11,11 +11,25 @@ defmodule MobileAppBackendWeb.SearchController do
   end
 
   def query(%Conn{} = conn, %{"query" => query}) do
-    queries = [
+    algolia_request(conn, [
       Algolia.QueryPayload.for_index(:route, query),
       Algolia.QueryPayload.for_index(:stop, query)
-    ]
+    ])
+  end
 
+  @spec routes(Conn.t(), map) :: Conn.t()
+  def routes(%Conn{} = conn, %{"query" => ""}) do
+    json(conn, %{data: %{}})
+  end
+
+  def routes(%Conn{} = conn, %{"query" => query}) do
+    algolia_request(conn, [
+      Algolia.QueryPayload.for_route_filter(query)
+    ])
+  end
+
+  @spec routes(Conn.t(), [Algolia.QueryPayload.t()]) :: Conn.t()
+  defp algolia_request(conn, queries) do
     algolia_query_fn =
       Application.get_env(
         :mobile_app_backend,

--- a/lib/mobile_app_backend_web/router.ex
+++ b/lib/mobile_app_backend_web/router.ex
@@ -46,6 +46,7 @@ defmodule MobileAppBackendWeb.Router do
     get("/route/stops", RouteController, :stops)
     get("/schedules", ScheduleController, :schedules)
     get("/search/query", SearchController, :query)
+    get("/search/routes", SearchController, :routes)
     get("/shapes/map-friendly/rail", ShapesController, :rail)
     get("/shapes/rail", ShapesController, :rail)
     get("/stop/map", StopController, :map)

--- a/test/mobile_app_backend/search/algolia/query_payload_test.exs
+++ b/test/mobile_app_backend/search/algolia/query_payload_test.exs
@@ -36,6 +36,22 @@ defmodule MobileAppBackend.Search.Algolia.QueryPayloadTest do
              } == QueryPayload.for_index(:stop, "testString")
     end
 
+    test "when for a route filter, configures the index & params" do
+      reassign_env(:mobile_app_backend, MobileAppBackend.Search.Algolia,
+        route_index: "fake_route_index"
+      )
+
+      assert %QueryPayload{
+               index_name: "fake_route_index",
+               params: %{
+                 "query" => "testString",
+                 "hitsPerPage" => 50,
+                 "clickAnalytics" => true,
+                 "analytics" => false
+               }
+             } == QueryPayload.for_route_filter("testString")
+    end
+
     test "when analytics is configured for the environment, then sets analytics param to true" do
       reassign_env(:mobile_app_backend, MobileAppBackend.Search.Algolia, track_analytics?: true)
 


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Favorites | Add stops flow - search / filter](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210229155855234?focus=true)

This returns a max of 50 results to use to filter the list of displayed routes on the route picker page. The top level search only returns a max of 5 route results.
