### PR TITLE
fix: Use prod algolia indices

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -8,6 +8,10 @@ import Config
 config :mobile_app_backend, MobileAppBackendWeb.Endpoint,
   cache_static_manifest: "priv/static/cache_manifest.json"
 
+config :mobile_app_backend, MobileAppBackend.Search.Algolia,
+  route_index: "routes",
+  stop_index: "stops"
+
 # Do not print debug messages in production
 config :logger, level: :info
 


### PR DESCRIPTION
### Summary

_Ticket:_ [[algolia - use prod indices in prod]](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210967667899897?focus=true)

We've been using the test indices in prod this whole time. This switches over the prod config to use the prod ones, now we should be more free to make test changes on the test environment.