### PR TITLE
feat: Add T-Alert URL campaign tracking params

### DIFF
--- a/lib/mobile_app_backend_web/controllers/deep_link_controller.ex
+++ b/lib/mobile_app_backend_web/controllers/deep_link_controller.ex
@@ -1,7 +1,7 @@
 defmodule MobileAppBackendWeb.DeepLinkController do
   use MobileAppBackendWeb, :controller
 
-  defp t_alert_cta_campaign_params(),
+  defp t_alert_cta_campaign_params,
     do: %{
       "pt" => "117998862",
       "ct" => "TAlerts",
@@ -15,16 +15,16 @@ defmodule MobileAppBackendWeb.DeepLinkController do
     |> Keyword.get(key)
   end
 
+  defp app_store_redirect(conn, params) do
+    redirect(conn, external: "#{config(:dotcom_root)}/app-store?#{URI.encode_query(params)}")
+  end
+
   def root(conn, params) do
     app_store_redirect(conn, params)
   end
 
   def t_alert_cta(conn, params) do
     app_store_redirect(conn, Map.merge(params, t_alert_cta_campaign_params()))
-  end
-
-  defp app_store_redirect(conn, params) do
-    redirect(conn, external: "#{config(:dotcom_root)}/app-store?#{URI.encode_query(params)}")
   end
 
   def apple_app_site_association(conn, _params) do

--- a/lib/mobile_app_backend_web/controllers/deep_link_controller.ex
+++ b/lib/mobile_app_backend_web/controllers/deep_link_controller.ex
@@ -1,14 +1,15 @@
 defmodule MobileAppBackendWeb.DeepLinkController do
   use MobileAppBackendWeb, :controller
 
-  defp t_alert_cta_campaign_params,
-    do: %{
+  defp t_alert_cta_campaign_params do
+    %{
       "pt" => "117998862",
       "ct" => "TAlerts",
       "mt" => "8",
       "utm_source" => "TAlerts",
       "utm_campaign" => "TAlerts"
     }
+  end
 
   defp config(key) do
     Application.fetch_env!(:mobile_app_backend, :deep_links)

--- a/lib/mobile_app_backend_web/controllers/deep_link_controller.ex
+++ b/lib/mobile_app_backend_web/controllers/deep_link_controller.ex
@@ -1,12 +1,29 @@
 defmodule MobileAppBackendWeb.DeepLinkController do
   use MobileAppBackendWeb, :controller
 
+  defp t_alert_cta_campaign_params(),
+    do: %{
+      "pt" => "117998862",
+      "ct" => "TAlerts",
+      "mt" => "8",
+      "utm_source" => "TAlerts",
+      "utm_campaign" => "TAlerts"
+    }
+
   defp config(key) do
     Application.fetch_env!(:mobile_app_backend, :deep_links)
     |> Keyword.get(key)
   end
 
   def root(conn, params) do
+    app_store_redirect(conn, params)
+  end
+
+  def t_alert_cta(conn, params) do
+    app_store_redirect(conn, Map.merge(params, t_alert_cta_campaign_params()))
+  end
+
+  defp app_store_redirect(conn, params) do
     redirect(conn, external: "#{config(:dotcom_root)}/app-store?#{URI.encode_query(params)}")
   end
 

--- a/lib/mobile_app_backend_web/router.ex
+++ b/lib/mobile_app_backend_web/router.ex
@@ -19,6 +19,7 @@ defmodule MobileAppBackendWeb.Router do
     pipe_through :browser
 
     get "/", DeepLinkController, :root
+    get "/t-alert", DeepLinkController, :t_alert_cta
   end
 
   scope "/", MobileAppBackendWeb do

--- a/test/mobile_app_backend_web/controllers/deep_link_controller_test.exs
+++ b/test/mobile_app_backend_web/controllers/deep_link_controller_test.exs
@@ -12,6 +12,17 @@ defmodule MobileAppBackendWeb.DeepLinkControllerTest do
     end
   end
 
+  describe "t-alert" do
+    test "redirects to dotcom, adding tracking params", %{conn: conn} do
+      reassign_env(:mobile_app_backend, :deep_links, dotcom_root: "https://example.com")
+
+      conn = get(conn, ~p"/t-alert?param_1=val_1")
+
+      assert redirected_to(conn, 302) ==
+               "https://example.com/app-store?ct=TAlerts&mt=8&param_1=val_1&pt=117998862&utm_campaign=TAlerts&utm_source=TAlerts"
+    end
+  end
+
   describe "Android deep link approval" do
     test "works when configured", %{conn: conn} do
       package_name = "com.mbta.tid.mbta_app"


### PR DESCRIPTION
### Summary

_Ticket:_ [Add campaign tracking to T-alerts CTA on bus delay alerts](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210919282215092?focus=true)

Add a new `go.mbta.com/t-alert` endpoint, which will deeplink into the app if on a device with the app already installed, or redirect to the dotcom `app-store` endpoint if not, including the T Alerts link campaign params so that we can tell when users are installing the app from that link.

After this is deployed, we'll need a follow up alerts-concierge change to update the URL. This also does not include GA events within the app if opened with a deep link (see [ticket](https://app.asana.com/1/15492006741476/project/1205425564113216/task/1211066386453647?focus=true)).
