### PR TITLE
fix(Alert.recurrence_range): count all days in active period

### DIFF
--- a/lib/mbta_v3_api/alert.ex
+++ b/lib/mbta_v3_api/alert.ex
@@ -357,25 +357,38 @@ defmodule MBTAV3API.Alert do
     with num_periods when num_periods > 1 <- length(alert.active_period),
          first_period <- Enum.min_by(alert.active_period, & &1.start, DateTime),
          last_period <- Enum.max_by(alert.active_period, & &1.end, DateTime),
-         true <-
-           Enum.all?(alert.active_period, fn %ActivePeriod{} = ap ->
-             Util.datetime_to_gtfs(ap.start) ==
-               Util.datetime_to_gtfs(ap.end, rounding: :backwards) and
-               DateTime.to_time(ap.start) == DateTime.to_time(first_period.start) and
-               DateTime.to_time(ap.end) == DateTime.to_time(last_period.end)
-           end) do
-      alert_days = Enum.map(alert.active_period, &Util.datetime_to_gtfs(&1.start))
+         false <- last_period.end == nil,
+         false <-
+           Util.datetime_to_gtfs(last_period.end, rounding: :backwards) ==
+             Util.datetime_to_gtfs(first_period.start) do
+      seen_days_of_week =
+        alert.active_period
+        |> Enum.flat_map(fn ap ->
+          ap.start
+          |> Util.datetime_to_gtfs()
+          |> Date.range(Util.datetime_to_gtfs(ap.end, rounding: :backwards))
+          |> Enum.map(&Date.day_of_week(&1))
+        end)
+        |> MapSet.new()
 
-      all_alert_days_contiguous? =
-        alert_days
-        |> Enum.chunk_every(2, 1, :discard)
-        |> Enum.all?(fn [a, b] -> Date.diff(b, a) == 1 end)
+      # If all the days in the range have been seen, then include all days.
+      # This indicates that the alert is "daily".
+      all_days_in_range_seen =
+        first_period.start
+        |> Util.datetime_to_gtfs()
+        |> Date.range(
+          Util.datetime_to_gtfs(last_period.end,
+            rounding: :backwards
+          )
+        )
+        |> Enum.map(&Date.day_of_week(&1))
+        |> MapSet.new() == seen_days_of_week
 
       days =
-        if all_alert_days_contiguous? do
+        if all_days_in_range_seen do
           MapSet.new(1..7)
         else
-          MapSet.new(alert_days, &Date.day_of_week/1)
+          seen_days_of_week
         end
 
       %RecurrenceInfo{

--- a/test/mbta_v3_api/alert_test.exs
+++ b/test/mbta_v3_api/alert_test.exs
@@ -525,6 +525,33 @@ defmodule MBTAV3API.AlertTest do
                end_day_known: false
              }
     end
+
+    test "two sets of continuous week days" do
+      alert =
+        build(:alert,
+          duration_certainty: :known,
+          active_period: [
+            %ActivePeriod{
+              start:
+                DateTime.new!(Date.new!(2026, 4, 22), Time.new!(3, 0, 0), "America/New_York"),
+              end: DateTime.new!(Date.new!(2026, 4, 25), Time.new!(3, 0, 0), "America/New_York")
+            },
+            %ActivePeriod{
+              start:
+                DateTime.new!(Date.new!(2026, 4, 27), Time.new!(3, 0, 0), "America/New_York"),
+              end: DateTime.new!(Date.new!(2026, 5, 1), Time.new!(3, 0, 0), "America/New_York")
+            }
+          ]
+        )
+
+      assert Alert.recurrence_range(alert) == %Alert.RecurrenceInfo{
+               start:
+                 DateTime.new!(Date.new!(2026, 4, 22), Time.new!(3, 0, 0), "America/New_York"),
+               end: DateTime.new!(Date.new!(2026, 5, 1), Time.new!(3, 0, 0), "America/New_York"),
+               days: MapSet.new(1..5),
+               end_day_known: true
+             }
+    end
   end
 
   test "alert can notify based on timeframe and closed status" do


### PR DESCRIPTION
### Summary

_Ticket:_ [GL-B Alert recurrence display issue](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214178823562892?focus=true)

What is this PR for?

Backend version of https://github.com/mbta/mobile_app/pull/1689. 

> [The backend](https://github.com/mbta/mobile_app_backend/blob/721639f298451e67fb66355fc6c1110ddc352ea4/lib/mbta_v3_api/alert.ex#L233) collapses consecutive periods together, whereas the frontend was expecting separate periods for each day. I'm concerned that there could be other ramifications of removing the backend collapsing logic (introduced https://github.com/mbta/mobile_app_backend/pull/328 to address a different active period display issue), so this just makes the recurrence check handle cases where a period is > 1 day.
> ...
> Note: [outstanding discussion](https://mbta.slack.com/archives/C082U4THN5A/p1776886055791379?thread_ts=1776858827.168749&cid=C082U4THN5A) as to whether we can get the data representation for a recurrence directly from Alerts

Testing:
* Added unit test
* TODO: test making a notification
