### PR TITLE
build: fix diff formatting to slack for route branching check

### DIFF
--- a/.github/workflows/route-branching.yml
+++ b/.github/workflows/route-branching.yml
@@ -99,5 +99,5 @@ jobs:
       - name: Report diff
         if: ${{ steps.diff.outcome == 'failure' }}
         run: |
-          jq --null-input '{text: "⚠️ Route branching different between prod/dev and dev-orange:\n\(env.DIFFSTAT)", url: env.RUN_URL}' | \
+          jq --null-input '{text: "⚠️ Route branching different between prod/dev and dev-orange:\n\(env.DIFFSTAT)", url: "\(env.RUN_URL)#step:15:14"}' | \
             curl -X POST --json @- ${{ secrets.ROUTE_BRANCHING_SLACK_WEBHOOK }}


### PR DESCRIPTION
### Summary

_Ticket:_ none

I had assumed that since `git diff` will include a trailing newline, I didn’t need to add one explicitly, but presumably the shell strips trailing newlines in variables or something, because that newline isn’t present. The markdown code fences don’t actually cause the diff to render in monospace, though, so there’s no point in including them.