### PR TITLE
fix: Future alert reminder check

### DIFF
--- a/lib/mbta_v3_api/alert.ex
+++ b/lib/mbta_v3_api/alert.ex
@@ -220,10 +220,11 @@ defmodule MBTAV3API.Alert do
 
   @spec all_clear?(t(), DateTime.t()) :: boolean()
   def all_clear?(alert, at_time) do
-    Enum.all?(
-      alert.active_period,
-      &(not is_nil(&1.end) and DateTime.before?(&1.end, at_time))
-    )
+    not is_nil(alert.closed_timestamp) and
+      Enum.all?(
+        alert.active_period,
+        &(not is_nil(&1.end) and DateTime.before?(&1.end, at_time))
+      )
   end
 
   @spec parse!(JsonApi.Item.t()) :: t()

--- a/lib/mbta_v3_api/alert.ex
+++ b/lib/mbta_v3_api/alert.ex
@@ -218,13 +218,10 @@ defmodule MBTAV3API.Alert do
     next_period(alert, now) != nil
   end
 
-  @spec all_clear?(t(), DateTime.t()) :: boolean()
-  def all_clear?(alert, at_time) do
+  @spec all_clear?(t()) :: boolean()
+  def all_clear?(alert) do
     not is_nil(alert.closed_timestamp) and
-      Enum.all?(
-        alert.active_period,
-        &(not is_nil(&1.end) and DateTime.before?(&1.end, at_time))
-      )
+      alert.closed_timestamp == alert.last_push_notification_timestamp
   end
 
   @spec parse!(JsonApi.Item.t()) :: t()
@@ -277,41 +274,20 @@ defmodule MBTAV3API.Alert do
     Enum.all?(alert.informed_entity, &(&1.stop != nil))
   end
 
-  @type significance :: :major | :secondary | :accessibility | :minor | nil
-
-  @spec significance(t(), DateTime.t() | nil) :: significance()
-  def significance(alert, at_time) do
-    intrinsic_significance = intrinsic_significance(alert)
-
-    max_significance =
-      cond do
-        # active now or checking intrinsic significance, use intrinsic
-        is_nil(at_time) or active?(alert, at_time) ->
-          :major
-
-        # upcoming, show as secondary if will be major later
-        active_soon?(alert, at_time) ->
-          :secondary
-
-        # all clear
-        all_clear?(alert, at_time) ->
-          :major
-
-        # will be active later but not soon enough to show yet, hide completely
-        true ->
-          nil
-      end
-
-    Enum.min([intrinsic_significance, max_significance], &(compare_significance(&1, &2) != :gt))
+  @spec can_notify?(t(), DateTime.t()) :: boolean()
+  def can_notify?(alert, now \\ DateTime.now!("America/New_York")) do
+    active?(alert, now) or active_soon?(alert, now) or all_clear?(alert)
   end
 
-  defp intrinsic_significance(alert)
+  @type significance :: :major | :secondary | :accessibility | :minor | nil
 
-  defp intrinsic_significance(%__MODULE__{effect: e}) when e in [:shuttle, :suspension],
+  def significance(alert)
+
+  def significance(%__MODULE__{effect: e}) when e in [:shuttle, :suspension],
     do: :major
 
-  defp intrinsic_significance(%__MODULE__{effect: e} = alert)
-       when e in [:station_closure, :stop_closure, :dock_closure, :detour, :snow_route] do
+  def significance(%__MODULE__{effect: e} = alert)
+      when e in [:station_closure, :stop_closure, :dock_closure, :detour, :snow_route] do
     if has_stops_specified(alert) do
       :major
     else
@@ -319,11 +295,11 @@ defmodule MBTAV3API.Alert do
     end
   end
 
-  defp intrinsic_significance(%__MODULE__{effect: :service_change}), do: :secondary
-  defp intrinsic_significance(%__MODULE__{effect: :elevator_closure}), do: :accessibility
-  defp intrinsic_significance(%__MODULE__{effect: :track_change}), do: :minor
+  def significance(%__MODULE__{effect: :service_change}), do: :secondary
+  def significance(%__MODULE__{effect: :elevator_closure}), do: :accessibility
+  def significance(%__MODULE__{effect: :track_change}), do: :minor
 
-  defp intrinsic_significance(%__MODULE__{effect: :delay} = alert) do
+  def significance(%__MODULE__{effect: :delay} = alert) do
     if (alert.severity >= 3 and Enum.any?(alert.informed_entity, &(&1.route_type != :bus))) or
          alert.cause == :single_tracking do
       :minor
@@ -334,9 +310,9 @@ defmodule MBTAV3API.Alert do
 
   # in the frontend, we treat cancellation alerts as minor, since we don’t want to show an icon in nearby transit
   # but in the backend, we still want to treat them as significant enough to be sent
-  defp intrinsic_significance(%__MODULE__{effect: :cancellation}), do: :secondary
+  def significance(%__MODULE__{effect: :cancellation}), do: :secondary
 
-  defp intrinsic_significance(_), do: nil
+  def significance(_), do: nil
 
   @spec compare_significance(significance(), significance()) :: :lt | :eq | :gt
   def compare_significance(s1, s2) do
@@ -439,7 +415,7 @@ defmodule MBTAV3API.Alert do
       Enum.filter(
         alerts,
         &(has_stops_specified(&1) and
-            compare_significance(significance(&1, nil), :accessibility) != :lt)
+            compare_significance(significance(&1), :accessibility) != :lt)
       )
 
     target_stop_alert_ids =

--- a/lib/mobile_app_backend/alerts/alert_summary.ex
+++ b/lib/mobile_app_backend/alerts/alert_summary.ex
@@ -392,7 +392,7 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
           GlobalDataCache.data()
         ) :: t()
   def summarizing(alert, stop_id, direction_id, patterns, at_time, schedules, global) do
-    with nil <- all_clear_summary(alert, stop_id, direction_id, patterns, at_time, global),
+    with nil <- all_clear_summary(alert, stop_id, direction_id, patterns, global),
          nil <-
            TripSpecific.summary(
              alert,
@@ -512,11 +512,10 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
           Stop.id(),
           0 | 1,
           [RoutePattern.t()],
-          DateTime.t(),
           GlobalDataCache.data()
         ) :: AllClear.t() | nil
-  defp all_clear_summary(alert, stop_id, direction_id, patterns, at_time, global) do
-    if Alert.all_clear?(alert, at_time) do
+  defp all_clear_summary(alert, stop_id, direction_id, patterns, global) do
+    if Alert.all_clear?(alert) do
       %AllClear{location: alert_location(alert, stop_id, direction_id, patterns, global)}
     end
   end

--- a/lib/mobile_app_backend/notifications/delivered_notification.ex
+++ b/lib/mobile_app_backend/notifications/delivered_notification.ex
@@ -5,7 +5,7 @@ defmodule MobileAppBackend.Notifications.DeliveredNotification do
   alias MobileAppBackend.Repo
   alias MobileAppBackend.User
 
-  @type type :: :notification | {:reminder, DateTime.t()} | :all_clear
+  @type type :: :reminder | {:notification, DateTime.t()} | :all_clear
 
   @primary_key {:id, :binary_id, autogenerate: true}
   typed_schema "delivered_notifications" do

--- a/lib/mobile_app_backend/notifications/engine.ex
+++ b/lib/mobile_app_backend/notifications/engine.ex
@@ -165,8 +165,7 @@ defmodule MobileAppBackend.Notifications.Engine do
     active_now? = next_overlap_in_hours <= 0
 
     cond do
-      open_now? and not is_nil(alert.closed_timestamp) and
-          alert.closed_timestamp == alert.last_push_notification_timestamp ->
+      open_now? and Alert.all_clear?(alert) ->
         {alert, :all_clear, subscription}
 
       is_nil(next_overlap) ->

--- a/lib/mobile_app_backend/notifications/scheduler.ex
+++ b/lib/mobile_app_backend/notifications/scheduler.ex
@@ -40,7 +40,7 @@ defmodule MobileAppBackend.Notifications.Scheduler do
     active_now_or_soon? =
       alert.active_period
       |> Enum.any?(fn %Alert.ActivePeriod{start: active_start, end: active_end} ->
-        start_hours_away = DateTime.diff(now, active_start, :hour)
+        start_hours_away = DateTime.diff(active_start, now, :hour)
         ends_in_future? = is_nil(active_end) or DateTime.compare(active_end, now) != :lt
 
         start_hours_away < 24 and ends_in_future?

--- a/lib/mobile_app_backend/notifications/scheduler.ex
+++ b/lib/mobile_app_backend/notifications/scheduler.ex
@@ -35,16 +35,9 @@ defmodule MobileAppBackend.Notifications.Scheduler do
     # to send anything, the alert must be significant
     significant? = Alert.significance(alert, now) != nil
 
-    # to send a reminder, the alert must be active at some point within the next 24h
     # to send a notification, the alert must be active right now
-    active_now_or_soon? =
-      alert.active_period
-      |> Enum.any?(fn %Alert.ActivePeriod{start: active_start, end: active_end} ->
-        start_hours_away = DateTime.diff(active_start, now, :hour)
-        ends_in_future? = is_nil(active_end) or DateTime.compare(active_end, now) != :lt
-
-        start_hours_away < 24 and ends_in_future?
-      end)
+    # to send a reminder, the alert must be active at some point within the next 24h
+    active_now_or_soon? = Alert.active?(alert, now) or Alert.active_soon?(alert, now)
 
     # to send an all clear, the alert must have an all clear timestamp
     all_clear? = not is_nil(alert.closed_timestamp)

--- a/lib/mobile_app_backend/notifications/scheduler.ex
+++ b/lib/mobile_app_backend/notifications/scheduler.ex
@@ -32,7 +32,7 @@ defmodule MobileAppBackend.Notifications.Scheduler do
 
   @spec filter_alert(Alert.t(), DateTime.t()) :: boolean()
   defp filter_alert(%Alert{} = alert, now) do
-    Alert.significance(alert, now) != nil
+    Alert.significance(alert) != nil && Alert.can_notify?(alert, now)
   catch
     :exit, error ->
       Logger.error(

--- a/lib/mobile_app_backend/notifications/scheduler.ex
+++ b/lib/mobile_app_backend/notifications/scheduler.ex
@@ -32,17 +32,7 @@ defmodule MobileAppBackend.Notifications.Scheduler do
 
   @spec filter_alert(Alert.t(), DateTime.t()) :: boolean()
   defp filter_alert(%Alert{} = alert, now) do
-    # to send anything, the alert must be significant
-    significant? = Alert.significance(alert, now) != nil
-
-    # to send a notification, the alert must be active right now
-    # to send a reminder, the alert must be active at some point within the next 24h
-    active_now_or_soon? = Alert.active?(alert, now) or Alert.active_soon?(alert, now)
-
-    # to send an all clear, the alert must have an all clear timestamp
-    all_clear? = not is_nil(alert.closed_timestamp)
-
-    significant? and (active_now_or_soon? or all_clear?)
+    Alert.significance(alert, now) != nil
   catch
     :exit, error ->
       Logger.error(

--- a/test/mbta_v3_api/alert_test.exs
+++ b/test/mbta_v3_api/alert_test.exs
@@ -361,7 +361,7 @@ defmodule MBTAV3API.AlertTest do
             _ -> nil
           end
 
-        actual_significance = Alert.significance(alert, nil)
+        actual_significance = Alert.significance(alert)
 
         assert actual_significance == expected_significance,
                Enum.join(
@@ -423,12 +423,12 @@ defmodule MBTAV3API.AlertTest do
         severity: 1
       )
 
-    assert Alert.significance(subway_delay_severe, nil) == :minor
-    assert Alert.significance(cr_delay_severe, nil) == :minor
-    assert Alert.significance(ferry_delay_severe, nil) == :minor
-    assert Alert.significance(single_tracking_delay_info, nil) == :minor
-    assert Alert.significance(subway_delay_not_severe, nil) == nil
-    assert Alert.significance(bus_delay_severe, nil) == nil
+    assert Alert.significance(subway_delay_severe) == :minor
+    assert Alert.significance(cr_delay_severe) == :minor
+    assert Alert.significance(ferry_delay_severe) == :minor
+    assert Alert.significance(single_tracking_delay_info) == :minor
+    assert Alert.significance(subway_delay_not_severe) == nil
+    assert Alert.significance(bus_delay_severe) == nil
   end
 
   describe "recurrence_range/1" do
@@ -527,22 +527,29 @@ defmodule MBTAV3API.AlertTest do
     end
   end
 
-  test "alert significance limited for upcoming and past alerts" do
+  test "alert can notify based on timeframe and closed status" do
     alert_start = DateTime.now!("America/New_York")
     alert_end = DateTime.add(alert_start, 2, :hour)
 
-    alert =
+    open_alert =
+      build(:alert,
+        effect: :suspension,
+        active_period: [%Alert.ActivePeriod{start: alert_start, end: alert_end}]
+      )
+
+    closed_alert =
       build(:alert,
         effect: :suspension,
         active_period: [%Alert.ActivePeriod{start: alert_start, end: alert_end}],
-        closed_timestamp: alert_end
+        closed_timestamp: alert_end,
+        last_push_notification_timestamp: alert_end
       )
 
-    assert Alert.significance(alert, nil) == :major
-    assert Alert.significance(alert, DateTime.add(alert_start, -25, :hour)) == nil
-    assert Alert.significance(alert, DateTime.add(alert_start, -12, :hour)) == :secondary
-    assert Alert.significance(alert, alert_start) == :major
-    assert Alert.significance(alert, DateTime.add(alert_end, 1, :minute)) == :major
+    assert Alert.can_notify?(open_alert, DateTime.add(alert_start, -25, :hour)) == false
+    assert Alert.can_notify?(open_alert, DateTime.add(alert_start, -12, :hour)) == true
+    assert Alert.can_notify?(open_alert, alert_start) == true
+    assert Alert.can_notify?(open_alert, DateTime.add(alert_end, 1, :minute)) == false
+    assert Alert.can_notify?(closed_alert, DateTime.add(alert_end, 1, :minute)) == true
   end
 
   test "alert all clear returns correctly" do
@@ -553,11 +560,11 @@ defmodule MBTAV3API.AlertTest do
       build(:alert,
         effect: :suspension,
         active_period: [%Alert.ActivePeriod{start: alert_start, end: alert_end}],
-        closed_timestamp: alert_end
+        closed_timestamp: alert_end,
+        last_push_notification_timestamp: alert_end
       )
 
-    assert Alert.all_clear?(alert, alert_start) == false
-    assert Alert.all_clear?(alert, DateTime.add(alert_end, 1, :minute)) == true
+    assert Alert.all_clear?(alert) == true
   end
 
   test "filter filters alerts to matching stops routes and directions" do

--- a/test/mbta_v3_api/alert_test.exs
+++ b/test/mbta_v3_api/alert_test.exs
@@ -534,7 +534,8 @@ defmodule MBTAV3API.AlertTest do
     alert =
       build(:alert,
         effect: :suspension,
-        active_period: [%Alert.ActivePeriod{start: alert_start, end: alert_end}]
+        active_period: [%Alert.ActivePeriod{start: alert_start, end: alert_end}],
+        closed_timestamp: alert_end
       )
 
     assert Alert.significance(alert, nil) == :major
@@ -551,7 +552,8 @@ defmodule MBTAV3API.AlertTest do
     alert =
       build(:alert,
         effect: :suspension,
-        active_period: [%Alert.ActivePeriod{start: alert_start, end: alert_end}]
+        active_period: [%Alert.ActivePeriod{start: alert_start, end: alert_end}],
+        closed_timestamp: alert_end
       )
 
     assert Alert.all_clear?(alert, alert_start) == false

--- a/test/mobile_app_backend/alerts/alert_summary_test.exs
+++ b/test/mobile_app_backend/alerts/alert_summary_test.exs
@@ -1118,7 +1118,8 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
 
       alert =
         build(:alert,
-          active_period: [%Alert.ActivePeriod{start: start_time, end: end_time}]
+          active_period: [%Alert.ActivePeriod{start: start_time, end: end_time}],
+          closed_timestamp: end_time
         )
 
       assert %AlertSummary.AllClear{location: nil} =

--- a/test/mobile_app_backend/alerts/alert_summary_test.exs
+++ b/test/mobile_app_backend/alerts/alert_summary_test.exs
@@ -1119,7 +1119,8 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
       alert =
         build(:alert,
           active_period: [%Alert.ActivePeriod{start: start_time, end: end_time}],
-          closed_timestamp: end_time
+          closed_timestamp: end_time,
+          last_push_notification_timestamp: end_time
         )
 
       assert %AlertSummary.AllClear{location: nil} =

--- a/test/mobile_app_backend/notifications/scheduler_test.exs
+++ b/test/mobile_app_backend/notifications/scheduler_test.exs
@@ -223,4 +223,122 @@ defmodule MobileAppBackend.Notifications.SchedulerTest do
 
     refute_enqueued(worker: Notifications.Deliverer)
   end
+
+  test "sends all clear notifications" do
+    now = DateTime.now!("America/New_York")
+
+    alert =
+      build(:alert,
+        active_period: [
+          %MBTAV3API.Alert.ActivePeriod{
+            start: DateTime.add(now, -25, :hour),
+            end: DateTime.add(now, -4, :minute)
+          }
+        ],
+        effect: :suspension,
+        informed_entity: [
+          %MBTAV3API.Alert.InformedEntity{
+            activities: [:board, :exit, :ride],
+            route: "66",
+            route_type: :bus
+          }
+        ],
+        last_push_notification_timestamp: DateTime.add(now, -20, :minute),
+        closed_timestamp: DateTime.add(now, -20, :minute)
+      )
+
+    user = NotificationsFactory.insert(:user)
+
+    NotificationsFactory.insert(:notification_subscription,
+      user_id: user.id,
+      route_id: "66",
+      stop_id: "1",
+      direction_id: 0,
+      windows: [NotificationsFactory.perpetual_window_factory()]
+    )
+
+    Repo.insert!(%DeliveredNotification{
+      user_id: user.id,
+      alert_id: alert.id,
+      type: :notification,
+      upstream_timestamp:
+        DateTime.add(now, -3, :hour)
+        |> DateTime.shift_zone!("Etc/UTC")
+        |> DateTime.truncate(:second)
+    })
+
+    start_link_supervised!(Store.Alerts)
+    Store.Alerts.process_reset([alert], [])
+    {:ok, _} = perform_job(MobileAppBackend.Notifications.Scheduler, %{})
+
+    assert_enqueued(
+      worker: Notifications.Deliverer,
+      args: %{
+        "user_id" => user.id,
+        "alert_id" => alert.id,
+        "title" => %{
+          "type" => "mode_label",
+          "label" => "66",
+          "mode" => "bus"
+        },
+        "summary" => %{
+          "type" => "all_clear",
+          "location" => nil
+        },
+        "subscriptions" => [%{"route" => "66", "stop" => "1", "direction" => 0}],
+        "type" => "all_clear",
+        "upstream_timestamp" => nil
+      }
+    )
+  end
+
+  test "skips notifications that have ended without a closed timestamp" do
+    now = DateTime.now!("America/New_York")
+
+    alert =
+      build(:alert,
+        active_period: [
+          %MBTAV3API.Alert.ActivePeriod{
+            start: DateTime.add(now, -25, :hour),
+            end: DateTime.add(now, -4, :minute)
+          }
+        ],
+        effect: :suspension,
+        informed_entity: [
+          %MBTAV3API.Alert.InformedEntity{
+            activities: [:board, :exit, :ride],
+            route: "66",
+            route_type: :bus
+          }
+        ],
+        last_push_notification_timestamp: DateTime.add(now, -20, :minute),
+        closed_timestamp: nil
+      )
+
+    user = NotificationsFactory.insert(:user)
+
+    NotificationsFactory.insert(:notification_subscription,
+      user_id: user.id,
+      route_id: "66",
+      stop_id: "1",
+      direction_id: 0,
+      windows: [NotificationsFactory.perpetual_window_factory()]
+    )
+
+    Repo.insert!(%DeliveredNotification{
+      user_id: user.id,
+      alert_id: alert.id,
+      type: :notification,
+      upstream_timestamp:
+        DateTime.add(now, -3, :hour)
+        |> DateTime.shift_zone!("Etc/UTC")
+        |> DateTime.truncate(:second)
+    })
+
+    start_link_supervised!(Store.Alerts)
+    Store.Alerts.process_reset([alert], [])
+    {:ok, _} = perform_job(MobileAppBackend.Notifications.Scheduler, %{})
+
+    refute_enqueued(worker: Notifications.Deliverer)
+  end
 end

--- a/test/mobile_app_backend/notifications/scheduler_test.exs
+++ b/test/mobile_app_backend/notifications/scheduler_test.exs
@@ -15,7 +15,7 @@ defmodule MobileAppBackend.Notifications.SchedulerTest do
       build(:alert,
         active_period: [
           %MBTAV3API.Alert.ActivePeriod{
-            start: DateTime.add(now, -10, :minute),
+            start: DateTime.add(now, -48, :hour),
             end: DateTime.add(now, 10, :minute)
           }
         ],
@@ -118,6 +118,103 @@ defmodule MobileAppBackend.Notifications.SchedulerTest do
           days_of_week: [Date.day_of_week(now)]
         )
       ]
+    )
+
+    start_link_supervised!(Store.Alerts)
+    Store.Alerts.process_reset([alert], [])
+    {:ok, _} = perform_job(MobileAppBackend.Notifications.Scheduler, %{})
+
+    refute_enqueued(worker: Notifications.Deliverer)
+  end
+
+  test "sends notifications preminders starting less than a day in the future" do
+    now = DateTime.now!("America/New_York")
+
+    alert =
+      build(:alert,
+        active_period: [
+          %MBTAV3API.Alert.ActivePeriod{
+            start: DateTime.add(now, 22, :hour),
+            end: DateTime.add(now, 27, :hour)
+          }
+        ],
+        effect: :suspension,
+        informed_entity: [
+          %MBTAV3API.Alert.InformedEntity{
+            activities: [:board, :exit, :ride],
+            route: "66",
+            route_type: :bus
+          }
+        ],
+        last_push_notification_timestamp: DateTime.add(now, -1, :minute)
+      )
+
+    user = NotificationsFactory.insert(:user)
+
+    NotificationsFactory.insert(:notification_subscription,
+      user_id: user.id,
+      route_id: "66",
+      stop_id: "1",
+      direction_id: 0,
+      windows: [NotificationsFactory.perpetual_window_factory()]
+    )
+
+    start_link_supervised!(Store.Alerts)
+    Store.Alerts.process_reset([alert], [])
+    {:ok, _} = perform_job(MobileAppBackend.Notifications.Scheduler, %{})
+
+    assert_enqueued(
+      worker: Notifications.Deliverer,
+      args: %{
+        "user_id" => user.id,
+        "alert_id" => alert.id,
+        "title" => %{
+          "type" => "mode_label",
+          "label" => "66",
+          "mode" => "bus"
+        },
+        "summary" => %{
+          "effect" => "suspension",
+          "location" => nil,
+          "timeframe" => %{"type" => "starting_tomorrow"}
+        },
+        "subscriptions" => [%{"route" => "66", "stop" => "1", "direction" => 0}],
+        "type" => "reminder",
+        "upstream_timestamp" => nil
+      }
+    )
+  end
+
+  test "skips notifications over a day in the future" do
+    now = DateTime.now!("America/New_York")
+
+    alert =
+      build(:alert,
+        active_period: [
+          %MBTAV3API.Alert.ActivePeriod{
+            start: DateTime.add(now, 25, :hour),
+            end: DateTime.add(now, 27, :hour)
+          }
+        ],
+        effect: :suspension,
+        informed_entity: [
+          %MBTAV3API.Alert.InformedEntity{
+            activities: [:board, :exit, :ride],
+            route: "66",
+            route_type: :bus
+          }
+        ],
+        last_push_notification_timestamp: DateTime.add(now, -1, :minute)
+      )
+
+    user = NotificationsFactory.insert(:user)
+
+    NotificationsFactory.insert(:notification_subscription,
+      user_id: user.id,
+      route_id: "66",
+      stop_id: "1",
+      direction_id: 0,
+      windows: [NotificationsFactory.perpetual_window_factory()]
     )
 
     start_link_supervised!(Store.Alerts)


### PR DESCRIPTION
### Summary

_Ticket:_ [Notifications QA | no notifications sent for future alerts with trips specified](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1213994843939436?focus=true)

I'm a bit cautious of this change, but looking at the sequence of #397, #414, and #419, I'm pretty sure the current alert filtering is doing some redundant checks within both the scheduler filter and the significance check.

First, in #397, the alert filter was added in the scheduler, and `significance` was just doing the now `intrinsic_significance` checks. It also mixes up the params to `DateTime.diff`, which results in all future alerts getting through the filter no matter how far in the future they become active, and filters out any alerts that became active > 24 hours in the past. It also does the `all_clear?` check just by checking the presence of the closed timestamp.

Then, #414 added the max significance checks and the `active_soon?` helper (with the params in the right order), which makes the timeframe check in the scheduler redundant, because any alert that doesn't have an active/upcoming/past period will have a nil significance.

Then #419 adds the `Alert.all_clear?` function, which checks that all the active periods are in the past, but ignores the presence of the closed timestamp.

So in these changes, I added the closed timestamp check to `Alert.all_clear?`, it's only used in `AlertSummary.all_clear_summary` and `Alert.significance`, and I'm pretty sure both of them should be taking the closed timestamp into account. Then, since `Alert.significance` is checking both that the alert is either active, upcoming, or all clear, it should no longer be necessary to do those checks within the scheduler, and we can just check that the significance is non-nil.

We also recently added the check on [engine.ex#L169](https://github.com/mbta/mobile_app_backend/blob/main/lib/mobile_app_backend/notifications/engine.ex#L169) which only creates all clears when `alert.closed_timestamp == alert.last_push_notification_timestamp`. Would it also make sense to include that in `Alert.all_clear?`, then switch the engine check to also use that? Maybe the active periods being in the past don't matter in any of these cases and we can just use the closed timestamp being non-null and equal to the last push timestamp?

I'm not actually sure how this would prevent reminders, since negative times are still less than 24, and this change should make future alerts notify less frequently (but more correctly). Alerts over 24 hours in the future should also have still not been sent, because they would have a nil significance, so this would have only erroneously prevented alerts that started over 24 hours in the past from being sent. That said, I'm seeing trip specific notifications for alerts with future active periods now, so either this did fix it, or there was something else going wrong with the testing when this was reported.

## Testing

I added a few new tests to ensure that future alerts and all clears are being filtered properly, and did some manual testing with all clears and trip specific suspensions in dev.