### PR TITLE
fix: Send all clear notifications after reminder

### DIFF
--- a/lib/mobile_app_backend/notifications/delivered_notification.ex
+++ b/lib/mobile_app_backend/notifications/delivered_notification.ex
@@ -46,7 +46,9 @@ defmodule MobileAppBackend.Notifications.DeliveredNotification do
   def can_send?(user_id, alert_id, :all_clear) do
     Repo.aggregate(
       from(dn in __MODULE__,
-        where: dn.user_id == ^user_id and dn.alert_id == ^alert_id and dn.type == :notification
+        where:
+          dn.user_id == ^user_id and dn.alert_id == ^alert_id and
+            (dn.type == :notification or dn.type == :reminder)
       ),
       :count
     ) > 0 and

--- a/test/mobile_app_backend/notifications/delivered_notification_test.exs
+++ b/test/mobile_app_backend/notifications/delivered_notification_test.exs
@@ -117,6 +117,20 @@ defmodule MobileAppBackend.Notifications.DeliveredNotificationTest do
       assert DeliveredNotification.can_send?(user.id, alert_id, :all_clear)
     end
 
+    test "all clear if reminded and not all clear" do
+      user = insert(:user)
+      alert_id = "3"
+
+      Repo.insert!(%DeliveredNotification{
+        user_id: user.id,
+        alert_id: alert_id,
+        upstream_timestamp: ~U[2025-12-04 13:11:00Z],
+        type: :reminder
+      })
+
+      assert DeliveredNotification.can_send?(user.id, alert_id, :all_clear)
+    end
+
     test "no all clear if already all clear" do
       user = insert(:user)
       alert_id = "3"


### PR DESCRIPTION
### Summary

_Ticket:_ [Slack thread](https://mbta.slack.com/archives/C05QMG9GS9M/p1776100818533149)

Update the check to see if an all clear should be sent to also include previous reminders for upcoming alerts, not just for previous active notifications.
