### PR TITLE
fix: return all route search results

### DIFF
--- a/lib/mobile_app_backend/search/algolia/query_payload.ex
+++ b/lib/mobile_app_backend/search/algolia/query_payload.ex
@@ -31,7 +31,7 @@ defmodule MobileAppBackend.Search.Algolia.QueryPayload do
   def for_route_filter(query) do
     Algolia.Index.index_name(:route)
     |> new(query)
-    |> with_hit_size(50)
+    |> with_hit_size(1000)
   end
 
   defp new(index_name, query) do

--- a/test/mobile_app_backend/search/algolia/query_payload_test.exs
+++ b/test/mobile_app_backend/search/algolia/query_payload_test.exs
@@ -45,7 +45,7 @@ defmodule MobileAppBackend.Search.Algolia.QueryPayloadTest do
                index_name: "fake_route_index",
                params: %{
                  "query" => "testString",
-                 "hitsPerPage" => 50,
+                 "hitsPerPage" => 1000,
                  "clickAnalytics" => true,
                  "analytics" => false
                }


### PR DESCRIPTION
### Summary

_Ticket:_ [Favorites | QA | route search](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210826290372839?focus=true)

Filtering by route type in Algolia is not currently possible since route types aren’t set up as a facet, but even if they were, that wouldn’t let us distinguish SL buses from non-SL buses; we’d need to add a new `isSilverLine` property on all the routes as they go into the index, and then we’d need to set that property as a facet as well. Filtering by route type in the `SearchController` would also not be able to distinguish SL routes. The frontend already knows which routes are on the SL page, so I think it makes the most sense to just return every single search result from the backend and let the frontend continue to filter based on which routes are included in the page being viewed.