### PR TITLE
ci: set up database for route branching too

### DIFF
--- a/.github/workflows/route-branching.yml
+++ b/.github/workflows/route-branching.yml
@@ -12,6 +12,21 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+      DATABASE_USER: postgres
+      DATABASE_PASSWORD: postgres
+      DATABASE_HOST: localhost
+      DATABASE_NAME: mobile_app_backend_test
+      DATABASE_DISABLE_SSL: insecure-yes
+    services:
+      postgres:
+        image: postgres
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: ${{env.DATABASE_USER}}
+          POSTGRES_PASSWORD: ${{env.DATABASE_PASSWORD}}
+          POSTGRES_DB: ${{env.DATABASE_NAME}}
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v5
       - name: Set cache keys


### PR DESCRIPTION
### Summary

_Ticket:_ none

It might be possible to just make the database optional, but it seems easier to stand a database up for this CI job.
