### PR TITLE
feat: cache search results

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -22,6 +22,11 @@ config :mobile_app_backend, MBTAV3API.RepositoryCache,
   gc_interval: :timer.hours(2),
   allocated_memory: 250_000_000
 
+config :mobile_app_backend, MobileAppBackend.Search.Algolia.Cache,
+  gc_interval: :timer.hours(2),
+  allocated_memory: 250_000_000,
+  stats: true
+
 # Configures the endpoint
 config :mobile_app_backend, MobileAppBackendWeb.Endpoint,
   url: [host: "localhost"],

--- a/config/config.exs
+++ b/config/config.exs
@@ -23,7 +23,7 @@ config :mobile_app_backend, MBTAV3API.RepositoryCache,
   allocated_memory: 250_000_000
 
 config :mobile_app_backend, MobileAppBackend.Search.Algolia.Cache,
-  gc_interval: :timer.hours(2),
+  gc_interval: :timer.hours(6),
   allocated_memory: 250_000_000,
   stats: true
 

--- a/lib/mobile_app_backend/application.ex
+++ b/lib/mobile_app_backend/application.ex
@@ -29,6 +29,8 @@ defmodule MobileAppBackend.Application do
         {MBTAV3API.RepositoryCache, []},
         MBTAV3API.Supervisor,
         {MobileAppBackend.Health.FinchPool, pool_name: Finch.CustomPool},
+        {MobileAppBackend.Search.Algolia.Cache, []},
+        {MobileAppBackend.Health.Cache, cache: MobileAppBackend.Search.Algolia.Cache},
         MobileAppBackend.MapboxTokenRotator,
         MobileAppBackend.Alerts.Registry,
         MobileAppBackend.Predictions.Registry,

--- a/lib/mobile_app_backend/health/cache.ex
+++ b/lib/mobile_app_backend/health/cache.ex
@@ -2,7 +2,7 @@ defmodule MobileAppBackend.Health.Cache do
   use GenServer
   require Logger
 
-  @interval :timer.seconds(5)
+  @interval to_timeout(minute: 1)
 
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts)

--- a/lib/mobile_app_backend/health/cache.ex
+++ b/lib/mobile_app_backend/health/cache.ex
@@ -1,0 +1,35 @@
+defmodule MobileAppBackend.Health.Cache do
+  use GenServer
+  require Logger
+
+  @interval :timer.seconds(5)
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @impl true
+  def init(opts) do
+    cache = Keyword.fetch!(opts, :cache)
+    Process.send_after(self(), :check, @interval)
+
+    {:ok, %{cache: cache}}
+  end
+
+  @impl true
+  def handle_info(:check, %{cache: cache} = state) do
+    case cache.stats() do
+      nil ->
+        Logger.info("#{__MODULE__} cache=#{cache} cache stats disabled")
+
+      %Nebulex.Stats{measurements: %{hits: cache_hits, misses: cache_misses}} ->
+        Logger.info(
+          "#{__MODULE__} cache=#{cache} cache_health hits=#{cache_hits} misses=#{cache_misses} hit_rate=#{cache_hits / max(cache_hits + cache_misses, 1)}"
+        )
+    end
+
+    Process.send_after(self(), :check, @interval)
+
+    {:noreply, state}
+  end
+end

--- a/lib/mobile_app_backend/search/algolia/api.ex
+++ b/lib/mobile_app_backend/search/algolia/api.ex
@@ -9,12 +9,15 @@ defmodule MobileAppBackend.Search.Algolia.Api do
   alias MobileAppBackend.Search.Algolia
   require Logger
 
+  # even the most commonly requested search query should be refreshed every 24 hours
+  @cache_ttl to_timeout(hour: 24)
+
   @spec multi_index_search([Algolia.QueryPayload.t()]) ::
           {:ok, [any()]} | {:error, any}
   @doc """
   Perform the given index queries and return a flattened list of parsed results
   """
-  @decorate cacheable(cache: Algolia.Cache)
+  @decorate cacheable(cache: Algolia.Cache, opts: [ttl: @cache_ttl])
   def multi_index_search(queries) do
     perform_request_fn =
       Application.get_env(

--- a/lib/mobile_app_backend/search/algolia/api.ex
+++ b/lib/mobile_app_backend/search/algolia/api.ex
@@ -4,6 +4,7 @@ defmodule MobileAppBackend.Search.Algolia.Api do
   See https://www.algolia.com/doc/rest-api/search/
   Relies on configuration from :mobile_app_backend, MobileAppBackend.Search.Algolia
   """
+  use Nebulex.Caching
   @algolia_api_version 1
   alias MobileAppBackend.Search.Algolia
   require Logger
@@ -13,6 +14,7 @@ defmodule MobileAppBackend.Search.Algolia.Api do
   @doc """
   Perform the given index queries and return a flattened list of parsed results
   """
+  @decorate cacheable(cache: Algolia.Cache)
   def multi_index_search(queries) do
     perform_request_fn =
       Application.get_env(

--- a/lib/mobile_app_backend/search/algolia/cache.ex
+++ b/lib/mobile_app_backend/search/algolia/cache.ex
@@ -1,0 +1,8 @@
+defmodule MobileAppBackend.Search.Algolia.Cache do
+  @moduledoc """
+  Cache used to reduce the number of calls to the Algolia API.
+  """
+  use Nebulex.Cache,
+    otp_app: :mobile_app_backend,
+    adapter: Nebulex.Adapters.Local
+end

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,8 @@ defmodule MobileAppBackend.MixProject do
       deps: deps(),
       dialyzer: [plt_add_apps: [:mix]],
       test_coverage: [tool: LcovEx],
-      compilers: [:phoenix_live_view] ++ Mix.compilers()
+      compilers: [:phoenix_live_view] ++ Mix.compilers(),
+      listeners: [Phoenix.CodeReloader]
     ]
   end
 

--- a/test/mobile_app_backend/health/cache_test.exs
+++ b/test/mobile_app_backend/health/cache_test.exs
@@ -1,0 +1,40 @@
+defmodule MobileAppBackend.Health.CacheTest do
+  use ExUnit.Case
+  alias MobileAppBackend.Health
+  import ExUnit.CaptureLog
+  import Test.Support.Helpers
+
+  describe "handle_info/1" do
+    test "when stats disabled, logs" do
+      defmodule StatslessCache do
+        def stats, do: nil
+      end
+
+      set_log_level(:info)
+
+      msg =
+        capture_log(fn ->
+          Health.Cache.handle_info(:check, %{cache: StatslessCache})
+        end)
+
+      assert msg =~ "cache=#{StatslessCache} cache stats disabled"
+    end
+
+    test "when stats found, logs stats" do
+      defmodule Cache do
+        def stats do
+          %Nebulex.Stats{measurements: %{hits: 4, misses: 4}}
+        end
+      end
+
+      set_log_level(:info)
+
+      msg =
+        capture_log(fn ->
+          Health.Cache.handle_info(:check, %{cache: Cache})
+        end)
+
+      assert msg =~ "cache=#{Cache} cache_health hits=4 misses=4 hit_rate=0.5"
+    end
+  end
+end

--- a/test/mobile_app_backend_web/controllers/schedule_controller_test.exs
+++ b/test/mobile_app_backend_web/controllers/schedule_controller_test.exs
@@ -10,6 +10,7 @@ defmodule MobileAppBackendWeb.ScheduleControllerTest do
   setup do
     verify_on_exit!()
     reassign_env(:mobile_app_backend, MBTAV3API.Repository, RepositoryMock)
+    MobileAppBackend.Search.Algolia.Cache.delete_all()
     :ok
   end
 

--- a/test/mobile_app_backend_web/controllers/schedule_controller_test.exs
+++ b/test/mobile_app_backend_web/controllers/schedule_controller_test.exs
@@ -10,7 +10,6 @@ defmodule MobileAppBackendWeb.ScheduleControllerTest do
   setup do
     verify_on_exit!()
     reassign_env(:mobile_app_backend, MBTAV3API.Repository, RepositoryMock)
-    MobileAppBackend.Search.Algolia.Cache.delete_all()
     :ok
   end
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Cache Algolia results](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210967667899895?focus=true)

I’m not sure if we’d be interested in also logging the hit rates on our other caches, but I’ve designed the health check to allow for that if we decide we want it.