### PR TITLE
feat: Update trip summary behavior

### DIFF
--- a/lib/mobile_app_backend/alerts/alert_summary.ex
+++ b/lib/mobile_app_backend/alerts/alert_summary.ex
@@ -228,27 +228,39 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
 
   defmodule Location do
     defmodule DirectionToStop do
-      @type t :: %__MODULE__{direction: Direction.t(), end_stop_name: String.t()}
+      @type t :: %__MODULE__{
+              direction: Direction.t(),
+              end_stop_name: String.t(),
+              downstream: boolean() | nil
+            }
       @derive PolymorphicJson
-      defstruct [:direction, :end_stop_name]
+      defstruct [:direction, :end_stop_name, :downstream]
     end
 
     defmodule SingleStop do
-      @type t :: %__MODULE__{stop_name: String.t()}
+      @type t :: %__MODULE__{stop_name: String.t(), downstream: boolean() | nil}
       @derive PolymorphicJson
-      defstruct [:stop_name]
+      defstruct [:stop_name, :downstream]
     end
 
     defmodule StopToDirection do
-      @type t :: %__MODULE__{start_stop_name: String.t(), direction: Direction.t()}
+      @type t :: %__MODULE__{
+              start_stop_name: String.t(),
+              direction: Direction.t(),
+              downstream: boolean() | nil
+            }
       @derive PolymorphicJson
-      defstruct [:start_stop_name, :direction]
+      defstruct [:start_stop_name, :direction, :downstream]
     end
 
     defmodule SuccessiveStops do
-      @type t :: %__MODULE__{start_stop_name: String.t(), end_stop_name: String.t()}
+      @type t :: %__MODULE__{
+              start_stop_name: String.t(),
+              end_stop_name: String.t(),
+              downstream: boolean() | nil
+            }
       @derive PolymorphicJson
-      defstruct [:start_stop_name, :end_stop_name]
+      defstruct [:start_stop_name, :end_stop_name, :downstream]
     end
 
     defmodule WholeRoute do
@@ -558,10 +570,11 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
     with nil <- gl_whole_route_location,
          nil <- alert_location_for_whole_route(alert, direction_id, routes) do
       affected_stops = get_alert_affected_stops(global, alert, routes)
+      downstream = Enum.all?(affected_stops, &(&1.id != stop_id))
 
       cond do
         length(affected_stops) == 1 ->
-          %Location.SingleStop{stop_name: hd(affected_stops).name}
+          %Location.SingleStop{stop_name: hd(affected_stops).name, downstream: downstream}
 
         # Never show multiple stops for bus
         Enum.any?(routes, &(&1.type == :bus and not String.starts_with?(&1.id, "Shuttle"))) ->
@@ -574,6 +587,7 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
             direction_id,
             patterns,
             routes,
+            downstream,
             global
           )
       end
@@ -754,7 +768,15 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
     end
   end
 
-  defp alert_location_for_multiple_stops(alert, stop_id, direction_id, patterns, routes, global) do
+  defp alert_location_for_multiple_stops(
+         alert,
+         stop_id,
+         direction_id,
+         patterns,
+         routes,
+         downstream,
+         global
+       ) do
     # Map each pattern to its list of stops affected by this alert
     affected_pattern_stops =
       map_patterns_to_affected_stops(
@@ -778,7 +800,7 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
         }
 
       _ ->
-        multi_stop_location(affected_pattern_stops, direction_id, global)
+        multi_stop_location(affected_pattern_stops, direction_id, downstream, global)
     end
   end
 
@@ -849,7 +871,7 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
     end)
   end
 
-  defp multi_stop_location(affected_pattern_stops, direction_id, global) do
+  defp multi_stop_location(affected_pattern_stops, direction_id, downstream, global) do
     # Compare the first stop list to all the others to determine if all patterns share the same disrupted stops,
     # or if multiple branches are disrupted
     first_stops = affected_pattern_stops |> Map.values() |> Enum.find(&(length(&1) > 1))
@@ -864,7 +886,8 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
       end) ->
         %Location.SuccessiveStops{
           start_stop_name: List.first(ordered_stops).name,
-          end_stop_name: List.last(ordered_stops).name
+          end_stop_name: List.last(ordered_stops).name,
+          downstream: downstream
         }
 
       Enum.all?(affected_pattern_stops, fn {_, stops} ->
@@ -881,7 +904,8 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
 
         %Location.StopToDirection{
           start_stop_name: stop.name,
-          direction: Enum.at(directions, direction_id)
+          direction: Enum.at(directions, direction_id),
+          downstream: downstream
         }
 
       Enum.all?(affected_pattern_stops, fn {_, stops} ->
@@ -898,7 +922,8 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
 
         %Location.DirectionToStop{
           direction: Enum.at(directions, 1 - direction_id),
-          end_stop_name: stop.name
+          end_stop_name: stop.name,
+          downstream: downstream
         }
 
       true ->

--- a/lib/mobile_app_backend/alerts/alert_summary/trip_shuttle.ex
+++ b/lib/mobile_app_backend/alerts/alert_summary/trip_shuttle.ex
@@ -10,9 +10,19 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripShuttle do
   alias Util.PolymorphicJson
 
   defmodule SingleTrip do
-    @type t :: %__MODULE__{trip_time: DateTime.t(), route_type: Route.type()}
+    @type t :: %__MODULE__{
+            trip_time: DateTime.t(),
+            route_type: Route.type(),
+            from_stop_name: String.t() | nil
+          }
     @derive PolymorphicJson
-    defstruct [:trip_time, :route_type]
+    defstruct [:trip_time, :route_type, :from_stop_name]
+  end
+
+  defmodule ThisTrip do
+    @type t :: %__MODULE__{route_type: Route.type()}
+    @derive PolymorphicJson
+    defstruct [:route_type]
   end
 
   defmodule MultipleTrips do
@@ -21,20 +31,18 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripShuttle do
     defstruct []
   end
 
-  @type trip_identity :: SingleTrip.t() | MultipleTrips.t()
+  @type trip_identity :: SingleTrip.t() | ThisTrip.t() | MultipleTrips.t()
 
   @type t :: %__MODULE__{
           trip_identity: trip_identity(),
-          is_today: boolean(),
-          current_stop_name: String.t(),
+          start_stop_name: String.t(),
           end_stop_name: String.t(),
           recurrence: AlertSummary.Recurrence.t() | nil
         }
   @derive PolymorphicJson
   defstruct [
     :trip_identity,
-    :is_today,
-    :current_stop_name,
+    :start_stop_name,
     :end_stop_name,
     :recurrence
   ]
@@ -57,20 +65,40 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripShuttle do
         informed_schedules,
         global
       ) do
-    with {trip_identity, is_today} when not is_nil(trip_identity) <-
-           trip_identity_is_today(patterns, at_time, informed_schedules, global),
+    with %AlertSummary.Location.SuccessiveStops{
+           start_stop_name: location_start_stop_name,
+           end_stop_name: end_stop_name,
+           downstream: downstream
+         } <-
+           AlertSummary.alert_location(alert, stop_id, direction_id, patterns, global),
          %Stop{name: current_stop_name} <- global.stops[stop_id],
-         %AlertSummary.Location.SuccessiveStops{end_stop_name: end_stop_name} <-
-           AlertSummary.alert_location(alert, stop_id, direction_id, patterns, global) do
+         start_stop_name <-
+           resolve_start_stop_name(downstream, location_start_stop_name, current_stop_name),
+         identity_stop_name <- resolve_trip_identity_stop_name(downstream, current_stop_name),
+         trip_identity when not is_nil(trip_identity) <-
+           trip_identity(identity_stop_name, patterns, informed_schedules, global) do
       %__MODULE__{
         trip_identity: trip_identity,
-        is_today: is_today,
-        current_stop_name: current_stop_name,
+        start_stop_name: start_stop_name,
         end_stop_name: end_stop_name,
         recurrence: AlertSummary.alert_recurrence(alert, at_time)
       }
     else
       _ -> nil
+    end
+  end
+
+  defp resolve_start_stop_name(downstream, location_start_stop_name, current_stop_name) do
+    case downstream do
+      false -> current_stop_name
+      _ -> location_start_stop_name
+    end
+  end
+
+  defp resolve_trip_identity_stop_name(downstream, current_stop_name) do
+    case downstream do
+      false -> nil
+      _ -> current_stop_name
     end
   end
 
@@ -85,7 +113,7 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripShuttle do
 
     same_stops =
       summaries
-      |> Enum.flat_map(&[&1.current_stop_name, &1.end_stop_name])
+      |> Enum.flat_map(&[&1.start_stop_name, &1.end_stop_name])
       |> MapSet.new()
       |> MapSet.size() == 2
 
@@ -105,8 +133,7 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripShuttle do
 
       %__MODULE__{
         trip_identity: trip_identity,
-        is_today: first.is_today,
-        current_stop_name: first.current_stop_name,
+        start_stop_name: first.start_stop_name,
         end_stop_name: first.end_stop_name,
         recurrence: first.recurrence
       }
@@ -115,15 +142,15 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripShuttle do
     end
   end
 
-  defp trip_identity_is_today(
+  defp trip_identity(
+         current_stop_name,
          patterns,
-         at_time,
          informed_schedules,
          global
        ) do
     case informed_schedules do
       [] ->
-        {nil, nil}
+        nil
 
       [%Schedule{} = informed_trip]
       when not is_nil(informed_trip.departure_time) or not is_nil(informed_trip.arrival_time) ->
@@ -131,22 +158,18 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripShuttle do
 
         case Enum.find_value(patterns, &global.routes[&1.route_id]) do
           %Route{type: route_type} ->
-            {%SingleTrip{
-               trip_time: trip_time,
-               route_type: route_type
-             }, Util.datetime_to_gtfs(trip_time) == Util.datetime_to_gtfs(at_time)}
+            %SingleTrip{
+              trip_time: trip_time,
+              route_type: route_type,
+              from_stop_name: current_stop_name
+            }
 
           _ ->
-            {nil, nil}
+            nil
         end
 
       _ ->
-        {%MultipleTrips{},
-         Enum.any?(
-           informed_schedules,
-           &(Util.datetime_to_gtfs(&1.departure_time || &1.arrival_time) ==
-               Util.datetime_to_gtfs(at_time))
-         )}
+        %MultipleTrips{}
     end
   end
 end

--- a/lib/mobile_app_backend/alerts/alert_summary/trip_specific.ex
+++ b/lib/mobile_app_backend/alerts/alert_summary/trip_specific.ex
@@ -1,6 +1,7 @@
 defmodule MobileAppBackend.Alerts.AlertSummary.TripSpecific do
   alias MBTAV3API.Alert
   alias MBTAV3API.Repository
+  alias MBTAV3API.Route
   alias MBTAV3API.RoutePattern
   alias MBTAV3API.Schedule
   alias MBTAV3API.Stop
@@ -10,16 +11,30 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripSpecific do
   alias MobileAppBackend.GlobalDataCache
   alias Util.PolymorphicJson
 
-  defmodule TripFrom do
-    @type t :: %__MODULE__{trip_time: DateTime.t(), stop_name: String.t()}
+  defmodule ThisTrip do
+    @type t :: %__MODULE__{route_type: Route.type()}
     @derive PolymorphicJson
-    defstruct [:trip_time, :stop_name]
+    defstruct [:route_type]
+  end
+
+  defmodule TripFrom do
+    @type t :: %__MODULE__{
+            trip_time: DateTime.t(),
+            route_type: Route.type(),
+            stop_name: String.t()
+          }
+    @derive PolymorphicJson
+    defstruct [:trip_time, :route_type, :stop_name]
   end
 
   defmodule TripTo do
-    @type t :: %__MODULE__{trip_time: DateTime.t(), headsign: String.t()}
+    @type t :: %__MODULE__{
+            trip_time: DateTime.t(),
+            route_type: Route.type(),
+            headsign: String.t()
+          }
     @derive PolymorphicJson
-    defstruct [:trip_time, :headsign]
+    defstruct [:trip_time, :route_type, :headsign]
   end
 
   defmodule MultipleTrips do
@@ -28,7 +43,7 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripSpecific do
     defstruct []
   end
 
-  @type trip_identity :: TripFrom.t() | TripTo.t() | MultipleTrips.t()
+  @type trip_identity :: ThisTrip.t() | TripFrom.t() | TripTo.t() | MultipleTrips.t()
 
   @type t :: %__MODULE__{
           trip_identity: trip_identity(),
@@ -76,11 +91,19 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripSpecific do
           global
         )
 
-      :station_closure ->
-        trip_stop_bypass_summary(alert, stop_id, at_time, informed_schedules, global)
+      effect when effect in [:station_closure, :stop_closure, :dock_closure] ->
+        trip_stop_bypass_summary(alert, stop_id, patterns, at_time, informed_schedules, global)
 
       _ ->
-        trip_specific_other_summary(alert, stop_id, at_time, informed_schedules, global)
+        trip_specific_other_summary(
+          alert,
+          stop_id,
+          direction_id,
+          patterns,
+          at_time,
+          informed_schedules,
+          global
+        )
     end
   end
 
@@ -132,16 +155,28 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripSpecific do
     end
   end
 
-  defp trip_stop_bypass_summary(alert, stop_id, at_time, informed_schedules, global) do
+  defp route_type_from_patterns(patterns, global) do
+    Enum.find_value(patterns, fn pattern ->
+      case global.routes[pattern.route_id] do
+        %Route{type: type} -> type
+        _ -> nil
+      end
+    end)
+  end
+
+  defp trip_stop_bypass_summary(alert, stop_id, patterns, at_time, informed_schedules, global) do
+    route_type = route_type_from_patterns(patterns, global)
+
     {trip_identity, is_today} =
-      case trip_identity_is_today(stop_id, at_time, informed_schedules, global) do
-        {%TripFrom{trip_time: trip_time}, is_today} ->
+      case trip_identity_is_today(stop_id, at_time, route_type, informed_schedules, global) do
+        {%TripFrom{trip_time: trip_time}, is_today} when route_type != nil ->
           # must be a single trip since there weren’t multiple trips
           [informed_schedule] = informed_schedules
 
           case Repository.trips(filter: [id: informed_schedule.trip_id]) do
             {:ok, %{data: [%Trip{headsign: headsign}]}} ->
-              {%TripTo{trip_time: trip_time, headsign: headsign}, is_today}
+              {%TripTo{trip_time: trip_time, route_type: route_type, headsign: headsign},
+               is_today}
 
             _ ->
               {nil, nil}
@@ -151,7 +186,7 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripSpecific do
           x
       end
 
-    if trip_identity do
+    if trip_identity != nil do
       informed_stops =
         alert.informed_entity
         |> Enum.map(& &1.stop)
@@ -171,15 +206,28 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripSpecific do
     end
   end
 
-  defp trip_specific_other_summary(alert, stop_id, at_time, informed_schedules, global) do
+  defp trip_specific_other_summary(
+         alert,
+         stop_id,
+         direction_id,
+         patterns,
+         at_time,
+         informed_schedules,
+         global
+       ) do
+    route_type = route_type_from_patterns(patterns, global)
+
     {trip_identity, is_today} =
-      trip_identity_is_today(stop_id, at_time, informed_schedules, global)
+      trip_identity_is_today(stop_id, at_time, route_type, informed_schedules, global)
+
+    effect_stops =
+      trip_specific_effect_stops(alert, stop_id, direction_id, patterns, global)
 
     if trip_identity != nil do
       %__MODULE__{
         trip_identity: trip_identity,
         effect: alert.effect,
-        effect_stops: nil,
+        effect_stops: effect_stops,
         is_today: is_today,
         cause: alert.cause,
         recurrence: AlertSummary.alert_recurrence(alert, at_time)
@@ -187,9 +235,45 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripSpecific do
     end
   end
 
-  defp trip_identity_is_today(stop_id, at_time, informed_schedules, global) do
+  defp trip_specific_effect_stops(
+         %Alert{effect: :suspension} = alert,
+         stop_id,
+         direction_id,
+         patterns,
+         global
+       ) do
+    location =
+      AlertSummary.alert_location(alert, stop_id, direction_id, patterns, global)
+
+    effect_stop =
+      case location do
+        %AlertSummary.Location.SingleStop{downstream: true, stop_name: stop_name} ->
+          stop_name
+
+        %AlertSummary.Location.SuccessiveStops{downstream: true, start_stop_name: stop_name} ->
+          stop_name
+
+        %AlertSummary.Location.StopToDirection{downstream: true, start_stop_name: stop_name} ->
+          stop_name
+
+        _ ->
+          nil
+      end
+
+    case effect_stop do
+      nil -> nil
+      stop_name -> [stop_name]
+    end
+  end
+
+  defp trip_specific_effect_stops(_, _, _, _, _), do: nil
+
+  defp trip_identity_is_today(stop_id, at_time, route_type, informed_schedules, global) do
     case informed_schedules do
       [] ->
+        {nil, nil}
+
+      [%Schedule{}] when is_nil(route_type) ->
         {nil, nil}
 
       [%Schedule{} = informed_trip]
@@ -198,6 +282,7 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripSpecific do
 
         {%TripFrom{
            trip_time: trip_time,
+           route_type: route_type,
            stop_name: global.stops[stop_id].name
          }, Util.datetime_to_gtfs(trip_time) == Util.datetime_to_gtfs(at_time)}
 

--- a/test/mobile_app_backend/alerts/alert_summary_test.exs
+++ b/test/mobile_app_backend/alerts/alert_summary_test.exs
@@ -1666,6 +1666,78 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                })
     end
 
+    test "trip specific dock closure" do
+      Mox.stub_with(MobileAppBackend.HTTPMock, Test.Support.HTTPStub)
+      now = ~B[2026-03-12 12:00:00]
+      stop1 = build(:stop, name: "Hingham")
+      stop2 = build(:stop, name: "Hull")
+      stop3 = build(:stop, name: "Rowes Wharf")
+      route = build(:route, type: :ferry)
+      pattern = build(:route_pattern, route_id: route.id)
+      trip = build(:trip, route_pattern_id: pattern.id, headsign: stop3.name)
+
+      expect(
+        MobileAppBackend.HTTPMock,
+        :request,
+        fn %Req.Request{url: %URI{path: "/trips"}, options: %{params: _params}} ->
+          {:ok,
+           Req.Response.json([
+             %{
+               "attributes" => %{
+                 "headsign" => trip.headsign
+               },
+               "id" => trip.id,
+               "type" => "trip"
+             }
+           ])}
+        end
+      )
+
+      alert =
+        build(:alert,
+          active_period: [
+            %Alert.ActivePeriod{
+              start: DateTime.add(now, -2, :hour),
+              end: DateTime.add(now, 2, :hour)
+            }
+          ],
+          cause: :weather,
+          effect: :dock_closure,
+          informed_entity: [
+            %Alert.InformedEntity{
+              trip: trip.id,
+              stop: stop2.id
+            }
+          ]
+        )
+
+      schedule =
+        build(:schedule,
+          trip_id: trip.id,
+          departure_time: ~B[2026-03-12 12:13:00]
+        )
+
+      trip_time = schedule.departure_time
+      route_type = route.type
+
+      assert %AlertSummary.TripSpecific{
+               trip_identity: %AlertSummary.TripSpecific.TripTo{
+                 trip_time: ^trip_time,
+                 route_type: ^route_type,
+                 headsign: "Rowes Wharf"
+               },
+               effect: :dock_closure,
+               effect_stops: ["Hull"],
+               is_today: true,
+               cause: :weather,
+               recurrence: nil
+             } =
+               AlertSummary.summarizing(alert, stop1.id, 0, [pattern], now, [schedule], %{
+                 stops: %{stop1.id => stop1, stop2.id => stop2, stop3.id => stop3},
+                 routes: %{route.id => route}
+               })
+    end
+
     test "multiple trip cancellation" do
       now = ~B[2026-03-12 12:00:00]
       stop = build(:stop, name: "Blossom Street Pier")

--- a/test/mobile_app_backend/alerts/alert_summary_test.exs
+++ b/test/mobile_app_backend/alerts/alert_summary_test.exs
@@ -241,6 +241,7 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
       assert json_round_trip(%AlertSummary.TripSpecific{
                trip_identity: %AlertSummary.TripSpecific.TripFrom{
                  trip_time: ~B[2026-03-06 15:19:00],
+                 route_type: :commuter_rail,
                  stop_name: "North Station"
                },
                effect: :suspension,
@@ -255,6 +256,7 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                trip_identity: %{
                  type: "trip_from",
                  trip_time: "2026-03-06T15:19:00-05:00",
+                 route_type: "commuter_rail",
                  stop_name: "North Station"
                },
                effect: "suspension",
@@ -272,10 +274,10 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
       assert json_round_trip(%AlertSummary.TripShuttle{
                trip_identity: %AlertSummary.TripShuttle.SingleTrip{
                  trip_time: ~B[2026-03-06 15:21:00],
-                 route_type: :commuter_rail
+                 route_type: :commuter_rail,
+                 from_stop_name: "Route 128"
                },
-               is_today: true,
-               current_stop_name: "Ruggles",
+               start_stop_name: "Ruggles",
                end_stop_name: "Forest Hills",
                recurrence: nil
              }) == %{
@@ -283,10 +285,10 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                trip_identity: %{
                  type: "single_trip",
                  trip_time: "2026-03-06T15:21:00-05:00",
-                 route_type: "commuter_rail"
+                 route_type: "commuter_rail",
+                 from_stop_name: "Route 128"
                },
-               is_today: true,
-               current_stop_name: "Ruggles",
+               start_stop_name: "Ruggles",
                end_stop_name: "Forest Hills",
                recurrence: nil
              }
@@ -384,19 +386,23 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
     test "can serialize all trip identities" do
       assert json_round_trip(%AlertSummary.TripSpecific.TripFrom{
                trip_time: ~B[2026-03-06 15:25:00],
+               route_type: :commuter_rail,
                stop_name: "Ruggles"
              }) == %{
                type: "trip_from",
                trip_time: "2026-03-06T15:25:00-05:00",
+               route_type: "commuter_rail",
                stop_name: "Ruggles"
              }
 
       assert json_round_trip(%AlertSummary.TripSpecific.TripTo{
                trip_time: ~B[2026-03-06 15:25:00],
+               route_type: :commuter_rail,
                headsign: "South Station"
              }) == %{
                type: "trip_to",
                trip_time: "2026-03-06T15:25:00-05:00",
+               route_type: "commuter_rail",
                headsign: "South Station"
              }
 
@@ -1442,7 +1448,7 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
           ],
           cause: :weather,
           effect: :suspension,
-          informed_entity: [%Alert.InformedEntity{trip: trip.id}]
+          informed_entity: [%Alert.InformedEntity{trip: trip.id, stop: stop.id}]
         )
 
       schedule =
@@ -1452,10 +1458,12 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
         )
 
       trip_time = schedule.departure_time
+      route_type = route.type
 
       assert %AlertSummary.TripSpecific{
                trip_identity: %AlertSummary.TripSpecific.TripFrom{
                  trip_time: ^trip_time,
+                 route_type: ^route_type,
                  stop_name: "Ruggles"
                },
                effect: :suspension,
@@ -1465,7 +1473,196 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                recurrence: nil
              } =
                AlertSummary.summarizing(alert, stop.id, 0, [pattern], now, [schedule], %{
-                 stops: %{stop.id => stop}
+                 stops: %{stop.id => stop},
+                 routes: %{route.id => route}
+               })
+    end
+
+    test "trip specific suspension single stop downstream" do
+      now = ~B[2026-03-12 12:00:00]
+      stop1 = build(:stop, name: "Ruggles")
+      stop2 = build(:stop, name: "Back Bay")
+      route = build(:route)
+      pattern = build(:route_pattern, route_id: route.id)
+      trip = build(:trip, route_pattern_id: pattern.id)
+
+      alert =
+        build(:alert,
+          active_period: [
+            %Alert.ActivePeriod{
+              start: DateTime.add(now, -2, :hour),
+              end: DateTime.add(now, 2, :hour)
+            }
+          ],
+          cause: :weather,
+          effect: :suspension,
+          informed_entity: [%Alert.InformedEntity{trip: trip.id, stop: stop2.id}]
+        )
+
+      schedule =
+        build(:schedule,
+          trip_id: trip.id,
+          departure_time: ~B[2026-03-12 12:13:00]
+        )
+
+      trip_time = schedule.departure_time
+      route_type = route.type
+
+      assert %AlertSummary.TripSpecific{
+               trip_identity: %AlertSummary.TripSpecific.TripFrom{
+                 trip_time: ^trip_time,
+                 route_type: ^route_type,
+                 stop_name: "Ruggles"
+               },
+               effect: :suspension,
+               effect_stops: ["Back Bay"],
+               is_today: true,
+               cause: :weather,
+               recurrence: nil
+             } =
+               AlertSummary.summarizing(alert, stop1.id, 0, [pattern], now, [schedule], %{
+                 stops: %{stop1.id => stop1, stop2.id => stop2},
+                 routes: %{route.id => route}
+               })
+    end
+
+    test "trip specific suspension multi stop downstream" do
+      now = ~B[2026-03-12 12:00:00]
+      stop1 = build(:stop, name: "Ruggles")
+      stop2 = build(:stop, name: "Back Bay")
+      stop3 = build(:stop, name: "South Station")
+      route = build(:route, type: :commuter_rail)
+
+      representative_trip =
+        build(:trip, stop_ids: [build(:stop).id, stop1.id, stop2.id, stop3.id])
+
+      pattern =
+        build(:route_pattern,
+          representative_trip_id: representative_trip.id,
+          route_id: route.id,
+          typicality: :typical
+        )
+
+      trip = build(:trip, route_pattern_id: pattern.id)
+
+      alert =
+        build(:alert,
+          active_period: [
+            %Alert.ActivePeriod{
+              start: DateTime.add(now, -2, :hour),
+              end: DateTime.add(now, 2, :hour)
+            }
+          ],
+          cause: :weather,
+          effect: :suspension,
+          informed_entity: [
+            %Alert.InformedEntity{trip: trip.id, stop: stop2.id},
+            %Alert.InformedEntity{trip: trip.id, stop: stop3.id}
+          ]
+        )
+
+      schedule =
+        build(:schedule,
+          trip_id: trip.id,
+          departure_time: ~B[2026-03-12 12:13:00]
+        )
+
+      trip_time = schedule.departure_time
+      route_type = route.type
+
+      assert %AlertSummary.TripSpecific{
+               trip_identity: %AlertSummary.TripSpecific.TripFrom{
+                 trip_time: ^trip_time,
+                 route_type: ^route_type,
+                 stop_name: "Ruggles"
+               },
+               effect: :suspension,
+               effect_stops: ["Back Bay"],
+               is_today: true,
+               cause: :weather,
+               recurrence: nil
+             } =
+               AlertSummary.summarizing(alert, stop1.id, 0, [pattern], now, [schedule], %{
+                 stops: %{stop1.id => stop1, stop2.id => stop2, stop3.id => stop3},
+                 routes: %{route.id => route},
+                 route_patterns: %{pattern.id => pattern},
+                 trips: %{representative_trip.id => representative_trip}
+               })
+    end
+
+    test "trip specific station closure" do
+      Mox.stub_with(MobileAppBackend.HTTPMock, Test.Support.HTTPStub)
+      now = ~B[2026-03-12 12:00:00]
+      stop1 = build(:stop, name: "Ruggles")
+      stop2 = build(:stop, name: "Back Bay")
+      stop3 = build(:stop, name: "South Station")
+      route = build(:route, type: :commuter_rail)
+      pattern = build(:route_pattern, route_id: route.id)
+      trip = build(:trip, route_pattern_id: pattern.id, headsign: stop3.name)
+
+      expect(
+        MobileAppBackend.HTTPMock,
+        :request,
+        fn %Req.Request{url: %URI{path: "/trips"}, options: %{params: _params}} ->
+          {:ok,
+           Req.Response.json([
+             %{
+               "attributes" => %{
+                 "headsign" => trip.headsign
+               },
+               "id" => trip.id,
+               "type" => "trip"
+             }
+           ])}
+        end
+      )
+
+      alert =
+        build(:alert,
+          active_period: [
+            %Alert.ActivePeriod{
+              start: DateTime.add(now, -2, :hour),
+              end: DateTime.add(now, 2, :hour)
+            }
+          ],
+          cause: :weather,
+          effect: :station_closure,
+          informed_entity: [
+            %Alert.InformedEntity{
+              trip: trip.id,
+              stop: stop2.id
+            },
+            %Alert.InformedEntity{
+              trip: trip.id,
+              stop: stop3.id
+            }
+          ]
+        )
+
+      schedule =
+        build(:schedule,
+          trip_id: trip.id,
+          departure_time: ~B[2026-03-12 12:13:00]
+        )
+
+      trip_time = schedule.departure_time
+      route_type = route.type
+
+      assert %AlertSummary.TripSpecific{
+               trip_identity: %AlertSummary.TripSpecific.TripTo{
+                 trip_time: ^trip_time,
+                 route_type: ^route_type,
+                 headsign: "South Station"
+               },
+               effect: :station_closure,
+               effect_stops: ["Back Bay", "South Station"],
+               is_today: true,
+               cause: :weather,
+               recurrence: nil
+             } =
+               AlertSummary.summarizing(alert, stop1.id, 0, [pattern], now, [schedule], %{
+                 stops: %{stop1.id => stop1, stop2.id => stop2, stop3.id => stop3},
+                 routes: %{route.id => route}
                })
     end
 
@@ -1519,7 +1716,7 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                  [pattern],
                  now,
                  [schedule1, schedule2],
-                 %{}
+                 %{routes: %{route.id => route}}
                )
     end
 
@@ -1561,10 +1758,10 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
       assert %AlertSummary.TripShuttle{
                trip_identity: %AlertSummary.TripShuttle.SingleTrip{
                  trip_time: ^trip_time,
-                 route_type: :commuter_rail
+                 route_type: :commuter_rail,
+                 from_stop_name: nil
                },
-               is_today: true,
-               current_stop_name: "Ruggles",
+               start_stop_name: "Ruggles",
                end_stop_name: "Forest Hills",
                recurrence: nil
              } =
@@ -1606,6 +1803,7 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
         )
 
       trip_time = schedule.departure_time
+      route_type = route.type
 
       reassign_env(:mobile_app_backend, MBTAV3API.Repository, RepositoryMock)
 
@@ -1617,13 +1815,15 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
       assert %AlertSummary.TripSpecific{
                trip_identity: %AlertSummary.TripSpecific.TripTo{
                  trip_time: ^trip_time,
+                 route_type: ^route_type,
                  headsign: "Stoughton"
                },
                effect: :station_closure,
                effect_stops: ["Back Bay", "Ruggles"]
              } =
                AlertSummary.summarizing(alert, stop1.id, 0, [pattern], now, [schedule], %{
-                 stops: %{stop1.id => stop1, stop2.id => stop2}
+                 stops: %{stop1.id => stop1, stop2.id => stop2},
+                 routes: %{route.id => route}
                })
     end
 
@@ -1653,17 +1853,20 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
         )
 
       trip_time = schedule.departure_time
+      route_type = route.type
 
       assert %AlertSummary.TripSpecific{
                trip_identity: %AlertSummary.TripSpecific.TripFrom{
                  trip_time: ^trip_time,
+                 route_type: ^route_type,
                  stop_name: "Ruggles"
                },
                effect: :suspension,
                is_today: false
              } =
                AlertSummary.summarizing(alert, stop.id, 0, [pattern], now, [schedule], %{
-                 stops: %{stop.id => stop}
+                 stops: %{stop.id => stop},
+                 routes: %{route.id => route}
                })
     end
 
@@ -1708,10 +1911,10 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
       assert %AlertSummary.TripShuttle{
                trip_identity: %AlertSummary.TripShuttle.SingleTrip{
                  trip_time: ^trip_time,
-                 route_type: :commuter_rail
+                 route_type: :commuter_rail,
+                 from_stop_name: nil
                },
-               is_today: true,
-               current_stop_name: "Ruggles",
+               start_stop_name: "Ruggles",
                end_stop_name: "Forest Hills",
                recurrence: %AlertSummary.Recurrence.Daily{
                  ending: %AlertSummary.Timeframe.ThisWeek{time: ^end_time}
@@ -2080,17 +2283,23 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
         )
 
       summary1 = %AlertSummary.TripShuttle{
-        trip_identity: %TripShuttle.SingleTrip{trip_time: now, route_type: :commuter_Rail},
-        is_today: true,
-        current_stop_name: "South Station",
+        trip_identity: %TripShuttle.SingleTrip{
+          trip_time: now,
+          route_type: :commuter_Rail,
+          from_stop_name: "Route 128"
+        },
+        start_stop_name: "South Station",
         end_stop_name: "Ruggles",
         recurrence: %Recurrence.Daily{ending: %Timeframe.Tomorrow{}}
       }
 
       summary2 = %AlertSummary.TripShuttle{
-        trip_identity: %TripShuttle.SingleTrip{trip_time: now, route_type: :commuter_Rail},
-        is_today: true,
-        current_stop_name: "South Station",
+        trip_identity: %TripShuttle.SingleTrip{
+          trip_time: now,
+          route_type: :commuter_Rail,
+          from_stop_name: "Route 128"
+        },
+        start_stop_name: "South Station",
         end_stop_name: "Ruggles",
         recurrence: %Recurrence.Daily{ending: %Timeframe.Tomorrow{}}
       }
@@ -2119,9 +2328,12 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
         )
 
       summary1 = %AlertSummary.TripShuttle{
-        trip_identity: %TripShuttle.SingleTrip{trip_time: now, route_type: :commuter_Rail},
-        is_today: true,
-        current_stop_name: "South Station",
+        trip_identity: %TripShuttle.SingleTrip{
+          trip_time: now,
+          route_type: :commuter_Rail,
+          from_stop_name: nil
+        },
+        start_stop_name: "South Station",
         end_stop_name: "Ruggles",
         recurrence: %Recurrence.Daily{ending: %Timeframe.Tomorrow{}}
       }
@@ -2129,18 +2341,17 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
       summary2 = %AlertSummary.TripShuttle{
         trip_identity: %TripShuttle.SingleTrip{
           trip_time: DateTime.add(now, 2),
-          route_type: :commuter_Rail
+          route_type: :commuter_Rail,
+          from_stop_name: nil
         },
-        is_today: true,
-        current_stop_name: "South Station",
+        start_stop_name: "South Station",
         end_stop_name: "Ruggles",
         recurrence: %Recurrence.Daily{ending: %Timeframe.Tomorrow{}}
       }
 
       assert %AlertSummary.TripShuttle{
                trip_identity: %TripShuttle.MultipleTrips{},
-               is_today: true,
-               current_stop_name: "South Station",
+               start_stop_name: "South Station",
                end_stop_name: "Ruggles",
                recurrence: %Recurrence.Daily{ending: %Timeframe.Tomorrow{}}
              } ==
@@ -2167,9 +2378,12 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
         )
 
       summary1 = %AlertSummary.TripShuttle{
-        trip_identity: %TripShuttle.SingleTrip{trip_time: now, route_type: :commuter_Rail},
-        is_today: true,
-        current_stop_name: "South Station",
+        trip_identity: %TripShuttle.SingleTrip{
+          trip_time: now,
+          route_type: :commuter_Rail,
+          from_stop_name: nil
+        },
+        start_stop_name: "South Station",
         end_stop_name: "Ruggles",
         recurrence: %Recurrence.Daily{ending: %Timeframe.Tomorrow{}}
       }
@@ -2177,10 +2391,10 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
       summary2 = %AlertSummary.TripShuttle{
         trip_identity: %TripShuttle.SingleTrip{
           trip_time: DateTime.add(now, 2),
-          route_type: :commuter_Rail
+          route_type: :commuter_Rail,
+          from_stop_name: nil
         },
-        is_today: true,
-        current_stop_name: "Needham",
+        start_stop_name: "Needham",
         end_stop_name: "Ruggles",
         recurrence: %Recurrence.Daily{ending: %Timeframe.Tomorrow{}}
       }

--- a/test/mobile_app_backend/alerts/alert_summary_test.exs
+++ b/test/mobile_app_backend/alerts/alert_summary_test.exs
@@ -207,7 +207,8 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                  effect: "station_closure",
                  location: %{
                    type: "single_stop",
-                   stop_name: "Lechmere"
+                   stop_name: "Lechmere",
+                   downstream: nil
                  },
                  timeframe: %{type: "tomorrow"},
                  recurrence: %{
@@ -222,14 +223,16 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
       assert json_round_trip(%AlertSummary.AllClear{
                location: %AlertSummary.Location.SuccessiveStops{
                  start_stop_name: "Lechmere",
-                 end_stop_name: "Government Center"
+                 end_stop_name: "Government Center",
+                 downstream: true
                }
              }) == %{
                type: "all_clear",
                location: %{
                  type: "successive_stops",
                  start_stop_name: "Lechmere",
-                 end_stop_name: "Government Center"
+                 end_stop_name: "Government Center",
+                 downstream: true
                }
              }
     end
@@ -292,34 +295,53 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
     test "can serialize all locations" do
       assert json_round_trip(%AlertSummary.Location.DirectionToStop{
                direction: %Direction{name: "East", destination: "Union Square", id: 1},
-               end_stop_name: "Lechmere"
+               end_stop_name: "Lechmere",
+               downstream: false
              }) == %{
                type: "direction_to_stop",
                direction: %{name: "East", destination: "Union Square", id: 1},
-               end_stop_name: "Lechmere"
+               end_stop_name: "Lechmere",
+               downstream: false
              }
 
-      assert json_round_trip(%AlertSummary.Location.SingleStop{stop_name: "Lechmere"}) == %{
+      assert json_round_trip(%AlertSummary.Location.SingleStop{
+               stop_name: "Lechmere",
+               downstream: nil
+             }) == %{
                type: "single_stop",
-               stop_name: "Lechmere"
+               stop_name: "Lechmere",
+               downstream: nil
              }
 
       assert json_round_trip(%AlertSummary.Location.StopToDirection{
                start_stop_name: "Lechmere",
-               direction: %Direction{name: "West", destination: "Copley & West", id: 0}
+               direction: %Direction{name: "West", destination: "Copley & West", id: 0},
+               downstream: true
              }) == %{
                type: "stop_to_direction",
                start_stop_name: "Lechmere",
-               direction: %{name: "West", destination: "Copley & West", id: 0}
+               direction: %{name: "West", destination: "Copley & West", id: 0},
+               downstream: true
              }
 
       assert json_round_trip(%AlertSummary.Location.SuccessiveStops{
                start_stop_name: "Lechmere",
-               end_stop_name: "North Station"
+               end_stop_name: "North Station",
+               downstream: false
              }) == %{
                type: "successive_stops",
                start_stop_name: "Lechmere",
-               end_stop_name: "North Station"
+               end_stop_name: "North Station",
+               downstream: false
+             }
+
+      assert json_round_trip(%AlertSummary.Location.WholeRoute{
+               route_label: "Orange Line",
+               route_type: :heavy_rail
+             }) == %{
+               type: "whole_route",
+               route_label: "Orange Line",
+               route_type: "heavy_rail"
              }
     end
 
@@ -526,7 +548,10 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
         )
 
       assert %AlertSummary.Standard{
-               location: %AlertSummary.Location.SingleStop{stop_name: "Parent Name"}
+               location: %AlertSummary.Location.SingleStop{
+                 stop_name: "Parent Name",
+                 downstream: true
+               }
              } =
                AlertSummary.summarizing(alert, "", 0, [pattern], now, nil, %{
                  routes: %{route.id => route},
@@ -568,14 +593,23 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
       assert %AlertSummary.Standard{
                location: %AlertSummary.Location.SuccessiveStops{
                  start_stop_name: "Harvard Sq @ Garden St - Dawes Island",
-                 end_stop_name: "Last Stop"
+                 end_stop_name: "Last Stop",
+                 downstream: false
                }
              } =
-               AlertSummary.summarizing(alert, "", 0, [pattern], now, nil, %{
-                 routes: %{route.id => route},
-                 stops: Map.new(stops, &{&1.id, &1}),
-                 trips: %{trip.id => trip}
-               })
+               AlertSummary.summarizing(
+                 alert,
+                 Enum.at(successive_stops, 2).id,
+                 0,
+                 [pattern],
+                 now,
+                 nil,
+                 %{
+                   routes: %{route.id => route},
+                   stops: Map.new(stops, &{&1.id, &1}),
+                   trips: %{trip.id => trip}
+                 }
+               )
     end
 
     test "summary with successive bus stops", %{now: now} do
@@ -674,7 +708,8 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
       assert %AlertSummary.Standard{
                location: %AlertSummary.Location.StopToDirection{
                  start_stop_name: "First Stop",
-                 direction: %Direction{name: "Inbound", destination: "A", id: 0}
+                 direction: %Direction{name: "Inbound", destination: "A", id: 0},
+                 downstream: true
                }
              } =
                AlertSummary.summarizing(
@@ -754,7 +789,8 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
       assert %AlertSummary.Standard{
                location: %AlertSummary.Location.DirectionToStop{
                  direction: %Direction{name: "Outbound", destination: "Z", id: 1},
-                 end_stop_name: "Last Stop"
+                 end_stop_name: "Last Stop",
+                 downstream: true
                }
              } =
                AlertSummary.summarizing(
@@ -831,7 +867,8 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
       assert %AlertSummary.Standard{
                location: %AlertSummary.Location.StopToDirection{
                  start_stop_name: "Kenmore",
-                 direction: %Direction{name: "Westbound", destination: "", id: 0}
+                 direction: %Direction{name: "Westbound", destination: "", id: 0},
+                 downstream: false
                }
              } =
                AlertSummary.summarizing(alert, kenmore.id, 0, [b_branch, c_branch], now, nil, %{


### PR DESCRIPTION
### Summary

_Ticket:_ [Notifications QA | Trip specific suspension and shuttle alert summaries](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214072175090608?focus=true)
Frontend PR: https://github.com/mbta/mobile_app/pull/1685

Fix a few edge cases with trip specific shuttle, suspension, and stop closure legibility.
I added the `ThisTrip` state, even though we don't use it anywhere on the backend, because it seemed weird to have this not match the frontend, but maybe it's worth removing it so that we have no chance of accidentally sending it to the frontend.

Added a few unit tests, but most cases were already covered by existing ones.

<img width="1170" height="349" alt="IMG_0050" src="https://github.com/user-attachments/assets/3cbddd96-33f8-4cc1-bd76-c7eae4468774" />
<img width="1166" height="323" alt="IMG_0051" src="https://github.com/user-attachments/assets/8aab7f15-72fa-4e3d-815a-de1d3fd8c426" />
<img width="1168" height="324" alt="IMG_0052" src="https://github.com/user-attachments/assets/b6fb620a-734f-4b02-ba18-268873ad63ca" />
<img width="1169" height="324" alt="IMG_0054" src="https://github.com/user-attachments/assets/960c9201-d3e9-40bf-91c2-1d213a65731a" />
<img width="1168" height="324" alt="IMG_0053" src="https://github.com/user-attachments/assets/fc929a5c-9ae6-421b-a444-118c6e2ff577" />
