### PR TITLE
test(NotificationSubscriptionsController): Fix flakiness comparing windows

### DIFF
--- a/test/mobile_app_backend_web/controllers/notification_subscriptions_controller_test.exs
+++ b/test/mobile_app_backend_web/controllers/notification_subscriptions_controller_test.exs
@@ -224,12 +224,12 @@ defmodule MobileAppBackendWeb.NotificationSubscriptionsControllerTest do
       assert new_subscription.include_accessibility == not old_subscription.include_accessibility
       assert length(new_subscription.windows) == length(old_subscription.windows) - 1
 
-      Enum.zip_with(new_subscription.windows, old_subscription.windows, fn new_window,
-                                                                           old_window ->
-        assert new_window.id == old_window.id
-        assert Time.compare(new_window.start_time, old_window.start_time) == :gt
-        assert Time.compare(new_window.end_time, old_window.end_time) == :lt
-        assert length(new_window.days_of_week) != length(old_window.days_of_week)
+      Enum.each(new_subscription.windows, fn actual_window ->
+        assert Enum.find(
+                 new_windows,
+                 &(Time.from_iso8601!(&1.start_time) == actual_window.start_time &&
+                     Time.from_iso8601!(&1.end_time) == actual_window.end_time)
+               ) != nil
       end)
     end
 

--- a/test/mobile_app_backend_web/controllers/notification_subscriptions_controller_test.exs
+++ b/test/mobile_app_backend_web/controllers/notification_subscriptions_controller_test.exs
@@ -225,11 +225,17 @@ defmodule MobileAppBackendWeb.NotificationSubscriptionsControllerTest do
       assert length(new_subscription.windows) == length(old_subscription.windows) - 1
 
       Enum.each(new_subscription.windows, fn actual_window ->
-        assert Enum.find(
-                 new_windows,
-                 &(Time.from_iso8601!(&1.start_time) == actual_window.start_time &&
-                     Time.from_iso8601!(&1.end_time) == actual_window.end_time)
-               ) != nil
+        matching_expected_window =
+          Enum.find(
+            new_windows,
+            &(Time.from_iso8601!(&1.start_time) == actual_window.start_time &&
+                Time.from_iso8601!(&1.end_time) == actual_window.end_time)
+          )
+
+        assert matching_expected_window != nil
+
+        assert Enum.sort(matching_expected_window.days_of_week) ==
+                 Enum.sort(actual_window.days_of_week)
       end)
     end
 


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket, observed in https://github.com/mbta/mobile_app_backend/pull/474

What is this PR for?
This updates how we are we testing that windows have changed when a subscription was updated. Previously, we were zipping old & new windows together and comparing values based on the window's id. However, in [WritePayload.changeset](https://github.com/mbta/mobile_app_backend/blob/c9d38906757265814ec8890422cd50220e8e8483/lib/mobile_app_backend/notifications/write_payload.ex#L69), windows are overwritten without regard to their id.

Because of that, I think we were getting a mismatch of expected & actual windows in the comparison. Now, the test is ignoring the old windows and only testing that the actual windows all match what was specified when updating the windows.

