### PR TITLE
fix(load_testing): don’t use empty string as default API key

### DIFF
--- a/load_testing/locustfile.py
+++ b/load_testing/locustfile.py
@@ -52,7 +52,7 @@ def on_init(environment, **_kwargs):
 
 @events.init_command_line_parser.add_listener
 def _(parser):
-    parser.add_argument("--api-key", type=str, env_var="V3_API_KEY", default="", help="API Key for the V3 API. Set to avoid rate limiting.")
+    parser.add_argument("--api-key", type=str, env_var="V3_API_KEY", default=None, help="API Key for the V3 API. Set to avoid rate limiting.")
 
 class MobileAppUser(HttpUser, PhoenixChannelUser):
     wait_time = between(5, 60)


### PR DESCRIPTION
### Summary

_Ticket:_ none

I get a lot of spam about the [low-intensity load test that runs every three days](https://github.com/mbta/mobile_app_backend/actions/workflows/trivial-load-test.yml) failing, and after some investigation, it fails because the empty string is not a valid API key and so the API will 403 if the API key is set to the empty string, which is set by default. Defaulting to `None` instead causes no API key to be sent, which for low user counts is fine.
