### PR TITLE
feat: endpoint to manage notification subscriptions

### DIFF
--- a/lib/mobile_app_backend/notifications/subscription.ex
+++ b/lib/mobile_app_backend/notifications/subscription.ex
@@ -8,7 +8,7 @@ defmodule MobileAppBackend.Notifications.Subscription do
     field(:stop_id, :string, null: false)
     field(:direction_id, :integer, null: false)
     field(:include_accessibility, :boolean, null: false)
-    has_many(:window, MobileAppBackend.Notifications.Window)
+    has_many(:windows, MobileAppBackend.Notifications.Window, on_replace: :delete_if_exists)
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/mobile_app_backend/notifications/write_payload.ex
+++ b/lib/mobile_app_backend/notifications/write_payload.ex
@@ -1,0 +1,142 @@
+defmodule MobileAppBackend.Notifications.WritePayload do
+  alias Ecto.Changeset
+  alias MobileAppBackend.Notifications
+  alias MobileAppBackend.User
+
+  defmodule Window do
+    @type t :: %__MODULE__{
+            start_time: Time.t(),
+            end_time: Time.t(),
+            days_of_week: [Calendar.ISO.day_of_week()]
+          }
+    defstruct [:start_time, :end_time, :days_of_week]
+
+    def parse!(%{
+          "start_time" => start_time,
+          "end_time" => end_time,
+          "days_of_week" => days_of_week
+        }) do
+      %__MODULE__{
+        start_time: parse_time!(start_time),
+        end_time: parse_time!(end_time),
+        days_of_week: Enum.sort(days_of_week)
+      }
+    end
+
+    defp parse_time!(time) do
+      case String.length(time) do
+        8 -> Time.from_iso8601!(time)
+        5 -> Time.from_iso8601!(time <> ":00")
+      end
+    end
+
+    @spec changeset(Notifications.Window.t(), t()) :: Changeset.t(Notifications.Window.t())
+    def changeset(%Notifications.Window{} = current, %__MODULE__{} = desired) do
+      Changeset.change(current, Map.from_struct(desired))
+    end
+  end
+
+  defmodule Subscription do
+    @type t :: %__MODULE__{
+            route_id: String.t(),
+            stop_id: String.t(),
+            direction_id: 0 | 1,
+            include_accessibility: boolean(),
+            windows: MapSet.t(Window.t())
+          }
+    defstruct [:route_id, :stop_id, :direction_id, :include_accessibility, :windows]
+
+    def parse!(%{
+          "route_id" => route_id,
+          "stop_id" => stop_id,
+          "direction_id" => direction_id,
+          "include_accessibility" => include_accessibility,
+          "windows" => windows
+        }) do
+      %__MODULE__{
+        route_id: route_id,
+        stop_id: stop_id,
+        direction_id: direction_id,
+        include_accessibility: include_accessibility,
+        windows: MapSet.new(windows, &Window.parse!/1)
+      }
+    end
+
+    @spec changeset(Changeset.t(Notifications.Subscription.t()), t()) ::
+            Changeset.t(Notifications.Subscription.t())
+    def changeset(current, %__MODULE__{} = desired) do
+      # since windows don’t really have identities,
+      # we just turn the first window from the DB into the first window from the payload, etc
+      current_windows =
+        Changeset.get_assoc(current, :windows, :struct)
+        |> Enum.with_index(fn window, index -> {index, window} end)
+        |> Map.new()
+
+      windows =
+        Enum.with_index(
+          desired.windows,
+          &Window.changeset(Map.get(current_windows, &2, %Notifications.Window{}), &1)
+        )
+
+      Changeset.change(current,
+        route_id: desired.route_id,
+        stop_id: desired.stop_id,
+        direction_id: desired.direction_id,
+        include_accessibility: desired.include_accessibility
+      )
+      |> Changeset.put_assoc(:windows, windows)
+    end
+
+    @spec key(Changeset.t(Notifications.Subscription.t()) | t()) ::
+            {route_id :: String.t(), stop_id :: String.t(), direction_id :: 0 | 1}
+    def key(%__MODULE__{route_id: route_id, stop_id: stop_id, direction_id: direction_id}) do
+      {route_id, stop_id, direction_id}
+    end
+
+    def key(%Changeset{} = subscription) do
+      {Changeset.get_field(subscription, :route_id), Changeset.get_field(subscription, :stop_id),
+       Changeset.get_field(subscription, :direction_id)}
+    end
+  end
+
+  @type t :: %__MODULE__{fcm_token: String.t(), subscriptions: MapSet.t(Subscription.t())}
+  defstruct [:fcm_token, :subscriptions]
+
+  def parse(payload) do
+    {:ok, parse!(payload)}
+  rescue
+    _ -> :error
+  end
+
+  def parse!(%{"fcm_token" => fcm_token, "subscriptions" => subscriptions}) do
+    %__MODULE__{
+      fcm_token: fcm_token,
+      subscriptions: MapSet.new(subscriptions, &Subscription.parse!/1)
+    }
+  end
+
+  @spec changeset(Changeset.t(User.t()), desired :: t()) :: Changeset.t(User.t())
+  def changeset(changeset, %__MODULE__{} = desired) do
+    current_subscriptions_by_key =
+      changeset
+      |> Changeset.get_assoc(:notification_subscriptions, :changeset)
+      |> Map.new(&{Subscription.key(&1), &1})
+
+    subscriptions =
+      Enum.map(desired.subscriptions, fn desired ->
+        key = Subscription.key(desired)
+
+        current =
+          Map.get(
+            current_subscriptions_by_key,
+            key,
+            Changeset.change(%Notifications.Subscription{})
+          )
+
+        Subscription.changeset(current, desired)
+      end)
+
+    # put_assoc will automatically delete anything that wasn’t included
+    Changeset.put_assoc(changeset, :notification_subscriptions, subscriptions)
+  end
+end

--- a/lib/mobile_app_backend/user.ex
+++ b/lib/mobile_app_backend/user.ex
@@ -11,6 +11,8 @@ defmodule MobileAppBackend.User do
     field(:fcm_token, :string, null: false)
     field(:fcm_last_verified, :utc_datetime, null: false)
 
-    has_many(:notification_subscription, MobileAppBackend.Notifications.Subscription)
+    has_many(:notification_subscriptions, MobileAppBackend.Notifications.Subscription,
+      on_replace: :delete_if_exists
+    )
   end
 end

--- a/lib/mobile_app_backend_web/controllers/notification_subscriptions_controller.ex
+++ b/lib/mobile_app_backend_web/controllers/notification_subscriptions_controller.ex
@@ -1,0 +1,60 @@
+defmodule MobileAppBackendWeb.NotificationSubscriptionsController do
+  use MobileAppBackendWeb, :controller
+
+  import Ecto.Query
+
+  alias MobileAppBackend.Notifications.WritePayload
+  alias MobileAppBackend.Repo
+  alias MobileAppBackend.User
+
+  def write(conn, params) do
+    status =
+      case WritePayload.parse(params) do
+        {:ok, payload} ->
+          now = Map.get_lazy(conn.private, :mobile_app_backend_now, &DateTime.utc_now/0)
+
+          case perform_write(payload, now) do
+            {:ok, _} ->
+              :ok
+
+            {:error, error} ->
+              Sentry.capture_message(
+                "NotificationSubscriptionsController.write/2 failure: #{inspect(error)}"
+              )
+
+              :internal_server_error
+          end
+
+        :error ->
+          :bad_request
+      end
+
+    conn |> put_status(status) |> json(nil)
+  end
+
+  @spec perform_write(WritePayload.t(), DateTime.t()) :: {:ok, :ok} | {:error, term()}
+  defp perform_write(payload, now) do
+    fcm_token = payload.fcm_token
+
+    Repo.transact(fn ->
+      user =
+        Repo.one(
+          from u in User,
+            where: u.fcm_token == ^fcm_token,
+            preload: [notification_subscriptions: :windows]
+        )
+        |> case do
+          nil -> %User{fcm_token: fcm_token}
+          user -> user
+        end
+
+      changeset =
+        user |> Ecto.Changeset.change(fcm_last_verified: now) |> WritePayload.changeset(payload)
+
+      case Repo.insert_or_update(changeset) do
+        {:ok, _} -> {:ok, :ok}
+        {:error, error} -> {:error, error}
+      end
+    end)
+  end
+end

--- a/lib/mobile_app_backend_web/router.ex
+++ b/lib/mobile_app_backend_web/router.ex
@@ -44,6 +44,7 @@ defmodule MobileAppBackendWeb.Router do
     pipe_through :api
     get("/global", GlobalController, :show)
     get("/nearby", NearbyController, :show)
+    post("/notifications/subscriptions/write", NotificationSubscriptionsController, :write)
     get("/route/stop-graph", RouteController, :stop_graph)
     get("/schedules", ScheduleController, :schedules)
     get("/search/query", SearchController, :query)

--- a/priv/repo/migrations/20250915170809_alter_notifications_on_delete.exs
+++ b/priv/repo/migrations/20250915170809_alter_notifications_on_delete.exs
@@ -1,0 +1,14 @@
+defmodule MobileAppBackend.Repo.Migrations.AlterNotificationsOnDelete do
+  use Ecto.Migration
+
+  def change do
+    alter table(:notification_subscriptions) do
+      modify :user_id, references(:users, on_delete: :delete_all), from: references(:users)
+    end
+
+    alter table(:notification_subscription_windows) do
+      modify :subscription_id, references(:notification_subscriptions, on_delete: :delete_all),
+        from: references(:notification_subscriptions)
+    end
+  end
+end

--- a/test/mobile_app_backend_web/controllers/notification_subscriptions_controller_test.exs
+++ b/test/mobile_app_backend_web/controllers/notification_subscriptions_controller_test.exs
@@ -1,0 +1,162 @@
+defmodule MobileAppBackendWeb.NotificationSubscriptionsControllerTest do
+  use MobileAppBackendWeb.ConnCase
+
+  import Ecto.Query
+  import MobileAppBackend.NotificationsFactory
+
+  alias MobileAppBackend.Notifications.Subscription
+  alias MobileAppBackend.Notifications.Window
+  alias MobileAppBackend.Repo
+  alias MobileAppBackend.User
+
+  setup %{conn: conn} do
+    now = DateTime.utc_now(:second)
+    conn = put_private(conn, :mobile_app_backend_now, now)
+    %{conn: conn, now: now}
+  end
+
+  test "creates new user with subscription", %{conn: conn, now: now} do
+    conn =
+      post(conn, "/api/notifications/subscriptions/write", %{
+        fcm_token: "fake_token",
+        subscriptions: [
+          %{
+            route_id: "Red",
+            stop_id: "place-sstat",
+            direction_id: 0,
+            include_accessibility: true,
+            windows: [
+              %{start_time: "08:00", end_time: "09:00", days_of_week: [1, 2, 3, 4, 5]},
+              %{start_time: "10:00", end_time: "17:00", days_of_week: [0, 7]}
+            ]
+          }
+        ]
+      })
+
+    assert json_response(conn, :ok) == nil
+    assert [%User{id: user_id, fcm_token: "fake_token", fcm_last_verified: ^now}] = Repo.all(User)
+
+    assert [
+             %Subscription{
+               id: subscription_id,
+               user_id: ^user_id,
+               route_id: "Red",
+               stop_id: "place-sstat",
+               direction_id: 0,
+               include_accessibility: true
+             }
+           ] = Repo.all(Subscription)
+
+    assert [
+             %Window{
+               subscription_id: ^subscription_id,
+               start_time: ~T[08:00:00],
+               end_time: ~T[09:00:00],
+               days_of_week: [1, 2, 3, 4, 5]
+             },
+             %Window{
+               subscription_id: ^subscription_id,
+               start_time: ~T[10:00:00],
+               end_time: ~T[17:00:00],
+               days_of_week: [0, 7]
+             }
+           ] = Repo.all(from(w in Window, order_by: w.start_time))
+  end
+
+  test "removes subscription", %{conn: conn, now: now} do
+    user = insert(:user, notification_subscriptions: [build(:notification_subscription)])
+
+    assert Repo.aggregate(Subscription, :count) == 1
+    assert Repo.aggregate(Window, :count) > 0
+
+    conn =
+      post(conn, "/api/notifications/subscriptions/write", %{
+        fcm_token: user.fcm_token,
+        subscriptions: []
+      })
+
+    assert json_response(conn, :ok) == nil
+    assert [%User{fcm_last_verified: ^now}] = Repo.all(User)
+    assert Repo.aggregate(Subscription, :count) == 0
+    assert Repo.aggregate(Window, :count) == 0
+  end
+
+  test "modifies subscription including windows", %{conn: conn} do
+    user = insert(:user)
+
+    old_subscription =
+      insert(:notification_subscription, user: user, windows: build_list(3, :window))
+
+    new_windows =
+      old_subscription.windows
+      |> Enum.drop(-1)
+      |> Enum.map(fn %Window{
+                       start_time: start_time,
+                       end_time: end_time,
+                       days_of_week: days_of_week
+                     } ->
+        %{
+          start_time: start_time |> Time.add(15, :second) |> Time.to_iso8601(),
+          end_time: end_time |> Time.add(-15, :second) |> Time.to_iso8601(),
+          days_of_week:
+            case days_of_week do
+              [single_day] -> Enum.sort([single_day, Integer.mod(single_day, 7) + 1])
+              [_first_day | days] -> days
+            end
+        }
+      end)
+
+    conn =
+      post(conn, "/api/notifications/subscriptions/write", %{
+        fcm_token: user.fcm_token,
+        subscriptions: [
+          %{
+            route_id: old_subscription.route_id,
+            stop_id: old_subscription.stop_id,
+            direction_id: old_subscription.direction_id,
+            include_accessibility: not old_subscription.include_accessibility,
+            windows: new_windows
+          }
+        ]
+      })
+
+    assert json_response(conn, :ok) == nil
+    assert [new_subscription] = Repo.all(from(Subscription, preload: :windows))
+
+    assert new_subscription.user_id == old_subscription.user_id
+    assert new_subscription.id == old_subscription.id
+    assert new_subscription.route_id == old_subscription.route_id
+    assert new_subscription.stop_id == old_subscription.stop_id
+    assert new_subscription.direction_id == old_subscription.direction_id
+
+    assert new_subscription.include_accessibility == not old_subscription.include_accessibility
+    assert length(new_subscription.windows) == length(old_subscription.windows) - 1
+
+    Enum.zip_with(new_subscription.windows, old_subscription.windows, fn new_window, old_window ->
+      assert new_window.id == old_window.id
+      assert Time.compare(new_window.start_time, old_window.start_time) == :gt
+      assert Time.compare(new_window.end_time, old_window.end_time) == :lt
+      assert length(new_window.days_of_week) != length(old_window.days_of_week)
+    end)
+  end
+
+  test "sends 400 on bad request", %{conn: conn} do
+    conn =
+      post(conn, "/api/notifications/subscriptions/write", %{
+        fcm_token: "fake_token",
+        subscriptions: [
+          %{
+            route_id: "Red",
+            stop_id: "place-sstat",
+            direction_id: 0,
+            include_accessibility: true,
+            windows: [
+              %{start_time: "not-a-time", end_time: "09:00", days_of_week: [1, 2, 3, 4, 5]}
+            ]
+          }
+        ]
+      })
+
+    assert json_response(conn, :bad_request) == nil
+  end
+end

--- a/test/support/notifications_factory.ex
+++ b/test/support/notifications_factory.ex
@@ -1,0 +1,35 @@
+defmodule MobileAppBackend.NotificationsFactory do
+  use ExMachina.Ecto, repo: MobileAppBackend.Repo
+
+  def notification_subscription_factory do
+    %MobileAppBackend.Notifications.Subscription{
+      route_id: sequence("route"),
+      stop_id: sequence("stop"),
+      direction_id: sequence(:direction, [0, 1]),
+      include_accessibility: sequence(:include_accessibility, [false, true]),
+      windows: [build(:window)]
+    }
+  end
+
+  def user_factory do
+    %MobileAppBackend.User{
+      fcm_token: :rand.bytes(64) |> Base.url_encode64(padding: false),
+      fcm_last_verified: DateTime.from_unix!(0)
+    }
+  end
+
+  defp time, do: sequence(:time, &Time.from_seconds_after_midnight(&1 * 60))
+
+  def window_factory do
+    days_of_week_count = :rand.normal(3.5, 1) |> round() |> max(1) |> min(7)
+
+    days_of_week =
+      Enum.map(1..days_of_week_count, fn _ -> :rand.uniform(7) end) |> Enum.uniq() |> Enum.sort()
+
+    %MobileAppBackend.Notifications.Window{
+      start_time: time(),
+      end_time: time(),
+      days_of_week: days_of_week
+    }
+  end
+end


### PR DESCRIPTION
### Summary

_Ticket:_ [Notifications | Endpoint for managing subscriptions](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211139143764269?focus=true)

I think if we want the frontend to maintain all the state and just sync it to the backend as needed, we don’t need separate create/update/delete endpoints and we can just have a “set my list of subscriptions” endpoint. Conveniently, [`Ecto.Changeset.put_assoc/4`](https://hexdocs.pm/ecto/3.13.2/Ecto.Changeset.html#put_assoc/4) makes it easy to set the entire list of associated objects, automatically deleting anything that’s no longer included.
