### PR TITLE
ci: temporarily disable build cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,8 +131,9 @@ jobs:
           context: .
           push: false
           load: true
-          cache-from: type=gha,scope=build-${{ github.ref_name }}
-          cache-to: type=gha,scope=build-${{ github.ref_name }},mode=max
+          no-cache: true
+          # cache-from: type=gha,scope=build-${{ github.ref_name }}
+          # cache-to: type=gha,scope=build-${{ github.ref_name }},mode=max
       - name: docker compose build
         run: docker compose build
       - name: docker compose up

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,8 @@ jobs:
       - uses: docker/build-push-action@v7
         with:
           context: .
-          cache-from: type=gha
+          # cache-from: type=gha
+          no-cache: true
           tags: ${{ steps.calc-version.outputs.tag-list }}
           push: true
       - uses: mbta/actions/deploy-ecs@v2

--- a/.github/workflows/trivial-load-test.yml
+++ b/.github/workflows/trivial-load-test.yml
@@ -20,7 +20,8 @@ jobs:
           context: .
           push: false
           load: true
-          cache-from: type=gha
+          no-cache: true
+          # cache-from: type=gha
       - name: docker compose build
         run: docker compose build
       - name: docker compose up


### PR DESCRIPTION
### Summary

What is this PR for?
No ticket. Docker build caching is broken for our repo and others, see https://github.com/mbta/glides/pull/3309 and [slack discussion](https://mbta.slack.com/archives/G01E809HUF2/p1775498043242509). I will make a ticket to try re-enabling this in a week.