### PR TITLE
fix: improve route branching looping handling

### DIFF
--- a/lib/mix/tasks/check_route_branching.ex
+++ b/lib/mix/tasks/check_route_branching.ex
@@ -253,6 +253,7 @@ defmodule Mix.Tasks.CheckRouteBranching do
     nodes_dot =
       graph
       |> :digraph.vertices()
+      |> Enum.sort()
       |> Enum.map_join(fn id ->
         {_, label} = :digraph.vertex(graph, id)
         "#{dot_vertex_id(id)} [label=\"#{process_vertex_label.(id, label)}\"];\n"
@@ -261,6 +262,7 @@ defmodule Mix.Tasks.CheckRouteBranching do
     edges_dot =
       graph
       |> :digraph.edges()
+      |> Enum.sort()
       |> Enum.map_join(fn {from, to} ->
         "#{dot_vertex_id(from)} -> #{dot_vertex_id(to)};\n"
       end)

--- a/lib/mobile_app_backend/route_branching/stop_disambiguation.ex
+++ b/lib/mobile_app_backend/route_branching/stop_disambiguation.ex
@@ -1,0 +1,193 @@
+defmodule MobileAppBackend.RouteBranching.StopDisambiguation do
+  alias MBTAV3API.RoutePattern
+  alias MBTAV3API.Stop
+  alias MobileAppBackend.GlobalDataCache
+
+  @type disambiguated_stop_id :: {Stop.id(), count :: pos_integer()}
+  @type t :: [{RoutePattern.t(), [disambiguated_stop_id()]}]
+
+  @spec build([Stop.id()], [RoutePattern.t()], GlobalDataCache.data()) :: t()
+  def build(canon_stop_ids, patterns, global_data) do
+    canon_stop_set = MapSet.new(canon_stop_ids)
+    pattern_stops = Enum.map(patterns, &pattern_stops(&1, canon_stop_set, global_data))
+    pattern_stops_with_counts = pattern_stops_with_counts(pattern_stops, canon_stop_ids)
+    pattern_stops_with_counts
+  end
+
+  @spec pattern_stops(RoutePattern.t(), MapSet.t(Stop.id()), GlobalDataCache.data()) ::
+          {RoutePattern.t(), [Stop.id()]}
+  defp pattern_stops(pattern, canon_stops, global_data) do
+    trip = global_data.trips[pattern.representative_trip_id]
+
+    stops =
+      trip.stop_ids
+      |> Enum.map(&stop_or_parent_if_canon(&1, canon_stops, global_data))
+      |> Enum.reject(&is_nil/1)
+
+    {pattern, stops}
+  end
+
+  @spec stop_or_parent_if_canon(Stop.id(), MapSet.t(Stop.id()), GlobalDataCache.data()) ::
+          Stop.id() | nil
+  defp stop_or_parent_if_canon(stop_id, canon_stops, global_data) do
+    if MapSet.member?(canon_stops, stop_id) do
+      stop_id
+    else
+      parent = global_data.stops[stop_id].parent_station_id
+
+      if MapSet.member?(canon_stops, parent) do
+        parent
+      end
+    end
+  end
+
+  defmodule StopCountState do
+    @moduledoc """
+    Internal helper for `pattern_stops_with_counts/1`.
+
+    Uses `List.myers_difference/2` to build up a list of disambiguated stops, so that repeated stops are correctly
+    assigned the most optimal count possible.
+    """
+    @type t :: %__MODULE__{
+            stops_with_counts: [{Stop.id(), count :: pos_integer()}],
+            global_list_countless: [Stop.id()],
+            global_list_countful: [{Stop.id(), count :: pos_integer()}],
+            global_list_countful_remaining: [non_neg_integer()],
+            counts: %{Stop.id() => pos_integer()}
+          }
+    defstruct [
+      :stops_with_counts,
+      :global_list_countless,
+      :global_list_countful,
+      :global_list_countful_remaining,
+      :counts
+    ]
+
+    @spec process_edit_list(
+            [{:eq | :ins | :del, [Stop.id()]}],
+            [Stop.id()],
+            [{Stop.id(), pos_integer()}],
+            %{Stop.id() => pos_integer()}
+          ) :: t()
+    def process_edit_list(edit_list, global_list_countless, global_list_countful, counts) do
+      edit_list
+      |> Enum.reduce(
+        new(global_list_countless, global_list_countful, counts),
+        fn {action, sublist}, state ->
+          apply_action(state, action, sublist)
+        end
+      )
+    end
+
+    # it would be possible to use the canon stop IDs as the initial global list, but sometimes the canon stop IDs are
+    # not actually in topological order, which breaks a lot of things
+    @spec new :: t()
+    def new, do: new([], [], %{})
+
+    @spec new([Stop.id()]) :: t()
+    def new(global_list_countless) do
+      global_list_countful = Enum.map(global_list_countless, &{&1, 1})
+      counts = Map.new(global_list_countful)
+      new(global_list_countless, global_list_countful, counts)
+    end
+
+    @spec new([Stop.id()], [{Stop.id(), pos_integer()}], %{Stop.id() => pos_integer()}) :: t()
+    defp new(global_list_countless, global_list_countful, counts) do
+      %__MODULE__{
+        stops_with_counts: [],
+        global_list_countless: global_list_countless,
+        global_list_countful: global_list_countful,
+        global_list_countful_remaining: global_list_countful,
+        counts: counts
+      }
+    end
+
+    @spec apply_action(t(), :eq | :ins | :del, [Stop.id()]) :: t()
+    defp apply_action(state, action, sublist)
+
+    defp apply_action(%__MODULE__{} = state, :eq, sublist) do
+      {new_countful, remaining_countful} =
+        Enum.split(state.global_list_countful_remaining, length(sublist))
+
+      %__MODULE__{
+        state
+        | stops_with_counts: state.stops_with_counts ++ new_countful,
+          global_list_countful_remaining: remaining_countful
+      }
+    end
+
+    defp apply_action(%__MODULE__{} = state, :del, sublist) do
+      remaining_countful = Enum.drop(state.global_list_countful_remaining, length(sublist))
+
+      %__MODULE__{
+        state
+        | global_list_countful_remaining: remaining_countful
+      }
+    end
+
+    defp apply_action(%__MODULE__{} = state, :ins, sublist) do
+      {new_countful, counts} =
+        Enum.map_reduce(sublist, state.counts, fn stop_id, counts ->
+          {count, counts} =
+            Map.get_and_update(counts, stop_id, fn
+              nil -> {1, 1}
+              x -> {x + 1, x + 1}
+            end)
+
+          {{stop_id, count}, counts}
+        end)
+
+      splice_point =
+        length(state.global_list_countful) - length(state.global_list_countful_remaining)
+
+      {countless_before, countless_after} = Enum.split(state.global_list_countless, splice_point)
+      new_global_countless = countless_before ++ sublist ++ countless_after
+      {countful_before, countful_after} = Enum.split(state.global_list_countful, splice_point)
+      new_global_countful = countful_before ++ new_countful ++ countful_after
+
+      %__MODULE__{
+        stops_with_counts: state.stops_with_counts ++ new_countful,
+        global_list_countless: new_global_countless,
+        global_list_countful: new_global_countful,
+        global_list_countful_remaining: state.global_list_countful_remaining,
+        counts: counts
+      }
+    end
+  end
+
+  @doc false
+  @spec pattern_stops_with_counts([{RoutePattern.t(), [Stop.id()]}], [Stop.id()]) :: t()
+  def pattern_stops_with_counts(patterns_stops, canon_stop_ids) do
+    {result, _} =
+      patterns_stops
+      |> Enum.sort_by(fn {pattern, stops} ->
+        # we want to consider more typical patterns earlier, and also we want to consider longer patterns earlier
+        # since longer patterns give us more context to use when disambiguating stops
+        {RoutePattern.serialize_typicality!(pattern.typicality), -length(stops)}
+      end)
+      |> Enum.map_reduce(
+        StopCountState.new(canon_stop_ids),
+        fn {pattern, stops}, %StopCountState{} = state ->
+          edit_list = List.myers_difference(state.global_list_countless, stops)
+
+          inner_state =
+            StopCountState.process_edit_list(
+              edit_list,
+              state.global_list_countless,
+              state.global_list_countful,
+              state.counts
+            )
+
+          {{pattern, inner_state.stops_with_counts},
+           %StopCountState{
+             state
+             | global_list_countless: inner_state.global_list_countless,
+               global_list_countful: inner_state.global_list_countful,
+               counts: inner_state.counts
+           }}
+        end
+      )
+
+    result
+  end
+end

--- a/lib/mobile_app_backend/route_branching/stop_graph.ex
+++ b/lib/mobile_app_backend/route_branching/stop_graph.ex
@@ -2,12 +2,11 @@ defmodule MobileAppBackend.RouteBranching.StopGraph do
   @moduledoc """
   Records the connections between individual stops, preserving how typical stops are.
   """
-  alias MBTAV3API.Route
   alias MBTAV3API.RoutePattern
   alias MBTAV3API.Stop
   alias MobileAppBackend.GlobalDataCache
   alias MobileAppBackend.RouteBranching.GraphUtil
-  alias MobileAppBackend.RouteBranching.Workarounds
+  alias MobileAppBackend.RouteBranching.StopDisambiguation
 
   defmodule Node do
     alias MBTAV3API.RoutePattern
@@ -19,24 +18,25 @@ defmodule MobileAppBackend.RouteBranching.StopGraph do
   @typedoc """
   A stop ID and and a count of how many times this stop has appeared.
   For looping routes, the first copy of a stop will be {"foo", 1} and the second {"foo", 2}.
+  For routes which only sometimes loop, the more typical patterns get dibs on the lower numbers,
+  and then with the power of `List.myers_difference/2` we figure out which copy of the stop is the
+  one that already exists with count 1 and which one is the new one that needs count 2.
   """
   @type vertex_id :: {Stop.id(), count :: pos_integer()}
   @type edge_id :: {vertex_id(), vertex_id()}
 
-  @spec build(Route.id(), 0 | 1, [Stop.id()], [RoutePattern.t()], GlobalDataCache.data()) :: t()
-  def build(route_id, direction_id, stop_ids, patterns, global_data) do
-    canon_stops = MapSet.new(stop_ids)
-
+  @spec build(StopDisambiguation.t(), GlobalDataCache.data()) :: t()
+  def build(patterns_disambiguated_stops, global_data) do
     result = :digraph.new([:cyclic, :protected])
 
-    typicalities_stops_with_counts =
-      Enum.map(patterns, &pattern_typicality_stops(&1, canon_stops, global_data))
-
-    typicalities_stops_with_counts
-    |> Enum.flat_map(fn {t, stops_with_counts} -> Enum.map(stops_with_counts, &{t, &1}) end)
-    |> Enum.group_by(fn {_t, stop_with_count} -> stop_with_count end, fn {t, _stop_with_count} ->
-      t
+    patterns_disambiguated_stops
+    |> Enum.flat_map(fn {pattern, disambiguated_stops} ->
+      Enum.map(disambiguated_stops, &{pattern.typicality, &1})
     end)
+    |> Enum.group_by(
+      fn {_t, disambiguated_stop} -> disambiguated_stop end,
+      fn {t, _disambiguated_stop} -> t end
+    )
     |> Enum.each(fn {{stop_id, stop_count}, typicalities} ->
       :digraph.add_vertex(result, {stop_id, stop_count}, %Node{
         stop: global_data.stops[stop_id],
@@ -44,59 +44,14 @@ defmodule MobileAppBackend.RouteBranching.StopGraph do
       })
     end)
 
-    for {_, stops_with_counts} <- typicalities_stops_with_counts do
+    for {_, stops_with_counts} <- patterns_disambiguated_stops do
       for [from, to] <- Enum.chunk_every(stops_with_counts, 2, 1, :discard) do
         :digraph.add_edge(result, {from, to}, from, to, nil)
       end
     end
 
-    Workarounds.rewrite_stop_graph(result, route_id, direction_id)
     GraphUtil.drop_skipping_edges(result)
 
     result
-  end
-
-  @spec pattern_typicality_stops(RoutePattern.t(), MapSet.t(Stop.id()), GlobalDataCache.data()) ::
-          {RoutePattern.typicality(), [{Stop.id(), pos_integer()}]}
-  defp pattern_typicality_stops(pattern, canon_stops, global_data) do
-    trip = global_data.trips[pattern.representative_trip_id]
-
-    stops_with_counts =
-      trip.stop_ids
-      |> Enum.map(&stop_or_parent_if_canon(&1, canon_stops, global_data))
-      |> Enum.reject(&is_nil/1)
-      |> stops_with_counts()
-
-    {pattern.typicality, stops_with_counts}
-  end
-
-  @spec stop_or_parent_if_canon(Stop.id(), MapSet.t(Stop.id()), GlobalDataCache.data()) ::
-          Stop.id() | nil
-  defp stop_or_parent_if_canon(stop_id, canon_stops, global_data) do
-    if MapSet.member?(canon_stops, stop_id) do
-      stop_id
-    else
-      parent = global_data.stops[stop_id].parent_station_id
-
-      if MapSet.member?(canon_stops, parent) do
-        parent
-      end
-    end
-  end
-
-  @spec stops_with_counts([Stop.id()], %{Stop.id() => pos_integer()}, [{Stop.id(), pos_integer()}]) ::
-          [{Stop.id(), pos_integer()}]
-  defp stops_with_counts(stop_ids, counts \\ %{}, result \\ [])
-
-  defp stops_with_counts([], _, result), do: Enum.reverse(result)
-
-  defp stops_with_counts([stop_id | stop_ids], counts, result) do
-    {count, counts} =
-      Map.get_and_update(counts, stop_id, fn
-        nil -> {1, 1}
-        x -> {x + 1, x + 1}
-      end)
-
-    stops_with_counts(stop_ids, counts, [{stop_id, count} | result])
   end
 end

--- a/lib/mobile_app_backend/route_branching/workarounds.ex
+++ b/lib/mobile_app_backend/route_branching/workarounds.ex
@@ -1,7 +1,6 @@
 defmodule MobileAppBackend.RouteBranching.Workarounds do
   alias MBTAV3API.Route
   alias MBTAV3API.Stop
-  alias MobileAppBackend.RouteBranching.StopGraph
 
   @doc """
   Rewrites a list of stop IDs as returned by the V3 API to apply the necessary workarounds.
@@ -62,77 +61,6 @@ defmodule MobileAppBackend.RouteBranching.Workarounds do
   end
 
   def rewrite_stop_ids(stop_ids, _, _), do: stop_ids
-
-  @spec rewrite_stop_graph(StopGraph.t(), Route.id(), 0 | 1) :: :ok
-  def rewrite_stop_graph(stop_graph, route_id, direction_id)
-
-  def rewrite_stop_graph(stop_graph, "70", 0) do
-    # as of 2025-07-14 the 70 outbound has A->B typical B->A deviation, so drop the deviation B->A
-    a = {"88333", 1}
-    b = {"883321", 1}
-
-    if contains_all_edges(stop_graph, [{a, b}, {b, a}]) do
-      record_workaround_used("70", 0)
-
-      :digraph.del_edge(stop_graph, {b, a})
-    end
-
-    :ok
-  end
-
-  def rewrite_stop_graph(stop_graph, "Boat-F6", 1) do
-    # as of 2025-07-14 morning routes visit Logan only after Seaport/Fan and afternoon routes visit Logan only before
-    # Central Wharf so Logan never gets disambiguated
-    a = {"Boat-Winthrop", 1}
-    b = {"Boat-Logan", 1}
-    c = {"Boat-Aquarium", 1}
-    d = {"Boat-Fan", 1}
-    e = {"Boat-Logan", 2}
-    f = {"Boat-Winthrop", 2}
-
-    if stop_graph |> :digraph.vertices() |> Enum.sort() == Enum.sort([a, b, c, d, f]) do
-      record_workaround_used("Boat-F6", 1)
-
-      {^b, node_value} = :digraph.vertex(stop_graph, b)
-
-      :digraph.add_vertex(stop_graph, e, node_value)
-      :digraph.add_edge(stop_graph, {d, e}, d, e, nil)
-      :digraph.add_edge(stop_graph, {e, f}, e, f, nil)
-      :digraph.del_edges(stop_graph, [{d, b}, {b, f}, {b, a}])
-    end
-
-    :ok
-  end
-
-  def rewrite_stop_graph(stop_graph, "Boat-F7", 1) do
-    # as of 2025-07-14morning routes visit Logan only after Central Wharf and afternoon routes visit Logan only before
-    # Seaport/Fan so Logan never gets disambiguated
-    a = {"Boat-Quincy", 1}
-    b = {"Boat-Logan", 1}
-    c = {"Boat-Fan", 1}
-    d = {"Boat-Aquarium", 1}
-    e = {"Boat-Logan", 2}
-    f = {"Boat-Quincy", 2}
-
-    if stop_graph |> :digraph.vertices() |> Enum.sort() == Enum.sort([a, b, c, d, f]) do
-      record_workaround_used("Boat-F7", 1)
-
-      {^b, node_value} = :digraph.vertex(stop_graph, b)
-
-      :digraph.add_vertex(stop_graph, e, node_value)
-      :digraph.add_edge(stop_graph, {d, e}, d, e, nil)
-      :digraph.add_edge(stop_graph, {e, f}, e, f, nil)
-      :digraph.del_edges(stop_graph, [{d, b}, {b, f}, {b, a}])
-    end
-
-    :ok
-  end
-
-  def rewrite_stop_graph(_, _, _), do: :ok
-
-  defp contains_all_edges(stop_graph, edges) do
-    Enum.all?(edges, fn {from, to} -> :digraph.edge(stop_graph, {from, to}) != false end)
-  end
 
   # Used by check_route_branching to verify that no workarounds have gone stale.
   # Always call with literals so that check_route_branching can determine that the workaround exists.

--- a/test/mobile_app_backend/route_branching/stop_disambiguation_test.exs
+++ b/test/mobile_app_backend/route_branching/stop_disambiguation_test.exs
@@ -1,0 +1,63 @@
+defmodule MobileAppBackend.RouteBranching.StopDisambiguationTest do
+  use ExUnit.Case, async: true
+  import MobileAppBackend.Factory
+  alias MobileAppBackend.RouteBranching.StopDisambiguation
+
+  describe "typicalities_stops_with_counts/1" do
+    test "assigns counts to a single pattern that loops" do
+      pattern = build(:route_pattern, typicality: :typical)
+
+      assert StopDisambiguation.pattern_stops_with_counts(
+               [{pattern, ~w(A B C D E C)}],
+               ~w(A B C D E)
+             ) == [
+               {pattern, [{"A", 1}, {"B", 1}, {"C", 1}, {"D", 1}, {"E", 1}, {"C", 2}]}
+             ]
+    end
+
+    test "gives a higher count to less typical loops even if they come earlier in the stop list" do
+      typical_pattern = build(:route_pattern, typicality: :typical)
+      atypical_pattern = build(:route_pattern, typicality: :atypical)
+
+      assert StopDisambiguation.pattern_stops_with_counts(
+               [
+                 {typical_pattern, ~w(A B C)},
+                 {atypical_pattern, ~w(C A B C)}
+               ],
+               ~w(A B C)
+             ) == [
+               {typical_pattern, [{"A", 1}, {"B", 1}, {"C", 1}]},
+               {atypical_pattern, [{"C", 2}, {"A", 1}, {"B", 1}, {"C", 1}]}
+             ]
+    end
+
+    test "even handles the ferry mess that looked impossible" do
+      [pattern1, pattern2] = build_pair(:route_pattern, typicality: :typical)
+
+      assert StopDisambiguation.pattern_stops_with_counts(
+               [
+                 {pattern1, ~w(Boat-Winthrop Boat-Aquarium Boat-Fan Boat-Logan Boat-Winthrop)},
+                 {pattern2, ~w(Boat-Winthrop Boat-Logan Boat-Aquarium Boat-Fan Boat-Winthrop)}
+               ],
+               ~w(Boat-Winthrop Boat-Logan Boat-Aquarium Boat-Fan)
+             ) == [
+               {pattern1,
+                [
+                  {"Boat-Winthrop", 1},
+                  {"Boat-Aquarium", 1},
+                  {"Boat-Fan", 1},
+                  {"Boat-Logan", 2},
+                  {"Boat-Winthrop", 2}
+                ]},
+               {pattern2,
+                [
+                  {"Boat-Winthrop", 1},
+                  {"Boat-Logan", 1},
+                  {"Boat-Aquarium", 1},
+                  {"Boat-Fan", 1},
+                  {"Boat-Winthrop", 2}
+                ]}
+             ]
+    end
+  end
+end


### PR DESCRIPTION
### Summary

_Ticket:_ none

Fixes the three cases in the upcoming rating where route branching fails. Also deletes most of the remaining workarounds.
