### PR TITLE
fix: Only send alerts with push timestamps

### DIFF
--- a/lib/mobile_app_backend/notifications/engine.ex
+++ b/lib/mobile_app_backend/notifications/engine.ex
@@ -51,9 +51,7 @@ defmodule MobileAppBackend.Notifications.Engine do
             {subscriptions, :all_clear}
 
           %{notification: subscriptions} ->
-            {subscriptions,
-             {:notification,
-              alert.last_push_notification_timestamp || hd(alert.active_period).start}}
+            {subscriptions, {:notification, alert.last_push_notification_timestamp}}
 
           %{reminder: subscriptions} ->
             {subscriptions, :reminder}
@@ -104,7 +102,9 @@ defmodule MobileAppBackend.Notifications.Engine do
         []
       end
 
-    relevant_alerts = Enum.uniq(applicable_alerts ++ downstream_alerts ++ elevator_alerts)
+    relevant_alerts =
+      Enum.uniq(applicable_alerts ++ downstream_alerts ++ elevator_alerts)
+      |> Enum.filter(&(&1.last_push_notification_timestamp != nil))
 
     Enum.flat_map(relevant_alerts, fn %Alert{} = alert ->
       List.wrap(alert_candidate(subscription, alert, now))

--- a/test/mobile_app_backend/notifications/engine_test.exs
+++ b/test/mobile_app_backend/notifications/engine_test.exs
@@ -22,8 +22,7 @@ defmodule MobileAppBackend.Notifications.EngineTest do
       build(:alert,
         active_period: [%Alert.ActivePeriod{start: DateTime.from_unix!(0), end: nil}],
         effect: :suspension,
-        informed_entity: [%Alert.InformedEntity{activities: [:board], route: "Green-D"}],
-        last_push_notification_timestamp: now |> DateTime.add(-2)
+        informed_entity: [%Alert.InformedEntity{activities: [:board], route: "Green-D"}]
       )
 
     subscription =
@@ -62,8 +61,7 @@ defmodule MobileAppBackend.Notifications.EngineTest do
         informed_entity: [
           %Alert.InformedEntity{activities: [:board], route: "Green-D"},
           %Alert.InformedEntity{activities: [:board], route: "Green-E"}
-        ],
-        last_push_notification_timestamp: now |> DateTime.add(-2)
+        ]
       )
 
     subscription =
@@ -119,8 +117,7 @@ defmodule MobileAppBackend.Notifications.EngineTest do
       build(:alert,
         active_period: [%Alert.ActivePeriod{start: DateTime.from_unix!(0), end: nil}],
         effect: :suspension,
-        informed_entity: [%Alert.InformedEntity{activities: [:board], stop: "70158"}],
-        last_push_notification_timestamp: now |> DateTime.add(-2)
+        informed_entity: [%Alert.InformedEntity{activities: [:board], stop: "70158"}]
       )
 
     subscription =
@@ -154,8 +151,7 @@ defmodule MobileAppBackend.Notifications.EngineTest do
             route: "Orange",
             stop: "70005"
           }
-        ],
-        last_push_notification_timestamp: now |> DateTime.add(-2)
+        ]
       )
 
     subscription =
@@ -182,8 +178,7 @@ defmodule MobileAppBackend.Notifications.EngineTest do
             activities: [:using_wheelchair],
             stop: "place-chncl"
           }
-        ],
-        last_push_notification_timestamp: now |> DateTime.add(-2)
+        ]
       )
 
     subscription_including =
@@ -378,8 +373,7 @@ defmodule MobileAppBackend.Notifications.EngineTest do
           %Alert.ActivePeriod{start: now |> DateTime.add(24, :hour) |> DateTime.add(-1), end: nil}
         ],
         effect: :suspension,
-        informed_entity: [%Alert.InformedEntity{activities: [:board], route: "Red"}],
-        last_push_notification_timestamp: now |> DateTime.add(-2)
+        informed_entity: [%Alert.InformedEntity{activities: [:board], route: "Red"}]
       )
 
     subscription =
@@ -434,8 +428,7 @@ defmodule MobileAppBackend.Notifications.EngineTest do
       build(:alert,
         active_period: [%Alert.ActivePeriod{start: now_plus_12h |> DateTime.add(-1), end: nil}],
         effect: :suspension,
-        informed_entity: [%Alert.InformedEntity{activities: [:board], route: "Red"}],
-        last_push_notification_timestamp: now |> DateTime.add(-2)
+        informed_entity: [%Alert.InformedEntity{activities: [:board], route: "Red"}]
       )
 
     subscription =
@@ -681,8 +674,7 @@ defmodule MobileAppBackend.Notifications.EngineTest do
         informed_entity: [
           %Alert.InformedEntity{activities: [:board], stop: "place-boyls", route: "Green-D"},
           %Alert.InformedEntity{activities: [:board], stop: "place-river", route: "Green-D"}
-        ],
-        last_push_notification_timestamp: now |> DateTime.add(-2)
+        ]
       )
 
     subscription1 =

--- a/test/mobile_app_backend/notifications/engine_test.exs
+++ b/test/mobile_app_backend/notifications/engine_test.exs
@@ -22,7 +22,8 @@ defmodule MobileAppBackend.Notifications.EngineTest do
       build(:alert,
         active_period: [%Alert.ActivePeriod{start: DateTime.from_unix!(0), end: nil}],
         effect: :suspension,
-        informed_entity: [%Alert.InformedEntity{activities: [:board], route: "Green-D"}]
+        informed_entity: [%Alert.InformedEntity{activities: [:board], route: "Green-D"}],
+        last_push_notification_timestamp: now |> DateTime.add(-2)
       )
 
     subscription =
@@ -61,7 +62,8 @@ defmodule MobileAppBackend.Notifications.EngineTest do
         informed_entity: [
           %Alert.InformedEntity{activities: [:board], route: "Green-D"},
           %Alert.InformedEntity{activities: [:board], route: "Green-E"}
-        ]
+        ],
+        last_push_notification_timestamp: now |> DateTime.add(-2)
       )
 
     subscription =
@@ -117,7 +119,8 @@ defmodule MobileAppBackend.Notifications.EngineTest do
       build(:alert,
         active_period: [%Alert.ActivePeriod{start: DateTime.from_unix!(0), end: nil}],
         effect: :suspension,
-        informed_entity: [%Alert.InformedEntity{activities: [:board], stop: "70158"}]
+        informed_entity: [%Alert.InformedEntity{activities: [:board], stop: "70158"}],
+        last_push_notification_timestamp: now |> DateTime.add(-2)
       )
 
     subscription =
@@ -151,7 +154,8 @@ defmodule MobileAppBackend.Notifications.EngineTest do
             route: "Orange",
             stop: "70005"
           }
-        ]
+        ],
+        last_push_notification_timestamp: now |> DateTime.add(-2)
       )
 
     subscription =
@@ -178,7 +182,8 @@ defmodule MobileAppBackend.Notifications.EngineTest do
             activities: [:using_wheelchair],
             stop: "place-chncl"
           }
-        ]
+        ],
+        last_push_notification_timestamp: now |> DateTime.add(-2)
       )
 
     subscription_including =
@@ -211,7 +216,8 @@ defmodule MobileAppBackend.Notifications.EngineTest do
       build(:alert,
         closed_timestamp: DateTime.add(now, -1),
         effect: :suspension,
-        informed_entity: [%Alert.InformedEntity{activities: [:board], route: "Red"}]
+        informed_entity: [%Alert.InformedEntity{activities: [:board], route: "Red"}],
+        last_push_notification_timestamp: DateTime.add(now, -2)
       )
 
     subscription =
@@ -302,6 +308,42 @@ defmodule MobileAppBackend.Notifications.EngineTest do
   test "sends notification with timestamp if open" do
     now = DateTime.now!("America/New_York")
     start_time = DateTime.add(now, -1)
+    notification_time = DateTime.add(now, -2)
+
+    alert =
+      build(:alert,
+        active_period: [%Alert.ActivePeriod{start: start_time, end: nil}],
+        effect: :suspension,
+        informed_entity: [%Alert.InformedEntity{activities: [:board], route: "Red"}],
+        last_push_notification_timestamp: notification_time
+      )
+
+    subscription =
+      NotificationsFactory.build(:notification_subscription,
+        route_id: "Red",
+        stop_id: "place-sstat",
+        windows: [
+          NotificationsFactory.build(:window,
+            start_time: start_time |> DateTime.to_time(),
+            end_time: now |> DateTime.add(1) |> DateTime.to_time(),
+            days_of_week: Range.to_list(0..6)
+          )
+        ]
+      )
+
+    assert [
+             %OutgoingNotification{
+               subscriptions: [^subscription],
+               alert: ^alert,
+               type: {:notification, ^notification_time}
+             }
+           ] =
+             Engine.notifications([subscription], [alert], now)
+  end
+
+  test "skips notification if timestamp is nil" do
+    now = DateTime.now!("America/New_York")
+    start_time = DateTime.add(now, -1)
 
     alert =
       build(:alert,
@@ -324,14 +366,7 @@ defmodule MobileAppBackend.Notifications.EngineTest do
         ]
       )
 
-    assert [
-             %OutgoingNotification{
-               subscriptions: [^subscription],
-               alert: ^alert,
-               type: {:notification, ^start_time}
-             }
-           ] =
-             Engine.notifications([subscription], [alert], now)
+    assert [] = Engine.notifications([subscription], [alert], now)
   end
 
   test "sends reminder at 24h-1s if open before active" do
@@ -343,7 +378,8 @@ defmodule MobileAppBackend.Notifications.EngineTest do
           %Alert.ActivePeriod{start: now |> DateTime.add(24, :hour) |> DateTime.add(-1), end: nil}
         ],
         effect: :suspension,
-        informed_entity: [%Alert.InformedEntity{activities: [:board], route: "Red"}]
+        informed_entity: [%Alert.InformedEntity{activities: [:board], route: "Red"}],
+        last_push_notification_timestamp: now |> DateTime.add(-2)
       )
 
     subscription =
@@ -398,7 +434,8 @@ defmodule MobileAppBackend.Notifications.EngineTest do
       build(:alert,
         active_period: [%Alert.ActivePeriod{start: now_plus_12h |> DateTime.add(-1), end: nil}],
         effect: :suspension,
-        informed_entity: [%Alert.InformedEntity{activities: [:board], route: "Red"}]
+        informed_entity: [%Alert.InformedEntity{activities: [:board], route: "Red"}],
+        last_push_notification_timestamp: now |> DateTime.add(-2)
       )
 
     subscription =
@@ -452,7 +489,8 @@ defmodule MobileAppBackend.Notifications.EngineTest do
       build(:alert,
         active_period: [%Alert.ActivePeriod{start: friday_noon, end: nil}],
         effect: :suspension,
-        informed_entity: [%Alert.InformedEntity{activities: [:board], route: "Red"}]
+        informed_entity: [%Alert.InformedEntity{activities: [:board], route: "Red"}],
+        last_push_notification_timestamp: friday_noon
       )
 
     subscription =
@@ -643,7 +681,8 @@ defmodule MobileAppBackend.Notifications.EngineTest do
         informed_entity: [
           %Alert.InformedEntity{activities: [:board], stop: "place-boyls", route: "Green-D"},
           %Alert.InformedEntity{activities: [:board], stop: "place-river", route: "Green-D"}
-        ]
+        ],
+        last_push_notification_timestamp: now |> DateTime.add(-2)
       )
 
     subscription1 =

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -20,7 +20,8 @@ defmodule MobileAppBackend.Factory do
           route_type: :bus
         }
       ],
-      lifecycle: :new
+      lifecycle: :new,
+      last_push_notification_timestamp: ~B[2024-02-14T03:00:00]
     }
   end
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Notifications | Fix: users receive notifications for alerts created with notification checkbox unchecked](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214312229016953?focus=true)

I think this should cover all cases of only notifying users if the checkbox updates the push timestamp. Since nil timestamps are filtered out, that ensures that a notification or reminder will never be sent unless the notification checkbox was ticket on creation or a subsequent update, and since now the push timestamp is the only time that can ever be saved with the notification record, new notifications can't be sent until the timestamp is updated, and all clears have their separate check to make sure the close timestamp is the same as the push timestamp.
