### PR TITLE
fix: Update TAlerts CTA campaign params

### DIFF
--- a/lib/mobile_app_backend_web/controllers/deep_link_controller.ex
+++ b/lib/mobile_app_backend_web/controllers/deep_link_controller.ex
@@ -3,11 +3,10 @@ defmodule MobileAppBackendWeb.DeepLinkController do
 
   defp t_alert_cta_campaign_params do
     %{
+      "referrer" => "utm_source=TAlerts&utm_campaign=TAlerts",
       "pt" => "117998862",
       "ct" => "TAlerts",
-      "mt" => "8",
-      "utm_source" => "TAlerts",
-      "utm_campaign" => "TAlerts"
+      "mt" => "8"
     }
   end
 

--- a/test/mobile_app_backend_web/controllers/deep_link_controller_test.exs
+++ b/test/mobile_app_backend_web/controllers/deep_link_controller_test.exs
@@ -19,7 +19,7 @@ defmodule MobileAppBackendWeb.DeepLinkControllerTest do
       conn = get(conn, ~p"/t-alert?param_1=val_1")
 
       assert redirected_to(conn, 302) ==
-               "https://example.com/app-store?ct=TAlerts&mt=8&param_1=val_1&pt=117998862&utm_campaign=TAlerts&utm_source=TAlerts"
+               "https://example.com/app-store?ct=TAlerts&mt=8&param_1=val_1&pt=117998862&referrer=utm_source%3DTAlerts%26utm_campaign%3DTAlerts"
     end
   end
 


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket

The TAlerts CTA link is not properly tracking the campaign when it redirects to dotcom, though based on Splunk logs, we are getting traffic to it with the params set here. This is an attempt to fix it at least for Android, other GA campaign URLs on dotcom seem to follow this format. It's also not working for iOS though, which is surprising because those params seem definitely correct.