### PR TITLE
refactor(Alert.RecurrenceInfo): Calculate daily based on set of days in range

### DIFF
--- a/lib/mbta_v3_api/alert.ex
+++ b/lib/mbta_v3_api/alert.ex
@@ -349,7 +349,17 @@ defmodule MBTAV3API.Alert do
     defstruct [:start, :end, :days, :end_day_known]
 
     @spec daily(t()) :: boolean()
-    def daily(%__MODULE__{days: days}), do: MapSet.size(days) == 7
+    def daily(recurrence_info) do
+      if recurrence_info.days <= 1 do
+        false
+      else
+        recurrence_info.start
+        |> Util.datetime_to_gtfs()
+        |> Date.range(Util.datetime_to_gtfs(recurrence_info.end, rounding: :backwards))
+        |> Enum.map(&Date.day_of_week(&1))
+        |> MapSet.new() == recurrence_info.days
+      end
+    end
   end
 
   @spec recurrence_range(t()) :: RecurrenceInfo.t() | nil
@@ -371,30 +381,10 @@ defmodule MBTAV3API.Alert do
         end)
         |> MapSet.new()
 
-      # If all the days in the range have been seen, then include all days.
-      # This indicates that the alert is "daily".
-      all_days_in_range_seen =
-        first_period.start
-        |> Util.datetime_to_gtfs()
-        |> Date.range(
-          Util.datetime_to_gtfs(last_period.end,
-            rounding: :backwards
-          )
-        )
-        |> Enum.map(&Date.day_of_week(&1))
-        |> MapSet.new() == seen_days_of_week
-
-      days =
-        if all_days_in_range_seen do
-          MapSet.new(1..7)
-        else
-          seen_days_of_week
-        end
-
       %RecurrenceInfo{
         start: first_period.start,
         end: last_period.end,
-        days: days,
+        days: seen_days_of_week,
         end_day_known: alert.duration_certainty == :known
       }
     else

--- a/test/mbta_v3_api/alert_test.exs
+++ b/test/mbta_v3_api/alert_test.exs
@@ -4,9 +4,7 @@ defmodule MBTAV3API.AlertTest do
   import Mox
   import MobileAppBackend.Factory
 
-  alias MBTAV3API.Alert.RecurrenceInfo
-  alias MBTAV3API.Alert.ActivePeriod
-  alias MBTAV3API.Alert.InformedEntity
+  alias MBTAV3API.Alert.{ActivePeriod, InformedEntity, RecurrenceInfo}
   alias MBTAV3API.{Alert, JsonApi}
   alias MobileAppBackend.GlobalDataCache
   import Test.Support.Helpers

--- a/test/mbta_v3_api/alert_test.exs
+++ b/test/mbta_v3_api/alert_test.exs
@@ -4,6 +4,7 @@ defmodule MBTAV3API.AlertTest do
   import Mox
   import MobileAppBackend.Factory
 
+  alias MBTAV3API.Alert.RecurrenceInfo
   alias MBTAV3API.Alert.ActivePeriod
   alias MBTAV3API.Alert.InformedEntity
   alias MBTAV3API.{Alert, JsonApi}
@@ -432,8 +433,12 @@ defmodule MBTAV3API.AlertTest do
   end
 
   describe "recurrence_range/1" do
-    test "daily on all days" do
-      today = "America/New_York" |> DateTime.now!() |> Util.datetime_to_gtfs()
+    test "daily on all days in range" do
+      today =
+        Date.new!(2026, 4, 13)
+        |> DateTime.new!(Time.new!(3, 0, 0), "America/New_York")
+        |> Util.datetime_to_gtfs()
+
       nine_pm = ~T[21:00:00]
       end_of_service = ~T[03:00:00]
 
@@ -454,12 +459,15 @@ defmodule MBTAV3API.AlertTest do
             end
         )
 
-      assert Alert.recurrence_range(alert) == %Alert.RecurrenceInfo{
-               start: DateTime.new!(today, nine_pm, "America/New_York"),
-               end: DateTime.new!(Date.add(today, 6), end_of_service, "America/New_York"),
-               days: MapSet.new(1..7),
-               end_day_known: true
-             }
+      recurrence = %Alert.RecurrenceInfo{
+        start: DateTime.new!(today, nine_pm, "America/New_York"),
+        end: DateTime.new!(Date.add(today, 6), end_of_service, "America/New_York"),
+        days: MapSet.new(1..6),
+        end_day_known: true
+      }
+
+      assert Alert.recurrence_range(alert) == recurrence
+      assert RecurrenceInfo.daily(recurrence)
     end
 
     test "selects specific days" do
@@ -488,17 +496,24 @@ defmodule MBTAV3API.AlertTest do
             end)
         )
 
-      assert Alert.recurrence_range(alert) == %Alert.RecurrenceInfo{
-               start: List.first(alert.active_period).start,
-               end: List.last(alert.active_period).end,
-               days: selected_days,
-               end_day_known: true
-             }
+      recurrence = %Alert.RecurrenceInfo{
+        start: List.first(alert.active_period).start,
+        end: List.last(alert.active_period).end,
+        days: selected_days,
+        end_day_known: true
+      }
+
+      assert Alert.recurrence_range(alert) == recurrence
+      refute RecurrenceInfo.daily(recurrence)
     end
 
     test "recurrence range end unknown" do
-      today = "America/New_York" |> DateTime.now!() |> Util.datetime_to_gtfs()
-      nine_pm = ~T[21:00:00]
+      today =
+        Date.new!(2026, 4, 13)
+        |> DateTime.new!(Time.new!(3, 0, 0), "America/New_York")
+        |> Util.datetime_to_gtfs()
+
+      nine_am = ~T[09:00:00]
       end_of_service = ~T[03:00:00]
 
       alert =
@@ -507,7 +522,7 @@ defmodule MBTAV3API.AlertTest do
           active_period:
             for days_forward <- 0..5 do
               %ActivePeriod{
-                start: DateTime.new!(Date.add(today, days_forward), nine_pm, "America/New_York"),
+                start: DateTime.new!(Date.add(today, days_forward), nine_am, "America/New_York"),
                 end:
                   DateTime.new!(
                     Date.add(today, days_forward + 1),
@@ -518,12 +533,15 @@ defmodule MBTAV3API.AlertTest do
             end
         )
 
-      assert Alert.recurrence_range(alert) == %Alert.RecurrenceInfo{
-               start: DateTime.new!(today, nine_pm, "America/New_York"),
-               end: DateTime.new!(Date.add(today, 6), end_of_service, "America/New_York"),
-               days: MapSet.new(1..7),
-               end_day_known: false
-             }
+      recurrence = %Alert.RecurrenceInfo{
+        start: DateTime.new!(today, nine_am, "America/New_York"),
+        end: DateTime.new!(Date.add(today, 6), end_of_service, "America/New_York"),
+        days: MapSet.new(1..6),
+        end_day_known: false
+      }
+
+      assert Alert.recurrence_range(alert) == recurrence
+      assert RecurrenceInfo.daily(recurrence)
     end
 
     test "two sets of continuous week days" do
@@ -544,13 +562,15 @@ defmodule MBTAV3API.AlertTest do
           ]
         )
 
-      assert Alert.recurrence_range(alert) == %Alert.RecurrenceInfo{
-               start:
-                 DateTime.new!(Date.new!(2026, 4, 22), Time.new!(3, 0, 0), "America/New_York"),
-               end: DateTime.new!(Date.new!(2026, 5, 1), Time.new!(3, 0, 0), "America/New_York"),
-               days: MapSet.new(1..5),
-               end_day_known: true
-             }
+      recurrence = %Alert.RecurrenceInfo{
+        start: DateTime.new!(Date.new!(2026, 4, 22), Time.new!(3, 0, 0), "America/New_York"),
+        end: DateTime.new!(Date.new!(2026, 5, 1), Time.new!(3, 0, 0), "America/New_York"),
+        days: MapSet.new(1..5),
+        end_day_known: true
+      }
+
+      assert Alert.recurrence_range(alert) == recurrence
+      refute RecurrenceInfo.daily(recurrence)
     end
   end
 


### PR DESCRIPTION
### Summary

What is this PR for?
Follow up to https://github.com/mbta/mobile_app_backend/pull/469. 
Backend version of https://github.com/mbta/mobile_app/pull/1690. 

Ensures `days` contains only the days that the alert actually covers, and `daily` can be true if all days in the range are covered, even if the range < 7 days.