### PR TITLE
feat: read and expand schedules’ added routes

### DIFF
--- a/lib/mbta_v3_api/schedule.ex
+++ b/lib/mbta_v3_api/schedule.ex
@@ -10,6 +10,7 @@ defmodule MBTAV3API.Schedule do
           pick_up_type: stop_edge_type(),
           stop_headsign: String.t() | nil,
           stop_sequence: integer(),
+          added_route_ids: [String.t()] | nil,
           route_id: String.t(),
           stop_id: String.t() | nil,
           trip_id: String.t() | nil
@@ -30,6 +31,7 @@ defmodule MBTAV3API.Schedule do
     :pick_up_type,
     :stop_headsign,
     :stop_sequence,
+    :added_route_ids,
     :route_id,
     :stop_id,
     :trip_id
@@ -47,7 +49,14 @@ defmodule MBTAV3API.Schedule do
     ]
 
   @impl JsonApi.Object
-  def includes, do: %{route: MBTAV3API.Route, stop: MBTAV3API.Stop, trip: MBTAV3API.Trip}
+  def includes do
+    %{
+      added_routes: MBTAV3API.Route,
+      route: MBTAV3API.Route,
+      stop: MBTAV3API.Stop,
+      trip: MBTAV3API.Trip
+    }
+  end
 
   @spec parse!(JsonApi.Item.t()) :: t()
   def parse!(%JsonApi.Item{} = item) do
@@ -59,9 +68,23 @@ defmodule MBTAV3API.Schedule do
       pick_up_type: parse_stop_edge_type!(item.attributes["pickup_type"]),
       stop_headsign: item.attributes["stop_headsign"],
       stop_sequence: item.attributes["stop_sequence"],
+      added_route_ids: JsonApi.Object.get_many_ids(item.relationships["added_routes"]),
       route_id: JsonApi.Object.get_one_id(item.relationships["route"]),
       stop_id: JsonApi.Object.get_one_id(item.relationships["stop"]),
       trip_id: JsonApi.Object.get_one_id(item.relationships["trip"])
     }
+  end
+
+  @spec expand_added_routes(t()) :: [t()]
+  def expand_added_routes(%__MODULE__{} = schedule) do
+    [schedule] ++
+      for added_route_id <- schedule.added_route_ids || [] do
+        %__MODULE__{
+          schedule
+          | id: "#{schedule.id}+r#{added_route_id}",
+            route_id: added_route_id,
+            added_route_ids: []
+        }
+      end
   end
 end

--- a/lib/mobile_app_backend_web/controllers/schedule_controller.ex
+++ b/lib/mobile_app_backend_web/controllers/schedule_controller.ex
@@ -4,6 +4,7 @@ defmodule MobileAppBackendWeb.ScheduleController do
 
   alias MBTAV3API.JsonApi
   alias MBTAV3API.Repository
+  alias MBTAV3API.Schedule
   alias MBTAV3API.Stop
   alias MobileAppBackend.GlobalDataCache
 
@@ -81,7 +82,7 @@ defmodule MobileAppBackendWeb.ScheduleController do
           integer(),
           String.t()
         ) ::
-          %{schedules: [MBTAV3API.Schedule.t()], trips: JsonApi.Object.trip_map()} | :error
+          %{schedules: [Schedule.t()], trips: JsonApi.Object.trip_map()} | :error
   defp fetch_schedules_parallel(filters, date_time, timeout, log_prefix) do
     metadata = Logger.metadata()
 
@@ -119,44 +120,43 @@ defmodule MobileAppBackendWeb.ScheduleController do
   end
 
   @spec fetch_schedules([JsonApi.Params.filter_param()], DateTime.t()) ::
-          %{schedules: [MBTAV3API.Schedule.t()], trips: JsonApi.Object.trip_map()}
+          %{schedules: [Schedule.t()], trips: JsonApi.Object.trip_map()}
           | :error
   defp fetch_schedules(filter, date_time) do
     case Repository.schedules(filter: filter, include: :trip) do
       {:ok, %{data: schedules, included: %{trips: trips}}} ->
-        filter_past_schedules(schedules, trips, date_time)
+        schedules
+        |> Enum.flat_map(&Schedule.expand_added_routes/1)
+        |> filter_past_schedules(trips, date_time)
 
       _ ->
         :error
     end
   end
 
-  @spec last_schedule_grouping(MBTAV3API.Schedule.t(), MBTAV3API.Trip.t() | nil) ::
+  @spec last_schedule_grouping(Schedule.t(), MBTAV3API.Trip.t() | nil) ::
           {String.t(), integer() | nil}
   defp last_schedule_grouping(schedule, nil), do: {schedule.route_id, nil}
   defp last_schedule_grouping(schedule, trip), do: {schedule.route_id, trip.direction_id}
 
-  @spec compare_schedule_time(MBTAV3API.Schedule.t() | DateTime.t(), DateTime.t()) :: boolean()
-  defp compare_schedule_time(
-         %MBTAV3API.Schedule{departure_time: nil, arrival_time: nil},
-         _date_time
-       ),
-       do: true
+  @spec compare_schedule_time(Schedule.t() | DateTime.t(), DateTime.t()) :: boolean()
+  defp compare_schedule_time(%Schedule{departure_time: nil, arrival_time: nil}, _date_time),
+    do: true
 
   defp compare_schedule_time(
-         %MBTAV3API.Schedule{departure_time: nil, arrival_time: arrival_time},
+         %Schedule{departure_time: nil, arrival_time: arrival_time},
          date_time
        ),
        do: compare_schedule_time(arrival_time, date_time)
 
-  defp compare_schedule_time(%MBTAV3API.Schedule{departure_time: departure_time}, date_time),
+  defp compare_schedule_time(%Schedule{departure_time: departure_time}, date_time),
     do: compare_schedule_time(departure_time, date_time)
 
   defp compare_schedule_time(schedule_time, date_time),
     do: DateTime.compare(schedule_time, DateTime.add(date_time, -1, :hour)) != :lt
 
-  @spec filter_past_schedules([MBTAV3API.Schedule.t()], JsonApi.Object.trip_map(), DateTime.t()) ::
-          %{schedules: [MBTAV3API.Schedule.t()], trips: JsonApi.Object.trip_map()}
+  @spec filter_past_schedules([Schedule.t()], JsonApi.Object.trip_map(), DateTime.t()) ::
+          %{schedules: [Schedule.t()], trips: JsonApi.Object.trip_map()}
   defp filter_past_schedules(schedules, trips, date_time) do
     global_data = GlobalDataCache.get_data()
 

--- a/test/mbta_v3_api/schedule_test.exs
+++ b/test/mbta_v3_api/schedule_test.exs
@@ -17,6 +17,7 @@ defmodule MBTAV3API.ScheduleTest do
                "stop_sequence" => 90
              },
              relationships: %{
+               "added_routes" => [%JsonApi.Reference{type: "route", id: "1"}],
                "route" => %JsonApi.Reference{type: "route", id: "Green-D"},
                "stop" => %JsonApi.Reference{type: "stop", id: "70159"},
                "trip" => %JsonApi.Reference{type: "trip", id: "60565179"}
@@ -29,6 +30,7 @@ defmodule MBTAV3API.ScheduleTest do
              pick_up_type: :regular,
              stop_headsign: "abc",
              stop_sequence: 90,
+             added_route_ids: ["1"],
              route_id: "Green-D",
              stop_id: "70159",
              trip_id: "60565179"

--- a/test/mobile_app_backend_web/controllers/schedule_controller_test.exs
+++ b/test/mobile_app_backend_web/controllers/schedule_controller_test.exs
@@ -843,6 +843,129 @@ defmodule MobileAppBackendWeb.ScheduleControllerTest do
       stop2_pid = stop2_line |> String.split(" ") |> Enum.find(&(&1 =~ "pid="))
       assert stop1_pid != stop2_pid
     end
+
+    test "expands added routes", %{conn: conn} do
+      s1 =
+        %MBTAV3API.Schedule{
+          id: "schedule-60565179-70159-90",
+          arrival_time: ~B[2024-03-13 01:07:00],
+          departure_time: ~B[2024-03-13 01:07:00],
+          drop_off_type: :regular,
+          pick_up_type: :regular,
+          stop_sequence: 90,
+          added_route_ids: ["Green-C"],
+          route_id: "Green-B",
+          stop_id: "70159",
+          trip_id: "60565179"
+        }
+
+      s2 = %MBTAV3API.Schedule{
+        id: "schedule-60565145-70158-590",
+        arrival_time: "2024-03-13T01:15:00-04:00",
+        departure_time: "2024-03-13T01:15:00-04:00",
+        drop_off_type: :regular,
+        pick_up_type: :regular,
+        stop_sequence: 590,
+        added_route_ids: ["Green-B"],
+        route_id: "Green-C",
+        stop_id: "70158",
+        trip_id: "60565145"
+      }
+
+      t1 = build(:trip, id: s1.trip_id)
+      t2 = build(:trip, id: s2.trip_id)
+
+      reassign_env(
+        :mobile_app_backend,
+        MobileAppBackend.GlobalDataCache.Module,
+        GlobalDataCacheMock
+      )
+
+      GlobalDataCacheMock
+      |> expect(:default_key, 2, fn -> :default_key end)
+      |> expect(:get_data, 2, fn _ ->
+        %{
+          lines: %{},
+          pattern_ids_by_stop: %{},
+          routes: %{"Green-C" => %{type: :light_rail}, "Green-B" => %{type: :light_rail}},
+          route_patterns: %{},
+          stops: %{},
+          trips: %{}
+        }
+      end)
+
+      RepositoryMock
+      |> expect(:schedules, fn params, _opts ->
+        assert [
+                 filter: [
+                   stop: "place-boyls",
+                   date: ~D[2024-03-12]
+                 ],
+                 include: :trip
+               ] = params
+
+        ok_response([s1, s2], [t1, t2])
+      end)
+
+      conn =
+        get(conn, "/api/schedules", %{
+          stop_ids: "place-boyls",
+          date_time: "2024-03-13T01:06:30-04:00"
+        })
+
+      assert %{
+               "schedules" => [
+                 %{
+                   "arrival_time" => "2024-03-13T01:07:00-04:00",
+                   "departure_time" => "2024-03-13T01:07:00-04:00",
+                   "drop_off_type" => "regular",
+                   "id" => "schedule-60565179-70159-90",
+                   "pick_up_type" => "regular",
+                   "route_id" => "Green-B",
+                   "stop_id" => "70159",
+                   "stop_sequence" => 90,
+                   "trip_id" => "60565179"
+                 },
+                 %{
+                   "arrival_time" => "2024-03-13T01:07:00-04:00",
+                   "departure_time" => "2024-03-13T01:07:00-04:00",
+                   "drop_off_type" => "regular",
+                   "id" => "schedule-60565179-70159-90+rGreen-C",
+                   "pick_up_type" => "regular",
+                   "route_id" => "Green-C",
+                   "stop_id" => "70159",
+                   "stop_sequence" => 90,
+                   "trip_id" => "60565179"
+                 },
+                 %{
+                   "arrival_time" => "2024-03-13T01:15:00-04:00",
+                   "departure_time" => "2024-03-13T01:15:00-04:00",
+                   "drop_off_type" => "regular",
+                   "id" => "schedule-60565145-70158-590",
+                   "pick_up_type" => "regular",
+                   "route_id" => "Green-C",
+                   "stop_id" => "70158",
+                   "stop_sequence" => 590,
+                   "trip_id" => "60565145"
+                 },
+                 %{
+                   "arrival_time" => "2024-03-13T01:15:00-04:00",
+                   "departure_time" => "2024-03-13T01:15:00-04:00",
+                   "drop_off_type" => "regular",
+                   "id" => "schedule-60565145-70158-590+rGreen-B",
+                   "pick_up_type" => "regular",
+                   "route_id" => "Green-B",
+                   "stop_id" => "70158",
+                   "stop_sequence" => 590,
+                   "trip_id" => "60565145"
+                 }
+               ],
+               "trips" => %{
+                 "60565145" => %{},
+                 "60565179" => %{}
+               }
+             } = json_response(conn, 200)
+    end
   end
 
   describe "trip schedules" do


### PR DESCRIPTION
### Summary

_Ticket:_ [Ensure multi-route schedules and predictions are correctly displayed](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1213913595242981?focus=true)

Reads https://github.com/mbta/api/pull/992 and turns a single schedule with added routes into multiple schedules. Creating multiple copies of the schedule in the backend means that we can treat schedules and predictions the same way in the frontend.