### PR TITLE
fix: add workaround for 15 inbound stop ID list

### DIFF
--- a/lib/mobile_app_backend/route_branching/workarounds.ex
+++ b/lib/mobile_app_backend/route_branching/workarounds.ex
@@ -8,8 +8,62 @@ defmodule MobileAppBackend.RouteBranching.Workarounds do
   @spec rewrite_stop_ids([Stop.id()], Route.id(), 0 | 1) :: [Stop.id()]
   def rewrite_stop_ids(stop_ids, route_id, direction_id)
 
-  # as of 2025-07-21, the 33 inbound has typical B->C atypical A->C A->D B->D, but the stop IDs are ADBC
+  # as of 2025-08-15, the 15 inbound has typical C->D->E atypical A->B->C B->E, but the stop IDs are ACBDE
   # with minor Elixir crimes we can use pure pattern matching in a legible way to solve this
+  special_case_15_inbound_a = [
+    "place-matt",
+    "10582",
+    "583",
+    "584",
+    "585",
+    "586",
+    "587",
+    "588",
+    "590",
+    "591",
+    "882",
+    "593",
+    "594",
+    "595",
+    "533",
+    "534",
+    "place-asmnl",
+    "30336",
+    "337",
+    "338",
+    "339",
+    "340",
+    "341",
+    "342",
+    "343",
+    "32501"
+  ]
+
+  special_case_15_inbound_b = ["322"]
+  special_case_15_inbound_c = ["place-fldcr"]
+  special_case_15_inbound_de = ["55600", "557"]
+
+  def rewrite_stop_ids(
+        [
+          unquote_splicing(special_case_15_inbound_a),
+          unquote_splicing(special_case_15_inbound_c),
+          unquote_splicing(special_case_15_inbound_b),
+          unquote_splicing(special_case_15_inbound_de) | rest
+        ],
+        "15",
+        1
+      ) do
+    record_workaround_used("15", 1)
+
+    [
+      unquote_splicing(special_case_15_inbound_a),
+      unquote_splicing(special_case_15_inbound_b),
+      unquote_splicing(special_case_15_inbound_c),
+      unquote_splicing(special_case_15_inbound_de) | rest
+    ]
+  end
+
+  # as of 2025-07-21, the 33 inbound has typical B->C atypical A->C A->D B->D, but the stop IDs are ADBC
   special_case_33_inbound_a = [
     "18975",
     "8328",


### PR DESCRIPTION
### Summary

_Ticket:_ none
[Slack thread](https://mbta.slack.com/archives/C05QMG9GS9M/p1755284280045719)

Even if this is something that can be fixed in the API without much hassle, it’s probably worth having a fix in place here in the short term.