### PR TITLE
feat: log User-Agent header and request ID in more places

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -93,7 +93,7 @@ config :tailwind,
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
-  metadata: [:request_id]
+  metadata: [:request_id, :user_agent]
 
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason

--- a/lib/mbta_v3_api/headers.ex
+++ b/lib/mbta_v3_api/headers.ex
@@ -8,7 +8,21 @@ defmodule MBTAV3API.Headers do
   @spec build(String.t() | nil) :: header_list
   def build(api_key) do
     []
+    |> derived_request_id()
     |> api_key_header(api_key)
+  end
+
+  @spec derived_request_id(header_list()) :: header_list()
+  defp derived_request_id(headers) do
+    Logger.metadata()
+    |> Keyword.fetch(:request_id)
+    |> case do
+      {:ok, request_id} ->
+        [{"X-Request-Id", "#{request_id}/#{System.unique_integer()}"} | headers]
+
+      :error ->
+        headers
+    end
   end
 
   @spec api_key_header(header_list, String.t() | nil) :: header_list

--- a/lib/mobile_app_backend_web/controllers/schedule_controller.ex
+++ b/lib/mobile_app_backend_web/controllers/schedule_controller.ex
@@ -83,10 +83,13 @@ defmodule MobileAppBackendWeb.ScheduleController do
         ) ::
           %{schedules: [MBTAV3API.Schedule.t()], trips: JsonApi.Object.trip_map()} | :error
   defp fetch_schedules_parallel(filters, date_time, timeout, log_prefix) do
+    metadata = Logger.metadata()
+
     result =
       filters
       |> Task.async_stream(
         fn filter_params ->
+          Logger.metadata(metadata)
           {filter_params, fetch_schedules(filter_params, date_time)}
         end,
         ordered: false,

--- a/lib/mobile_app_backend_web/endpoint.ex
+++ b/lib/mobile_app_backend_web/endpoint.ex
@@ -44,6 +44,7 @@ defmodule MobileAppBackendWeb.Endpoint do
     cookie_key: "request_logger"
 
   plug Plug.RequestId
+  plug MobileAppBackendWeb.Plugs.LogUserAgent
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
 
   plug Plug.Parsers,

--- a/lib/mobile_app_backend_web/plugs/log_user_agent.ex
+++ b/lib/mobile_app_backend_web/plugs/log_user_agent.ex
@@ -1,0 +1,17 @@
+defmodule MobileAppBackendWeb.Plugs.LogUserAgent do
+  @behaviour Plug
+
+  def init(_) do
+    :ok
+  end
+
+  def call(conn, _) do
+    user_agent = conn |> Plug.Conn.get_req_header("user-agent") |> List.last()
+
+    if not is_nil(user_agent) do
+      Logger.metadata(user_agent: user_agent)
+    end
+
+    conn
+  end
+end

--- a/test/mbta_v3_api/headers_test.exs
+++ b/test/mbta_v3_api/headers_test.exs
@@ -19,4 +19,10 @@ defmodule MBTAV3API.HeadersTest do
              {"MBTA-Version", "3005-01-02"}
            ]
   end
+
+  test "derives an outgoing X-Request-Id from the current one" do
+    request_id = "1234567890"
+    Logger.metadata(request_id: request_id)
+    assert [{"X-Request-Id", ^request_id <> "/" <> _}] = Headers.build(nil)
+  end
 end

--- a/test/mobile_app_backend_web/controllers/schedule_controller_test.exs
+++ b/test/mobile_app_backend_web/controllers/schedule_controller_test.exs
@@ -1,4 +1,5 @@
 defmodule MobileAppBackendWeb.ScheduleControllerTest do
+  require Logger
   use MobileAppBackendWeb.ConnCase
   use HttpStub.Case
   import ExUnit.CaptureLog
@@ -781,6 +782,66 @@ defmodule MobileAppBackendWeb.ScheduleControllerTest do
                  "6" => %{}
                }
              } = json_response(conn, 200)
+    end
+
+    test "propagates log metadata when fetching in parallel", %{conn: conn} do
+      request_id = "req1234"
+      user_agent = "userAgent"
+
+      conn =
+        conn
+        |> put_req_header("x-request-id", request_id)
+        |> put_req_header("user-agent", user_agent)
+
+      reassign_env(
+        :mobile_app_backend,
+        MobileAppBackend.GlobalDataCache.Module,
+        GlobalDataCacheMock
+      )
+
+      GlobalDataCacheMock
+      |> stub(:default_key, fn -> :default_key end)
+      |> stub(:get_data, fn _ ->
+        %{
+          lines: %{},
+          pattern_ids_by_stop: %{},
+          routes: %{},
+          route_patterns: %{},
+          stops: %{},
+          trips: %{}
+        }
+      end)
+
+      RepositoryMock
+      |> expect(:schedules, 2, fn params, _ ->
+        filter_stop = params[:filter][:stop]
+        Logger.warning("schedules stop=#{filter_stop} pid=#{inspect(self())}")
+        ok_response([])
+      end)
+
+      {conn, log} =
+        with_log(fn ->
+          get(conn, "/api/schedules", %{
+            stop_ids: "1,2",
+            date_time: "2026-04-07T16:15:00-04:00"
+          })
+        end)
+
+      request_id = get_resp_header(conn, "x-request-id")
+      log_lines = String.split(log, "\n")
+
+      stop1_line = Enum.find(log_lines, &(&1 =~ "stop=1"))
+      stop2_line = Enum.find(log_lines, &(&1 =~ "stop=2"))
+
+      assert stop1_line =~ "request_id=#{request_id}"
+      assert stop1_line =~ "user_agent=#{user_agent}"
+      assert stop2_line =~ "request_id=#{request_id}"
+      assert stop2_line =~ "user_agent=#{user_agent}"
+
+      # double check that parallel fetch was actually used
+      stop1_pid = stop1_line |> String.split(" ") |> Enum.find(&(&1 =~ "pid="))
+      stop2_pid = stop2_line |> String.split(" ") |> Enum.find(&(&1 =~ "pid="))
+      assert stop1_pid != stop2_pid
     end
   end
 

--- a/test/mobile_app_backend_web/plugs/log_user_agent_test.exs
+++ b/test/mobile_app_backend_web/plugs/log_user_agent_test.exs
@@ -1,0 +1,11 @@
+defmodule MobileAppBackendWeb.Plugs.LogUserAgentTest do
+  use MobileAppBackendWeb.ConnCase
+
+  alias MobileAppBackendWeb.Plugs.LogUserAgent
+
+  test "puts user agent in logger metadata", %{conn: conn} do
+    user_agent = "Mozilla/5.0 (X11; Linux riscv64; rv:140.0) Servo/1.0.0 Firefox/140.0"
+    conn |> put_req_header("user-agent", user_agent) |> LogUserAgent.call(nil)
+    assert Keyword.fetch!(Logger.metadata(), :user_agent) == user_agent
+  end
+end


### PR DESCRIPTION
### Summary

_Ticket:_ [Add platform and app version to Splunk logs](https://app.asana.com/1/15492006741476/project/1205425564113216/task/1213889644889727)

Pairs with https://github.com/mbta/mobile_app/pull/1647.

I looked through the controllers and the only inter-process handoff is the parallel schedules fetch; I think all our stores are read from channels, and those don’t really have request IDs in the same way.