### PR TITLE
feat: store delivered notifications until no longer worth storing

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -50,12 +50,16 @@ config :mobile_app_backend, MobileAppBackend.GlobalDataCache, update_ms: :timer.
 config :mobile_app_backend, Oban,
   engine: Oban.Engines.Basic,
   plugins: [
-    {Oban.Plugins.Cron, crontab: [], timezone: "America/New_York"},
+    {Oban.Plugins.Cron,
+     crontab: [
+       {"@daily", MobileAppBackend.Notifications.DeliveredNotificationPruner}
+     ],
+     timezone: "America/New_York"},
     {Oban.Plugins.Lifeline, rescue_after: :timer.minutes(30)},
     {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7},
     Oban.Plugins.Reindexer
   ],
-  queues: [],
+  queues: [default: 10],
   repo: MobileAppBackend.Repo
 
 config :mobile_app_backend, :logger, [

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -52,6 +52,8 @@ config :mobile_app_backend, MobileAppBackendWeb.Endpoint,
     ]
   ]
 
+config :mobile_app_backend, Oban, peer: Oban.Peers.Global
+
 # Enable dev routes for dashboard and mailbox
 config :mobile_app_backend, dev_routes: true
 

--- a/lib/mobile_app_backend/notifications/delivered_notification.ex
+++ b/lib/mobile_app_backend/notifications/delivered_notification.ex
@@ -1,0 +1,26 @@
+defmodule MobileAppBackend.Notifications.DeliveredNotification do
+  use MobileAppBackend.Schema
+  import Ecto.Query
+  alias MBTAV3API.Alert
+  alias MobileAppBackend.Repo
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  typed_schema "delivered_notifications" do
+    belongs_to(:user, MobileAppBackend.User, null: false)
+    field(:alert_id, :string, null: false) :: Alert.id()
+    field(:upstream_timestamp, :utc_datetime, null: false)
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def already_sent?(user_id, alert_id, upstream_timestamp) do
+    Repo.aggregate(
+      from(dn in __MODULE__,
+        where:
+          dn.user_id == ^user_id and dn.alert_id == ^alert_id and
+            dn.upstream_timestamp == ^upstream_timestamp
+      ),
+      :count
+    ) == 1
+  end
+end

--- a/lib/mobile_app_backend/notifications/delivered_notification_pruner.ex
+++ b/lib/mobile_app_backend/notifications/delivered_notification_pruner.ex
@@ -1,0 +1,34 @@
+defmodule MobileAppBackend.Notifications.DeliveredNotificationPruner do
+  use Oban.Worker
+  import Ecto.Query
+  require Logger
+  alias MBTAV3API.Store
+  alias MobileAppBackend.Notifications.DeliveredNotification
+  alias MobileAppBackend.Repo
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    current_alert_ids = current_alert_ids()
+
+    # if the alerts feed is empty, that’s more likely to mean that there’s a data outage somewhere than
+    # that all alerts have been closed, so wait for the alerts to populate
+    if current_alert_ids == [] do
+      {:snooze, 60}
+    else
+      one_week_ago = DateTime.utc_now(:second) |> DateTime.shift(week: -1)
+
+      {count, _} =
+        Repo.delete_all(
+          from dn in DeliveredNotification,
+            where: dn.alert_id not in ^current_alert_ids and dn.inserted_at < ^one_week_ago
+        )
+
+      Logger.info("#{__MODULE__} pruned=#{count}")
+      :ok
+    end
+  end
+
+  defp current_alert_ids do
+    Store.Alerts.fetch([]) |> Enum.map(& &1.id)
+  end
+end

--- a/lib/mobile_app_backend/user.ex
+++ b/lib/mobile_app_backend/user.ex
@@ -14,5 +14,7 @@ defmodule MobileAppBackend.User do
     has_many(:notification_subscriptions, MobileAppBackend.Notifications.Subscription,
       on_replace: :delete_if_exists
     )
+
+    has_many(:delivered_notifications, MobileAppBackend.Notifications.DeliveredNotification)
   end
 end

--- a/priv/repo/migrations/20250925172236_create_delivered_notifications.exs
+++ b/priv/repo/migrations/20250925172236_create_delivered_notifications.exs
@@ -1,0 +1,18 @@
+defmodule MobileAppBackend.Repo.Migrations.CreateDeliveredNotifications do
+  use Ecto.Migration
+
+  def change do
+    create table(:delivered_notifications, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :user_id, references(:users, on_delete: :delete_all), null: false
+      add :alert_id, :string, null: false
+      add :upstream_timestamp, :utc_datetime, null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:delivered_notifications, [:user_id])
+    create index(:delivered_notifications, [:alert_id, :upstream_timestamp])
+    create unique_index(:delivered_notifications, [:user_id, :alert_id, :upstream_timestamp])
+  end
+end

--- a/test/mobile_app_backend/notifications/delivered_notification_pruner_test.exs
+++ b/test/mobile_app_backend/notifications/delivered_notification_pruner_test.exs
@@ -1,0 +1,113 @@
+defmodule MobileAppBackend.Notifications.DeliveredNotificationPrunerTest do
+  alias MBTAV3API.Store.Alerts
+  use MobileAppBackend.DataCase, async: false
+  use Oban.Testing, repo: MobileAppBackend.Repo
+  import ExUnit.CaptureLog
+  import MobileAppBackend.Factory
+  import Test.Support.Helpers
+  alias MobileAppBackend.Notifications.DeliveredNotification
+  alias MobileAppBackend.Notifications.DeliveredNotificationPruner
+  alias MobileAppBackend.NotificationsFactory
+
+  defp two_weeks_ago, do: DateTime.utc_now(:second) |> DateTime.shift(week: -2)
+
+  setup do
+    start_link_supervised!(MBTAV3API.Store.Alerts)
+    Alerts.process_upsert(:add, [build(:alert)])
+    set_log_level(:info)
+    :ok
+  end
+
+  test "removes old notifications for closed alerts" do
+    user = NotificationsFactory.insert(:user)
+    alert = build(:alert)
+
+    dn =
+      Repo.insert!(%DeliveredNotification{
+        user_id: user.id,
+        alert_id: alert.id,
+        upstream_timestamp: DateTime.utc_now(:second),
+        inserted_at: two_weeks_ago()
+      })
+
+    assert Repo.all(DeliveredNotification) == [dn]
+
+    log =
+      capture_log([level: :info], fn ->
+        :ok = perform_job(DeliveredNotificationPruner, %{})
+      end)
+
+    assert Repo.all(DeliveredNotification) == []
+    assert log =~ "[info] #{DeliveredNotificationPruner} pruned=1\n"
+  end
+
+  test "does not remove old notifications for open alerts" do
+    user = NotificationsFactory.insert(:user)
+    alert = build(:alert)
+
+    :ok = Alerts.process_upsert(:add, [alert])
+
+    dn =
+      Repo.insert!(%DeliveredNotification{
+        user_id: user.id,
+        alert_id: alert.id,
+        upstream_timestamp: DateTime.utc_now(:second),
+        inserted_at: two_weeks_ago()
+      })
+
+    assert Repo.all(DeliveredNotification) == [dn]
+
+    log =
+      capture_log([level: :info], fn ->
+        :ok = perform_job(DeliveredNotificationPruner, %{})
+      end)
+
+    assert Repo.all(DeliveredNotification) == [dn]
+    assert log =~ "[info] #{DeliveredNotificationPruner} pruned=0\n"
+  end
+
+  test "does not remove recent notifications for closed alerts" do
+    user = NotificationsFactory.insert(:user)
+    alert = build(:alert)
+
+    dn =
+      Repo.insert!(%DeliveredNotification{
+        user_id: user.id,
+        alert_id: alert.id,
+        upstream_timestamp: DateTime.utc_now(:second),
+        inserted_at: DateTime.utc_now(:second) |> DateTime.shift(day: -6)
+      })
+
+    assert Repo.all(DeliveredNotification) == [dn]
+
+    log =
+      capture_log([level: :info], fn ->
+        :ok = perform_job(DeliveredNotificationPruner, %{})
+      end)
+
+    assert Repo.all(DeliveredNotification) == [dn]
+    assert log =~ "[info] #{DeliveredNotificationPruner} pruned=0\n"
+  end
+
+  test "does not remove notifications if alerts feed is empty" do
+    Logger.put_process_level(self(), :none)
+    user = NotificationsFactory.insert(:user)
+    alert = build(:alert)
+
+    dn =
+      Repo.insert!(%DeliveredNotification{
+        user_id: user.id,
+        alert_id: alert.id,
+        upstream_timestamp: DateTime.utc_now(:second),
+        inserted_at: two_weeks_ago()
+      })
+
+    assert Repo.all(DeliveredNotification) == [dn]
+
+    Alerts.process_reset([], [])
+
+    assert {:snooze, 60} = perform_job(DeliveredNotificationPruner, %{})
+
+    assert Repo.all(DeliveredNotification) == [dn]
+  end
+end

--- a/test/mobile_app_backend/notifications/delivered_notification_test.exs
+++ b/test/mobile_app_backend/notifications/delivered_notification_test.exs
@@ -1,0 +1,60 @@
+defmodule MobileAppBackend.Notifications.DeliveredNotificationTest do
+  use MobileAppBackend.DataCase
+  import MobileAppBackend.NotificationsFactory
+  alias MobileAppBackend.Notifications.DeliveredNotification
+
+  test "can insert delivered notification for user" do
+    %{id: user_id} = insert(:user)
+
+    Repo.insert!(%DeliveredNotification{
+      user_id: user_id,
+      alert_id: "3",
+      upstream_timestamp: ~U[2025-09-25 00:00:00Z]
+    })
+  end
+
+  describe "already_sent?/3" do
+    test "true if an exact match exists" do
+      user = insert(:user)
+      alert_id = "3"
+      upstream_timestamp = ~U[2025-09-25 13:06:00Z]
+
+      Repo.insert!(%DeliveredNotification{
+        user_id: user.id,
+        alert_id: alert_id,
+        upstream_timestamp: upstream_timestamp
+      })
+
+      assert DeliveredNotification.already_sent?(user.id, alert_id, upstream_timestamp)
+    end
+
+    test "false if a near match exists" do
+      user = insert(:user)
+      other_user = insert(:user)
+      alert_id = "3"
+      other_alert_id = "4"
+      upstream_timestamp = ~U[2025-09-25 13:08:00Z]
+      other_upstream_timestamp = ~U[2025-09-25 13:08:01Z]
+
+      Repo.insert!(%DeliveredNotification{
+        user_id: other_user.id,
+        alert_id: alert_id,
+        upstream_timestamp: upstream_timestamp
+      })
+
+      Repo.insert!(%DeliveredNotification{
+        user_id: user.id,
+        alert_id: other_alert_id,
+        upstream_timestamp: upstream_timestamp
+      })
+
+      Repo.insert!(%DeliveredNotification{
+        user_id: user.id,
+        alert_id: alert_id,
+        upstream_timestamp: other_upstream_timestamp
+      })
+
+      refute DeliveredNotification.already_sent?(user.id, alert_id, upstream_timestamp)
+    end
+  end
+end


### PR DESCRIPTION
### Summary

_Ticket:_ [Create a table to store delivered notifications](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211386327223565?focus=true)

Pruning the delivered notifications isn’t in the acceptance criteria, but I can’t think of a reason why we wouldn’t want to do it.