### PR TITLE
feat: store user locale for fallback text

### DIFF
--- a/lib/mobile_app_backend/notifications/write_payload.ex
+++ b/lib/mobile_app_backend/notifications/write_payload.ex
@@ -1,5 +1,4 @@
 defmodule MobileAppBackend.Notifications.WritePayload do
-  require Util
   alias Ecto.Changeset
   alias MobileAppBackend.Notifications
   alias MobileAppBackend.User
@@ -117,11 +116,7 @@ defmodule MobileAppBackend.Notifications.WritePayload do
     %__MODULE__{
       fcm_token: fcm_token,
       subscriptions: MapSet.new(subscriptions, &Subscription.parse!/1),
-      locale:
-        case Map.fetch(payload, "locale") do
-          {:ok, locale} when Util.is_known_locale(locale) -> locale
-          _ -> nil
-        end
+      locale: payload["locale"]
     }
   end
 

--- a/lib/mobile_app_backend/notifications/write_payload.ex
+++ b/lib/mobile_app_backend/notifications/write_payload.ex
@@ -1,4 +1,5 @@
 defmodule MobileAppBackend.Notifications.WritePayload do
+  require Util
   alias Ecto.Changeset
   alias MobileAppBackend.Notifications
   alias MobileAppBackend.User
@@ -99,8 +100,12 @@ defmodule MobileAppBackend.Notifications.WritePayload do
     end
   end
 
-  @type t :: %__MODULE__{fcm_token: String.t(), subscriptions: MapSet.t(Subscription.t())}
-  defstruct [:fcm_token, :subscriptions]
+  @type t :: %__MODULE__{
+          fcm_token: String.t(),
+          subscriptions: MapSet.t(Subscription.t()),
+          locale: Gettext.locale() | nil
+        }
+  defstruct [:fcm_token, :subscriptions, :locale]
 
   def parse(payload) do
     {:ok, parse!(payload)}
@@ -108,10 +113,15 @@ defmodule MobileAppBackend.Notifications.WritePayload do
     _ -> :error
   end
 
-  def parse!(%{"fcm_token" => fcm_token, "subscriptions" => subscriptions}) do
+  def parse!(%{"fcm_token" => fcm_token, "subscriptions" => subscriptions} = payload) do
     %__MODULE__{
       fcm_token: fcm_token,
-      subscriptions: MapSet.new(subscriptions, &Subscription.parse!/1)
+      subscriptions: MapSet.new(subscriptions, &Subscription.parse!/1),
+      locale:
+        case Map.fetch(payload, "locale") do
+          {:ok, locale} when Util.is_known_locale(locale) -> locale
+          _ -> nil
+        end
     }
   end
 
@@ -136,7 +146,11 @@ defmodule MobileAppBackend.Notifications.WritePayload do
         Subscription.changeset(current, desired)
       end)
 
+    user_changes = if is_nil(desired.locale), do: %{}, else: %{locale: desired.locale}
+
+    changeset
+    |> Changeset.cast(user_changes, [:locale])
     # put_assoc will automatically delete anything that wasn’t included
-    Changeset.put_assoc(changeset, :notification_subscriptions, subscriptions)
+    |> Changeset.put_assoc(:notification_subscriptions, subscriptions)
   end
 end

--- a/lib/mobile_app_backend/user.ex
+++ b/lib/mobile_app_backend/user.ex
@@ -12,7 +12,7 @@ defmodule MobileAppBackend.User do
   typed_schema "users" do
     field(:fcm_token, :string, null: false, redact: true)
     field(:fcm_last_verified, :utc_datetime, null: false)
-    # see Util.is_known_locale/1 for valid values
+    # should be a BCP 47 language tag like iOS’s
     field(:locale, :string, null: true) :: Gettext.locale() | nil
 
     has_many(:notification_subscriptions, MobileAppBackend.Notifications.Subscription,

--- a/lib/mobile_app_backend/user.ex
+++ b/lib/mobile_app_backend/user.ex
@@ -12,6 +12,8 @@ defmodule MobileAppBackend.User do
   typed_schema "users" do
     field(:fcm_token, :string, null: false, redact: true)
     field(:fcm_last_verified, :utc_datetime, null: false)
+    # see Util.is_known_locale/1 for valid values
+    field(:locale, :string, null: true) :: Gettext.locale() | nil
 
     has_many(:notification_subscriptions, MobileAppBackend.Notifications.Subscription,
       on_replace: :delete_if_exists

--- a/lib/mobile_app_backend_web/controllers/notification_subscriptions_controller.ex
+++ b/lib/mobile_app_backend_web/controllers/notification_subscriptions_controller.ex
@@ -3,8 +3,6 @@ defmodule MobileAppBackendWeb.NotificationSubscriptionsController do
 
   import Ecto.Query
 
-  require Util
-
   alias MobileAppBackend.Notifications.Subscription
   alias MobileAppBackend.Notifications.WritePayload
   alias MobileAppBackend.Repo
@@ -14,11 +12,7 @@ defmodule MobileAppBackendWeb.NotificationSubscriptionsController do
     status =
       with {:ok, fcm_token} <- Map.fetch(params, "fcm_token"),
            {:ok, include_accessibility} <- Map.fetch(params, "include_accessibility") do
-        locale =
-          case Map.fetch(params, "locale") do
-            {:ok, locale} when Util.is_known_locale(locale) -> locale
-            _ -> nil
-          end
+        locale = params["locale"]
 
         now = Map.get_lazy(conn.private, :mobile_app_backend_now, &DateTime.utc_now/0)
 

--- a/lib/mobile_app_backend_web/controllers/notification_subscriptions_controller.ex
+++ b/lib/mobile_app_backend_web/controllers/notification_subscriptions_controller.ex
@@ -3,6 +3,8 @@ defmodule MobileAppBackendWeb.NotificationSubscriptionsController do
 
   import Ecto.Query
 
+  require Util
+
   alias MobileAppBackend.Notifications.Subscription
   alias MobileAppBackend.Notifications.WritePayload
   alias MobileAppBackend.Repo
@@ -12,10 +14,20 @@ defmodule MobileAppBackendWeb.NotificationSubscriptionsController do
     status =
       with {:ok, fcm_token} <- Map.fetch(params, "fcm_token"),
            {:ok, include_accessibility} <- Map.fetch(params, "include_accessibility") do
+        locale =
+          case Map.fetch(params, "locale") do
+            {:ok, locale} when Util.is_known_locale(locale) -> locale
+            _ -> nil
+          end
+
         now = Map.get_lazy(conn.private, :mobile_app_backend_now, &DateTime.utc_now/0)
 
-        Repo.update_all(from(u in User, where: u.fcm_token == ^fcm_token),
-          set: [fcm_last_verified: now]
+        Repo.update_all(
+          from(u in User,
+            where: u.fcm_token == ^fcm_token,
+            update: [set: [fcm_last_verified: ^now, locale: coalesce(^locale, u.locale)]]
+          ),
+          []
         )
 
         Repo.update_all(

--- a/lib/util.ex
+++ b/lib/util.ex
@@ -352,4 +352,24 @@ defmodule Util do
 
     def ok(this)
   end
+
+  @doc """
+  Checks if a language tag is a supported locale in the app.
+
+  Format should match iOS.
+
+  ## Examples
+
+      iex> Util.is_known_locale("en")
+      true
+      iex> Util.is_known_locale("pt-BR")
+      true
+      iex> Util.is_known_locale("zh-Hans-CN")
+      true
+      iex> Util.is_known_locale("tok")
+      false
+      iex> Util.is_known_locale("pt-PT")
+      false
+  """
+  defguard is_known_locale(locale) when locale in ~w(en es fr ht pt-BR vi zh-Hans-CN zh-Hant-TW)
 end

--- a/lib/util.ex
+++ b/lib/util.ex
@@ -352,24 +352,4 @@ defmodule Util do
 
     def ok(this)
   end
-
-  @doc """
-  Checks if a language tag is a supported locale in the app.
-
-  Format should match iOS.
-
-  ## Examples
-
-      iex> Util.is_known_locale("en")
-      true
-      iex> Util.is_known_locale("pt-BR")
-      true
-      iex> Util.is_known_locale("zh-Hans-CN")
-      true
-      iex> Util.is_known_locale("tok")
-      false
-      iex> Util.is_known_locale("pt-PT")
-      false
-  """
-  defguard is_known_locale(locale) when locale in ~w(en es fr ht pt-BR vi zh-Hans-CN zh-Hant-TW)
 end

--- a/priv/repo/migrations/20260417174815_add_locale_to_user.exs
+++ b/priv/repo/migrations/20260417174815_add_locale_to_user.exs
@@ -1,0 +1,9 @@
+defmodule MobileAppBackend.Repo.Migrations.AddLocaleToUser do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :locale, :string, null: true
+    end
+  end
+end

--- a/test/mobile_app_backend_web/controllers/notification_subscriptions_controller_test.exs
+++ b/test/mobile_app_backend_web/controllers/notification_subscriptions_controller_test.exs
@@ -81,21 +81,6 @@ defmodule MobileAppBackendWeb.NotificationSubscriptionsControllerTest do
       assert %User{locale: "en"} = Repo.reload(user)
     end
 
-    test "ignores unknown locale", %{conn: conn} do
-      user = insert(:user, locale: "en")
-      assert user.locale == "en"
-
-      conn =
-        post(conn, "/api/notifications/subscriptions/accessibility", %{
-          fcm_token: user.fcm_token,
-          include_accessibility: false,
-          locale: "tok"
-        })
-
-      assert json_response(conn, :ok) == nil
-      assert %User{locale: "en"} = Repo.reload(user)
-    end
-
     test "refreshes FCM verification", %{conn: conn, now: now} do
       user = insert(:user)
 
@@ -269,20 +254,6 @@ defmodule MobileAppBackendWeb.NotificationSubscriptionsControllerTest do
         post(conn, "/api/notifications/subscriptions/write", %{
           fcm_token: user.fcm_token,
           subscriptions: []
-        })
-
-      assert json_response(conn, :ok) == nil
-      assert %User{locale: "en"} = Repo.reload(user)
-    end
-
-    test "ignores unknown locale", %{conn: conn} do
-      user = insert(:user, locale: "en")
-
-      conn =
-        post(conn, "/api/notifications/subscriptions/write", %{
-          fcm_token: user.fcm_token,
-          subscriptions: [],
-          locale: "tok"
         })
 
       assert json_response(conn, :ok) == nil

--- a/test/mobile_app_backend_web/controllers/notification_subscriptions_controller_test.exs
+++ b/test/mobile_app_backend_web/controllers/notification_subscriptions_controller_test.exs
@@ -52,6 +52,50 @@ defmodule MobileAppBackendWeb.NotificationSubscriptionsControllerTest do
       assert json_response(conn, :ok) == nil
     end
 
+    test "sets locale", %{conn: conn} do
+      user = insert(:user, locale: "en")
+      assert user.locale == "en"
+
+      conn =
+        post(conn, "/api/notifications/subscriptions/accessibility", %{
+          fcm_token: user.fcm_token,
+          include_accessibility: false,
+          locale: "es"
+        })
+
+      assert json_response(conn, :ok) == nil
+      assert %User{locale: "es"} = Repo.reload(user)
+    end
+
+    test "does not clear locale", %{conn: conn} do
+      user = insert(:user, locale: "en")
+      assert user.locale == "en"
+
+      conn =
+        post(conn, "/api/notifications/subscriptions/accessibility", %{
+          fcm_token: user.fcm_token,
+          include_accessibility: false
+        })
+
+      assert json_response(conn, :ok) == nil
+      assert %User{locale: "en"} = Repo.reload(user)
+    end
+
+    test "ignores unknown locale", %{conn: conn} do
+      user = insert(:user, locale: "en")
+      assert user.locale == "en"
+
+      conn =
+        post(conn, "/api/notifications/subscriptions/accessibility", %{
+          fcm_token: user.fcm_token,
+          include_accessibility: false,
+          locale: "tok"
+        })
+
+      assert json_response(conn, :ok) == nil
+      assert %User{locale: "en"} = Repo.reload(user)
+    end
+
     test "refreshes FCM verification", %{conn: conn, now: now} do
       user = insert(:user)
 
@@ -65,6 +109,7 @@ defmodule MobileAppBackendWeb.NotificationSubscriptionsControllerTest do
       assert %User{fcm_last_verified: ^now} = Repo.reload(user)
     end
 
+    @tag :capture_log
     test "sends 400 on bad request", %{conn: conn} do
       conn =
         post(conn, "/api/notifications/subscriptions/accessibility", %{is_reasonable: false})
@@ -89,12 +134,13 @@ defmodule MobileAppBackendWeb.NotificationSubscriptionsControllerTest do
                 %{start_time: "10:00", end_time: "17:00", days_of_week: [0, 7]}
               ]
             }
-          ]
+          ],
+          locale: "en"
         })
 
       assert json_response(conn, :ok) == nil
 
-      assert [%User{id: user_id, fcm_token: "fake_token", fcm_last_verified: ^now}] =
+      assert [%User{id: user_id, fcm_token: "fake_token", fcm_last_verified: ^now, locale: "en"}] =
                Repo.all(User)
 
       assert [
@@ -202,6 +248,48 @@ defmodule MobileAppBackendWeb.NotificationSubscriptionsControllerTest do
       end)
     end
 
+    test "sets locale", %{conn: conn} do
+      user = insert(:user, locale: "en")
+
+      conn =
+        post(conn, "/api/notifications/subscriptions/write", %{
+          fcm_token: user.fcm_token,
+          subscriptions: [],
+          locale: "es"
+        })
+
+      assert json_response(conn, :ok) == nil
+      assert %User{locale: "es"} = Repo.reload(user)
+    end
+
+    test "does not clear locale", %{conn: conn} do
+      user = insert(:user, locale: "en")
+
+      conn =
+        post(conn, "/api/notifications/subscriptions/write", %{
+          fcm_token: user.fcm_token,
+          subscriptions: []
+        })
+
+      assert json_response(conn, :ok) == nil
+      assert %User{locale: "en"} = Repo.reload(user)
+    end
+
+    test "ignores unknown locale", %{conn: conn} do
+      user = insert(:user, locale: "en")
+
+      conn =
+        post(conn, "/api/notifications/subscriptions/write", %{
+          fcm_token: user.fcm_token,
+          subscriptions: [],
+          locale: "tok"
+        })
+
+      assert json_response(conn, :ok) == nil
+      assert %User{locale: "en"} = Repo.reload(user)
+    end
+
+    @tag :capture_log
     test "sends 400 on bad request", %{conn: conn} do
       conn =
         post(conn, "/api/notifications/subscriptions/write", %{


### PR DESCRIPTION
### Summary

_Ticket:_ [Store top supported language for notifications fallback](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214048781923336?focus=true)

Pairs with https://github.com/mbta/mobile_app/pull/1681.