### PR TITLE
fix(Notifications.Scheduler): rescue exceptions, and fix one exception happening now

### DIFF
--- a/lib/mobile_app_backend/alerts/alert_summary.ex
+++ b/lib/mobile_app_backend/alerts/alert_summary.ex
@@ -209,11 +209,17 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
       patterns
       |> Enum.group_by(& &1.direction_id)
       |> Map.new(fn {direction_id, direction_patterns} ->
+        maybe_typical_patterns = Enum.find(direction_patterns, &(&1.typicality == :typical))
+
         stop_list =
-          get_stop_list_for_pattern(
-            Enum.find(direction_patterns, &(&1.typicality == :typical)),
-            global
-          )
+          if is_nil(maybe_typical_patterns) do
+            nil
+          else
+            get_stop_list_for_pattern(
+              maybe_typical_patterns,
+              global
+            )
+          end
 
         {direction_id, stop_list}
       end)

--- a/lib/mobile_app_backend/alerts/alert_summary.ex
+++ b/lib/mobile_app_backend/alerts/alert_summary.ex
@@ -189,6 +189,7 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
       end
     end
 
+    @spec get_stop_list_for_pattern(RoutePattern.t(), GlobalDataCache.data()) :: [Stop.id()]
     defp get_stop_list_for_pattern(pattern, global) do
       Enum.map(
         case global.trips[pattern.representative_trip_id] do
@@ -199,15 +200,21 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
       )
     end
 
+    @spec get_typical_stop_list_by_direction([RoutePattern.t()], GlobalDataCache.data()) :: %{integer() => [Stop.id()] | nil}
     defp get_typical_stop_list_by_direction(patterns, global) do
       patterns
       |> Enum.group_by(& &1.direction_id)
       |> Map.new(fn {direction_id, direction_patterns} ->
-        stop_list =
-          get_stop_list_for_pattern(
-            Enum.find(direction_patterns, &(&1.typicality == :typical)),
+        maybe_typical_patterns = Enum.find(direction_patterns, &(&1.typicality == :typical))
+
+        stop_list = if is_nil(maybe_typical_patterns) do
+        nil
+        else
+        get_stop_list_for_pattern(
+            maybe_typical_patterns,
             global
           )
+        end
 
         {direction_id, stop_list}
       end)

--- a/lib/mobile_app_backend/alerts/alert_summary.ex
+++ b/lib/mobile_app_backend/alerts/alert_summary.ex
@@ -209,17 +209,11 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
       patterns
       |> Enum.group_by(& &1.direction_id)
       |> Map.new(fn {direction_id, direction_patterns} ->
-        maybe_typical_patterns = Enum.find(direction_patterns, &(&1.typicality == :typical))
-
         stop_list =
-          if is_nil(maybe_typical_patterns) do
-            nil
-          else
-            get_stop_list_for_pattern(
-              maybe_typical_patterns,
-              global
-            )
-          end
+          get_stop_list_for_pattern(
+            Enum.find(direction_patterns, &(&1.typicality == :typical)),
+            global
+          )
 
         {direction_id, stop_list}
       end)

--- a/lib/mobile_app_backend/alerts/alert_summary.ex
+++ b/lib/mobile_app_backend/alerts/alert_summary.ex
@@ -139,6 +139,7 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
       end
     end
 
+    @spec get_directions_for_line(GlobalDataCache.data(), Stop.t(), [RoutePattern.t()]) :: [t()]
     def get_directions_for_line(global, stop, patterns) do
       directions_by_route =
         patterns
@@ -182,6 +183,7 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
     # This is hacky, but seemed like the best way to handle this case, where the Green Line has multiple routes which
     # terminate mid-line at Gov Center, but since those routes are served at the stop, it has non-null Direction objects
     # with Gov Center destinations. This checks if we have this specific case, and returns the North direction if we do.
+    @spec gov_center_special_case(%{(String.t() | nil) => t()}) :: t() | nil
     defp gov_center_special_case(directions_by_destination) do
       if Enum.sort(Map.keys(directions_by_destination)) ==
            Enum.sort(["Government Center", @north_station_destination]) do
@@ -200,21 +202,24 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
       )
     end
 
-    @spec get_typical_stop_list_by_direction([RoutePattern.t()], GlobalDataCache.data()) :: %{integer() => [Stop.id()] | nil}
+    @spec get_typical_stop_list_by_direction([RoutePattern.t()], GlobalDataCache.data()) :: %{
+            integer() => [Stop.id()] | nil
+          }
     defp get_typical_stop_list_by_direction(patterns, global) do
       patterns
       |> Enum.group_by(& &1.direction_id)
       |> Map.new(fn {direction_id, direction_patterns} ->
         maybe_typical_patterns = Enum.find(direction_patterns, &(&1.typicality == :typical))
 
-        stop_list = if is_nil(maybe_typical_patterns) do
-        nil
-        else
-        get_stop_list_for_pattern(
-            maybe_typical_patterns,
-            global
-          )
-        end
+        stop_list =
+          if is_nil(maybe_typical_patterns) do
+            nil
+          else
+            get_stop_list_for_pattern(
+              maybe_typical_patterns,
+              global
+            )
+          end
 
         {direction_id, stop_list}
       end)

--- a/lib/mobile_app_backend/alerts/alert_summary.ex
+++ b/lib/mobile_app_backend/alerts/alert_summary.ex
@@ -209,14 +209,14 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
       patterns
       |> Enum.group_by(& &1.direction_id)
       |> Map.new(fn {direction_id, direction_patterns} ->
-        maybe_typical_patterns = Enum.find(direction_patterns, &(&1.typicality == :typical))
+        maybe_typical_pattern = Enum.find(direction_patterns, &(&1.typicality == :typical))
 
         stop_list =
-          if is_nil(maybe_typical_patterns) do
+          if is_nil(maybe_typical_pattern) do
             nil
           else
             get_stop_list_for_pattern(
-              maybe_typical_patterns,
+              maybe_typical_pattern,
               global
             )
           end

--- a/lib/mobile_app_backend/application.ex
+++ b/lib/mobile_app_backend/application.ex
@@ -68,6 +68,7 @@ defmodule MobileAppBackend.Application do
     :ok = MobileAppBackend.Telemetry.WebsocketEventHandler.attach()
 
     :ok = Oban.Telemetry.attach_default_logger()
+    :telemetry.attach("oban-errors", [:oban, :job, :exception], &ObanLogger.handle_event/4, nil)
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options

--- a/lib/mobile_app_backend/notifications/scheduler.ex
+++ b/lib/mobile_app_backend/notifications/scheduler.ex
@@ -35,7 +35,12 @@ defmodule MobileAppBackend.Notifications.Scheduler do
     Alert.significance(alert) != nil && Alert.can_notify?(alert, now)
   rescue
     error ->
-      log_exception("process_alert", "alert=#{alert.id}", Exception.format(:error, error, __STACKTRACE__))
+      log_exception(
+        "process_alert",
+        "alert=#{alert.id}",
+        Exception.format(:error, error, __STACKTRACE__)
+      )
+
       false
   end
 

--- a/lib/mobile_app_backend/notifications/scheduler.ex
+++ b/lib/mobile_app_backend/notifications/scheduler.ex
@@ -86,44 +86,42 @@ defmodule MobileAppBackend.Notifications.Scheduler do
          alerts,
          now
        ) do
-    try do
-      {engine_us, outgoing_notifications} =
-        :timer.tc(&Engine.notifications/3, [subscriptions, alerts, now], :microsecond)
+    {engine_us, outgoing_notifications} =
+      :timer.tc(&Engine.notifications/3, [subscriptions, alerts, now], :microsecond)
 
-      Logger.info("#{__MODULE__} run_engine duration=#{engine_us}")
+    Logger.info("#{__MODULE__} run_engine duration=#{engine_us}")
 
-      Enum.flat_map(outgoing_notifications, fn outgoing_notification ->
-        try do
-          if DeliveredNotification.can_send?(
-               user_id,
-               outgoing_notification.alert.id,
-               outgoing_notification.type
-             ) do
-            [{user, outgoing_notification}]
-          else
-            []
-          end
-        rescue
-          error ->
-            log_exception(
-              "check_notification_sending",
-              "user_id=#{user_id} alert_id=#{outgoing_notification.alert.id}",
-              error
-            )
-
-            []
+    Enum.flat_map(outgoing_notifications, fn outgoing_notification ->
+      try do
+        if DeliveredNotification.can_send?(
+             user_id,
+             outgoing_notification.alert.id,
+             outgoing_notification.type
+           ) do
+          [{user, outgoing_notification}]
+        else
+          []
         end
-      end)
-    rescue
-      error ->
-        log_exception(
-          "find_new_notifications",
-          "user_id=#{user_id}",
-          error
-        )
+      rescue
+        error ->
+          log_exception(
+            "check_notification_sending",
+            "user_id=#{user_id} alert_id=#{outgoing_notification.alert.id}",
+            error
+          )
 
-        []
-    end
+          []
+      end
+    end)
+  rescue
+    error ->
+      log_exception(
+        "find_new_notifications",
+        "user_id=#{user_id}",
+        error
+      )
+
+      []
   end
 
   @spec enqueue_delivery([{User.t(), Engine.OutgoingNotification.t()}]) :: :ok

--- a/lib/mobile_app_backend/notifications/scheduler.ex
+++ b/lib/mobile_app_backend/notifications/scheduler.ex
@@ -33,12 +33,9 @@ defmodule MobileAppBackend.Notifications.Scheduler do
   @spec filter_alert(Alert.t(), DateTime.t()) :: boolean()
   defp filter_alert(%Alert{} = alert, now) do
     Alert.significance(alert) != nil && Alert.can_notify?(alert, now)
-  catch
-    :exit, error ->
-      Logger.error(
-        "#{__MODULE__} failed to process alert alert=#{alert.id} error=#{inspect(error)}"
-      )
-
+  rescue
+    error ->
+      log_exception("process_alert", "alert=#{alert.id}", error)
       false
   end
 
@@ -89,38 +86,44 @@ defmodule MobileAppBackend.Notifications.Scheduler do
          alerts,
          now
        ) do
-    {engine_us, outgoing_notifications} =
-      :timer.tc(&Engine.notifications/3, [subscriptions, alerts, now], :microsecond)
+    try do
+      {engine_us, outgoing_notifications} =
+        :timer.tc(&Engine.notifications/3, [subscriptions, alerts, now], :microsecond)
 
-    Logger.info("#{__MODULE__} run_engine duration=#{engine_us}")
+      Logger.info("#{__MODULE__} run_engine duration=#{engine_us}")
 
-    Enum.flat_map(outgoing_notifications, fn outgoing_notification ->
-      try do
-        if DeliveredNotification.can_send?(
-             user_id,
-             outgoing_notification.alert.id,
-             outgoing_notification.type
-           ) do
-          [{user, outgoing_notification}]
-        else
-          []
+      Enum.flat_map(outgoing_notifications, fn outgoing_notification ->
+        try do
+          if DeliveredNotification.can_send?(
+               user_id,
+               outgoing_notification.alert.id,
+               outgoing_notification.type
+             ) do
+            [{user, outgoing_notification}]
+          else
+            []
+          end
+        rescue
+          error ->
+            log_exception(
+              "check_notification_sending",
+              "user_id=#{user_id} alert_id=#{outgoing_notification.alert.id}",
+              error
+            )
+
+            []
         end
-      catch
-        :exit, error ->
-          Logger.error(
-            "#{__MODULE__} failed to check notification sending for user_id=#{user_id} alert_id=#{outgoing_notification.alert.id} error=#{inspect(error)}"
-          )
+      end)
+    rescue
+      error ->
+        log_exception(
+          "find_new_notifications",
+          "user_id=#{user_id}",
+          error
+        )
 
-          []
-      end
-    end)
-  catch
-    :exit, error ->
-      Logger.error(
-        "#{__MODULE__} failed to find new notifications for user_id=#{user_id} error=#{inspect(error)}"
-      )
-
-      []
+        []
+    end
   end
 
   @spec enqueue_delivery([{User.t(), Engine.OutgoingNotification.t()}]) :: :ok
@@ -155,12 +158,18 @@ defmodule MobileAppBackend.Notifications.Scheduler do
     }
     |> Deliverer.new()
     |> Oban.insert!()
-  catch
-    :exit, error ->
-      Logger.error(
-        "#{__MODULE__} failed to enqueue delivery for user_id=#{recipient.id} alert_id=#{notification.alert.id} error=#{inspect(error)}"
+  rescue
+    error ->
+      log_exception(
+        "enqueue_delivery",
+        "user_id=#{recipient.id} alert_id=#{notification.alert.id}",
+        error
       )
 
       :ok
+  end
+
+  defp log_exception(step_name, metadata, error) do
+    Logger.error("#{__MODULE__} failed #{step_name} #{metadata} error=#{inspect(error)}")
   end
 end

--- a/lib/mobile_app_backend/notifications/scheduler.ex
+++ b/lib/mobile_app_backend/notifications/scheduler.ex
@@ -35,7 +35,7 @@ defmodule MobileAppBackend.Notifications.Scheduler do
     Alert.significance(alert) != nil && Alert.can_notify?(alert, now)
   rescue
     error ->
-      log_exception("process_alert", "alert=#{alert.id}", error)
+      log_exception("process_alert", "alert=#{alert.id}", Exception.format(:error, error, __STACKTRACE__))
       false
   end
 
@@ -107,7 +107,7 @@ defmodule MobileAppBackend.Notifications.Scheduler do
           log_exception(
             "check_notification_sending",
             "user_id=#{user_id} alert_id=#{outgoing_notification.alert.id}",
-            error
+            Exception.format(:error, error, __STACKTRACE__)
           )
 
           []
@@ -118,7 +118,7 @@ defmodule MobileAppBackend.Notifications.Scheduler do
       log_exception(
         "find_new_notifications",
         "user_id=#{user_id}",
-        error
+        Exception.format(:error, error, __STACKTRACE__)
       )
 
       []
@@ -161,7 +161,7 @@ defmodule MobileAppBackend.Notifications.Scheduler do
       log_exception(
         "enqueue_delivery",
         "user_id=#{recipient.id} alert_id=#{notification.alert.id}",
-        error
+        Exception.format(:error, error, __STACKTRACE__)
       )
 
       :ok

--- a/lib/mobile_app_backend/oban_logger.ex
+++ b/lib/mobile_app_backend/oban_logger.ex
@@ -2,22 +2,8 @@ defmodule ObanLogger do
   require Logger
 
   def handle_event([:oban, :job, :exception], _, meta, nil) do
-    log_data = %{
-      worker: meta.worker,
-      id: meta.id,
-      meta: meta.meta,
-      state: meta.state,
-      max_attempts: meta.max_attempts,
-      queue: meta.queue,
-      source: meta.source,
-      event: meta.event,
-      duration: meta.duration,
-      attempt: meta.attempt,
-      queue_time: meta.queue_time,
-      error: meta.error,
-      stacktrace: Exception.format_stacktrace(meta.stacktrace)
-    }
-
-    Logger.error(Jason.encode!(log_data))
+    Logger.error(
+      "#{__MODULE__} job:exception id=#{meta.id} error=#{inspect(error)} stack_trace=#{inspect(Exception.format_stacktrace(meta.stacktrace))}"
+    )
   end
 end

--- a/lib/mobile_app_backend/oban_logger.ex
+++ b/lib/mobile_app_backend/oban_logger.ex
@@ -3,7 +3,7 @@ defmodule ObanLogger do
 
   def handle_event([:oban, :job, :exception], _, meta, nil) do
     Logger.error(
-      "#{__MODULE__} job:exception id=#{meta.id} error=#{inspect(error)} stack_trace=#{inspect(Exception.format_stacktrace(meta.stacktrace))}"
+      "#{__MODULE__} job:exception id=#{meta.id} error=#{inspect(meta.error)} stack_trace=#{inspect(Exception.format_stacktrace(meta.stacktrace))}"
     )
   end
 end

--- a/lib/mobile_app_backend/oban_logger.ex
+++ b/lib/mobile_app_backend/oban_logger.ex
@@ -1,0 +1,23 @@
+defmodule ObanLogger do
+  require Logger
+
+  def handle_event([:oban, :job, :exception], _, meta, nil) do
+    log_data = %{
+      worker: meta.worker,
+      id: meta.id,
+      meta: meta.meta,
+      state: meta.state,
+      max_attempts: meta.max_attempts,
+      queue: meta.queue,
+      source: meta.source,
+      event: meta.event,
+      duration: meta.duration,
+      attempt: meta.attempt,
+      queue_time: meta.queue_time,
+      error: meta.error,
+      stacktrace: Exception.format_stacktrace(meta.stacktrace)
+    }
+
+    Logger.error(Jason.encode!(log_data))
+  end
+end

--- a/test/mobile_app_backend/notifications/scheduler_test.exs
+++ b/test/mobile_app_backend/notifications/scheduler_test.exs
@@ -2,6 +2,8 @@ defmodule MobileAppBackend.Notifications.SchedulerTest do
   use MobileAppBackend.DataCase, async: true
   use Oban.Testing, repo: MobileAppBackend.Repo
   use HttpStub.Case
+
+  import ExUnit.CaptureLog
   import MobileAppBackend.Factory
   alias MBTAV3API.Store
   alias MobileAppBackend.Notifications
@@ -183,6 +185,47 @@ defmodule MobileAppBackend.Notifications.SchedulerTest do
         "upstream_timestamp" => nil
       }
     )
+  end
+
+  test "doesn't crash if issue building notifications" do
+    now = DateTime.now!("America/New_York")
+
+    alert =
+      build(:alert,
+        active_period: [
+          %MBTAV3API.Alert.ActivePeriod{
+            start: DateTime.add(now, 22, :hour),
+            end: DateTime.add(now, 27, :hour)
+          }
+        ],
+        effect: :suspension,
+        informed_entity: [
+          "this is bad"
+        ],
+        last_push_notification_timestamp: DateTime.add(now, -1, :minute)
+      )
+
+    user = NotificationsFactory.insert(:user)
+
+    NotificationsFactory.insert(:notification_subscription,
+      user_id: user.id,
+      route_id: "66",
+      stop_id: "1",
+      direction_id: 0,
+      windows: [NotificationsFactory.perpetual_window_factory()]
+    )
+
+    start_link_supervised!(Store.Alerts)
+    Store.Alerts.process_reset([alert], [])
+
+    {result, log} =
+      with_log([level: :error], fn ->
+        perform_job(MobileAppBackend.Notifications.Scheduler, %{})
+      end)
+
+    assert {:ok, nil} = result
+    assert log =~ "failed find_new_notifications"
+    assert log =~ "this is bad"
   end
 
   test "skips notifications over a day in the future" do


### PR DESCRIPTION
### Summary

_Ticket:_ [Prevent scheduler crashes](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214104746531461?focus=true)

What is this PR for?
This PR fixes the intended exception catching in the scheduler module by changing `catch` to `rescue`. This is a nitty difference I didn't think twice about since `catch` is the conventional word elsewhere! [From the docs](https://hexdocs.pm/elixir/try-catch-and-rescue.html#errors), rescue is for typical exceptions that are raised, and catch is for places you intentionally `throw` a value, which should be done ~never. "using try/catch is already uncommon and using it to catch exits is even rarer."


This also fixes the underlying GL issue thanks to help from @EmmaSimon and @boringcactus ([slack thread](https://mbta.slack.com/archives/C062QNAJZ2M/p1776451100556429)) and adds a couple more typespecs along the way.



Testing
* Ran without the GL fix to make sure exception catching & logging works as expected
<img width="982" height="193" alt="image" src="https://github.com/user-attachments/assets/c523fcef-ecaf-4cf1-963d-cffc6baabbc4" />


* Added unit test for exception catching
* Re-ran with the GL fix to make sure Scheduler ran as expected