### PR TITLE
feat: import localizations automatically from iOS format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,8 @@ jobs:
         run: mix credo --strict
       - name: Check formatting
         run: mix format --check-formatted
+      - name: Check gettext.extract
+        run: mix gettext.extract --check-up-to-date
       - name: Run tests
         run: mix test --cover
       - name: Report test coverage

--- a/config/config.exs
+++ b/config/config.exs
@@ -78,6 +78,8 @@ config :mobile_app_backend, :logger, [
    }}
 ]
 
+config :gettext, plural_forms: MobileAppBackend.Gettext.Plural
+
 # Configure esbuild (the version is required)
 config :esbuild,
   version: "0.27.3",

--- a/lib/mix/tasks/import_localizations.ex
+++ b/lib/mix/tasks/import_localizations.ex
@@ -1,0 +1,118 @@
+defmodule Mix.Tasks.ImportLocalizations do
+  @moduledoc """
+  Imports localizations from an iOS Localizable.xcstrings file.
+
+  Usage:
+
+      mix import_localizations ../mobile_app/iosApp/iosApp/Localizable.xcstrings
+  """
+  use Mix.Task
+  @shortdoc "Imports localizations from iOS"
+  @requirements ["app.config"]
+
+  @impl Mix.Task
+  def run([localizable_xcstrings_path]) do
+    localizable_xcstrings_json = localizable_xcstrings_path |> File.read!() |> Jason.decode!()
+    gettext_backend_dir = MobileAppBackend.Gettext.__gettext__(:priv)
+
+    for locale <- Application.fetch_env!(:mobile_app_backend, :locale_codes) do
+      Mix.Task.rerun("gettext.merge", [gettext_backend_dir, "--locale", locale, "--no-fuzzy"])
+      po_path = [gettext_backend_dir, locale, "LC_MESSAGES", "default.po"] |> Path.join()
+      po_contents = Expo.PO.parse_file!(po_path)
+
+      new_messages =
+        Enum.map(po_contents.messages, &rewrite_message(&1, locale, localizable_xcstrings_json))
+
+      new_po_contents = %Expo.Messages{po_contents | messages: new_messages}
+      new_po_contents |> Expo.PO.compose() |> then(&File.write!(po_path, &1))
+    end
+  end
+
+  @spec rewrite_message(Expo.Message.t(), String.t(), map()) :: Expo.Message.t()
+  def rewrite_message(%Expo.Message.Singular{} = po_message, locale, localizable_xcstrings_json) do
+    [msgid] = po_message.msgid
+    {ios_key_regex, interp_index_names} = from_gettext_interp(msgid)
+
+    {ios_key, ios_matching_string} =
+      localizable_xcstrings_json["strings"]
+      |> Enum.find({nil, nil}, fn {key, _data} -> Regex.match?(ios_key_regex, key) end)
+
+    ios_local_string =
+      ios_matching_string["localizations"][locale]["stringUnit"]["value"]
+
+    msgstr =
+      cond do
+        not is_nil(ios_local_string) ->
+          to_gettext_interp(ios_local_string, interp_index_names)
+
+        locale == "en" and not is_nil(ios_key) ->
+          to_gettext_interp(ios_key, interp_index_names)
+
+        Expo.Message.has_flag?(po_message, "import-optional") ->
+          [msgstr] = po_message.msgstr
+          msgstr
+
+        true ->
+          raise "no message found for msgid #{inspect(msgid)} (regex #{inspect(ios_key_regex)}, key #{inspect(ios_key)}) and locale #{inspect(locale)}"
+      end
+
+    %Expo.Message.Singular{
+      po_message
+      | msgstr: [msgstr]
+    }
+  end
+
+  @spec from_gettext_interp(String.t()) :: {Regex.t(), %{String.t() => String.t()}}
+  defp from_gettext_interp(text) do
+    gettext_pattern_regex = ~r/%\{([\w]+)\}/
+    gettext_patterns = Regex.scan(gettext_pattern_regex, text)
+
+    {result_regex, index_names} =
+      Enum.reduce(
+        gettext_patterns,
+        {Regex.escape(text), %{}},
+        fn [pattern, name], {result_regex, index_names} ->
+          this_index = to_string(map_size(index_names) + 1)
+
+          result_regex =
+            String.replace(result_regex, Regex.escape(pattern), "%(#{this_index}\\$)?[@sd]",
+              global: false
+            )
+
+          index_names = Map.put(index_names, this_index, name)
+          {result_regex, index_names}
+        end
+      )
+
+    {Regex.compile!("^" <> result_regex <> "$"), index_names}
+  end
+
+  @spec to_gettext_interp(String.t(), %{String.t() => String.t()}) :: String.t()
+  defp to_gettext_interp(text, index_names) do
+    ios_pattern_regex = ~r/%(?:(\d+)\$)?[@ds]/
+
+    # if the text contains just %@, we need to know what the index actually is
+    {:ok, fallback_index_agent} = Agent.start_link(fn -> 1 end)
+
+    consume_fallback_index = fn ->
+      Agent.get_and_update(fallback_index_agent, &{to_string(&1), &1 + 1})
+    end
+
+    result =
+      Regex.replace(ios_pattern_regex, text, fn _pattern, index ->
+        index =
+          case index do
+            "" -> consume_fallback_index.()
+            index -> index
+          end
+
+        index_name = Map.get(index_names, index, index)
+
+        "%{#{index_name}}"
+      end)
+
+    Agent.stop(fallback_index_agent)
+
+    result
+  end
+end

--- a/lib/mobile_app_backend/alerts/formatted_alert.ex
+++ b/lib/mobile_app_backend/alerts/formatted_alert.ex
@@ -141,24 +141,24 @@ defmodule MobileAppBackend.Alerts.FormattedAlert do
         gettext(" through tomorrow")
 
       %Timeframe.LaterDate{} ->
-        gettext(" through %{formatted_date}",
-          formatted_date:
+        gettext("key/alert_summary_timeframe_later_date",
+          "1":
             timeframe.time
             |> Util.datetime_to_gtfs(rounding: :backwards)
             |> Util.datetime_to_string(:short_month_day)
         )
 
       %Timeframe.ThisWeek{} ->
-        gettext(" through %{formatted_date}",
-          formatted_date:
+        gettext("key/alert_summary_timeframe_this_week",
+          "1":
             timeframe.time
             |> Util.datetime_to_gtfs(rounding: :backwards)
             |> Util.datetime_to_string(:wide_weekday)
         )
 
       %Timeframe.Time{} ->
-        gettext(" through %{formatted_date}",
-          formatted_date: Util.datetime_to_string(timeframe.time, :short_time)
+        gettext("key/alert_summary_timeframe_time",
+          "1": Util.datetime_to_string(timeframe.time, :short_time)
         )
 
       %Timeframe.StartingTomorrow{} ->
@@ -236,16 +236,16 @@ defmodule MobileAppBackend.Alerts.FormattedAlert do
         gettext(" until tomorrow")
 
       %Timeframe.LaterDate{} ->
-        gettext(" through %{date_formatted}",
-          date_formatted:
+        gettext("key/alert_summary_recurrence_end_day_later_date",
+          "1":
             end_day.time
             |> Util.datetime_to_gtfs(rounding: :backwards)
             |> Util.datetime_to_string(:short_month_day)
         )
 
       %Timeframe.ThisWeek{} ->
-        gettext(" through %{formatted_date}",
-          formatted_date:
+        gettext("key/alert_summary_recurrence_end_day_this_week",
+          "1":
             end_day.time
             |> Util.datetime_to_gtfs(rounding: :backwards)
             |> Util.datetime_to_string(:wide_weekday)
@@ -288,7 +288,7 @@ defmodule MobileAppBackend.Alerts.FormattedAlert do
     if match?(%TripShuttle.SingleTrip{}, alert_summary.trip_identity) &&
          alert_summary.trip_identity.from_stop_name != nil do
       gettext(
-        "%{trip_identity} is replaced by shuttle buses from **%{start_stop}** to **%{end_stop}%{recurrence}",
+        "%{trip_identity} is replaced by shuttle buses from **%{start_stop}** to **%{end_stop}**%{recurrence}",
         trip_identity: summary_trip_shuttle_identity(alert_summary.trip_identity),
         start_stop: alert_summary.start_stop_name,
         end_stop: alert_summary.end_stop_name,
@@ -310,7 +310,7 @@ defmodule MobileAppBackend.Alerts.FormattedAlert do
     case trip_identity do
       %AlertSummary.TripShuttle.SingleTrip{} ->
         if trip_identity.from_stop_name != nil do
-          gettext("the **%{time}** %{vehicle} from %{from_stop}",
+          gettext("**%{time}** %{vehicle} from **%{from_stop}**",
             time: Util.datetime_to_string(trip_identity.trip_time, :short_time),
             vehicle:
               MobileAppBackend.PresentationStrings.route_type(trip_identity.route_type, true),

--- a/lib/mobile_app_backend/gettext.ex
+++ b/lib/mobile_app_backend/gettext.ex
@@ -1,4 +1,12 @@
 defmodule MobileAppBackend.Gettext do
+  defmodule Plural do
+    def nplurals(:ht) do
+      nplurals(:fr)
+    end
+
+    use Cldr.Gettext.Plural, cldr_backend: MobileAppBackend.Cldr
+  end
+
   use Gettext.Backend,
     otp_app: :mobile_app_backend
 end

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1,176 +1,176 @@
-## This file is a PO Template file.
-##
-## "msgid"s here are often extracted from source code.
-## Add new messages manually only if they're dynamic
-## messages that can't be statically extracted.
-##
-## Run "mix gettext.extract" to bring this file up to
-## date. Leave "msgstr"s empty as changing them here has no
-## effect: edit them in PO (.po) files instead.
-#
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
 msgid ""
 msgstr ""
+"Language: en\n"
+"Plural-Forms: nplurals=2\n"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:101
 #, elixir-autogen, elixir-format
 msgid " at **%{stop_name}**"
-msgstr ""
+msgstr " at **%{stop_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:210
 #, elixir-autogen, elixir-format
 msgid " daily%{recurrence_text}"
-msgstr ""
+msgstr " daily%{recurrence_text}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:434
 #, elixir-autogen, elixir-format
 msgid " due to %{cause}"
-msgstr ""
+msgstr " due to %{cause}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:173
 #, elixir-autogen, elixir-format
 msgid " from %{start_time} to %{end_time}"
-msgstr ""
+msgstr " from %{start_time} to %{end_time}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:95
 #, elixir-autogen, elixir-format
 msgid " from **%{direction_name}** stops to **%{end_stop_name}**"
-msgstr ""
+msgstr " from **%{direction_name}** stops to **%{end_stop_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:110
 #, elixir-autogen, elixir-format
 msgid " from **%{start_stop}** to **%{end_stop}**"
-msgstr ""
+msgstr " from **%{start_stop}** to **%{end_stop}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:104
 #, elixir-autogen, elixir-format
 msgid " from **%{stop_name}** to **%{direction_name}** stops"
-msgstr ""
+msgstr " from **%{stop_name}** to **%{direction_name}** stops"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:121
 #, elixir-autogen, elixir-format
 msgid " on **%{mode_label}**"
-msgstr ""
+msgstr " on **%{mode_label}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:117
 #, elixir-autogen, elixir-format
 msgid " replacing **%{mode_label}**"
-msgstr ""
+msgstr " replacing **%{mode_label}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:219
 #, elixir-autogen, elixir-format
 msgid " some days%{recurrence_text}"
-msgstr ""
+msgstr " some days%{recurrence_text}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:168
 #, elixir-autogen, elixir-format
 msgid " starting **%{formatted_time}** today"
-msgstr ""
+msgstr " starting **%{formatted_time}** today"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:165
 #, elixir-autogen, elixir-format
 msgid " starting tomorrow"
-msgstr ""
+msgstr " starting tomorrow"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:138
 #, elixir-autogen, elixir-format
 msgid " through end of service"
-msgstr ""
+msgstr " through end of service"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:141
 #, elixir-autogen, elixir-format
 msgid " through tomorrow"
-msgstr ""
+msgstr " through tomorrow"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:135
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:233
 #, elixir-autogen, elixir-format
 msgid " until further notice"
-msgstr ""
+msgstr " until further notice"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:236
 #, elixir-autogen, elixir-format
 msgid " until tomorrow"
-msgstr ""
+msgstr " until tomorrow"
 
 #: lib/mobile_app_backend/notifications/notification_title.ex:63
 #, elixir-autogen, elixir-format
 msgid "%{label} %{mode_label}"
-msgstr ""
+msgstr "%{label} %{mode_label}"
 
 #: lib/presentation_strings.ex:22
 #, elixir-autogen, elixir-format
 msgid "%{name} bus"
-msgstr ""
+msgstr "%{name} bus"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:398
 #, elixir-autogen, elixir-format
 msgid "%{stop} and %{other_stops}"
-msgstr ""
+msgstr "%{stop} and %{other_stops}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:57
 #, elixir-autogen, elixir-format
 msgid "%{trip_identity} %{trip_effect}%{cause}%{recurrence}"
-msgstr ""
+msgstr "%{trip_identity} %{trip_effect}%{cause}%{recurrence}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:290
 #, elixir-autogen, elixir-format
 msgid "%{trip_identity} is replaced by shuttle buses from **%{start_stop}** to **%{end_stop}**%{recurrence}"
-msgstr ""
+msgstr "%{trip_identity} is replaced by shuttle buses from **%{start_stop}** to **%{end_stop}**%{recurrence}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:47
 #, elixir-autogen, elixir-format
 msgid "**%{effect_sentence_case}**%{summary_location}%{summary_timeframe}%{summary_recurrence}"
-msgstr ""
+msgstr "**%{effect_sentence_case}**%{summary_location}%{summary_timeframe}%{summary_recurrence}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:313
 #, elixir-autogen, elixir-format
 msgid "**%{time}** %{vehicle} from **%{from_stop}**"
-msgstr ""
+msgstr "**%{time}** %{vehicle} from **%{from_stop}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:268
 #, elixir-autogen, elixir-format
 msgid "**%{trip_time}** %{route_type} from **%{stop_name}**"
-msgstr ""
+msgstr "**%{trip_time}** %{route_type} from **%{stop_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:275
 #, elixir-autogen, elixir-format
 msgid "**%{trip_time}** %{route_type} to **%{headsign}**"
-msgstr ""
+msgstr "**%{trip_time}** %{route_type} to **%{headsign}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:28
 #, elixir-autogen, elixir-format
 msgid "**All clear:** Regular service%{location}"
-msgstr ""
+msgstr "**All clear:** Regular service%{location}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:39
 #, elixir-autogen, elixir-format
 msgid "**Update:** %{effect_sentence_case}%{summary_location}%{summary_timeframe}%{summary_recurrence}"
-msgstr ""
+msgstr "**Update:** %{effect_sentence_case}%{summary_location}%{summary_timeframe}%{summary_recurrence}"
 
 #: lib/presentation_strings.ex:71
 #, elixir-autogen, elixir-format
 msgid "Access Issue"
-msgstr ""
+msgstr "Access Issue"
 
 #: lib/presentation_strings.ex:31
 #, elixir-autogen, elixir-format
 msgid "Access issue"
-msgstr ""
+msgstr "Access issue"
 
 #: lib/presentation_strings.ex:174
 #, elixir-autogen, elixir-format
 msgid "Accident"
-msgstr ""
+msgstr "Accident"
 
 #: lib/presentation_strings.ex:72
 #, elixir-autogen, elixir-format
 msgid "Additional Service"
-msgstr ""
+msgstr "Additional Service"
 
 #: lib/presentation_strings.ex:32
 #, elixir-autogen, elixir-format
 msgid "Additional service"
-msgstr ""
+msgstr "Additional service"
 
 #: lib/presentation_strings.ex:63
 #: lib/presentation_strings.ex:64
@@ -178,1014 +178,1014 @@ msgstr ""
 #: lib/presentation_strings.ex:104
 #, elixir-autogen, elixir-format
 msgid "Alert"
-msgstr ""
+msgstr "Alert"
 
 #: lib/presentation_strings.ex:73
 #, elixir-autogen, elixir-format
 msgid "Amber Alert"
-msgstr ""
+msgstr "Amber Alert"
 
 #: lib/presentation_strings.ex:33
 #, elixir-autogen, elixir-format
 msgid "Amber alert"
-msgstr ""
+msgstr "Amber alert"
 
 #: lib/presentation_strings.ex:112
 #: lib/presentation_strings.ex:175
 #, elixir-autogen, elixir-format
 msgid "Amtrak"
-msgstr ""
+msgstr "Amtrak"
 
 #: lib/presentation_strings.ex:176
 #, elixir-autogen, elixir-format
 msgid "Amtrak Train Traffic"
-msgstr ""
+msgstr "Amtrak Train Traffic"
 
 #: lib/presentation_strings.ex:113
 #, elixir-autogen, elixir-format
 msgid "Amtrak train traffic"
-msgstr ""
+msgstr "Amtrak train traffic"
 
 #: lib/presentation_strings.ex:177
 #, elixir-autogen, elixir-format
 msgid "An Earlier Mechanical Problem"
-msgstr ""
+msgstr "An Earlier Mechanical Problem"
 
 #: lib/presentation_strings.ex:178
 #, elixir-autogen, elixir-format
 msgid "An Earlier Signal Problem"
-msgstr ""
+msgstr "An Earlier Signal Problem"
 
 #: lib/presentation_strings.ex:179
 #, elixir-autogen, elixir-format
 msgid "Autos Impeding Service"
-msgstr ""
+msgstr "Autos Impeding Service"
 
 #: lib/presentation_strings.ex:74
 #, elixir-autogen, elixir-format
 msgid "Bike Issue"
-msgstr ""
+msgstr "Bike Issue"
 
 #: lib/presentation_strings.ex:34
 #, elixir-autogen, elixir-format
 msgid "Bike issue"
-msgstr ""
+msgstr "Bike issue"
 
 #: lib/presentation_strings.ex:75
 #, elixir-autogen, elixir-format
 msgid "Cancellation"
-msgstr ""
+msgstr "Cancellation"
 
 #: lib/presentation_strings.ex:180
 #, elixir-autogen, elixir-format
 msgid "Coast Guard Restriction"
-msgstr ""
+msgstr "Coast Guard Restriction"
 
 #: lib/presentation_strings.ex:117
 #, elixir-autogen, elixir-format
 msgid "Coast Guard restriction"
-msgstr ""
+msgstr "Coast Guard restriction"
 
 #: lib/presentation_strings.ex:181
 #, elixir-autogen, elixir-format
 msgid "Congestion"
-msgstr ""
+msgstr "Congestion"
 
 #: lib/presentation_strings.ex:182
 #, elixir-autogen, elixir-format
 msgid "Construction"
-msgstr ""
+msgstr "Construction"
 
 #: lib/presentation_strings.ex:183
 #, elixir-autogen, elixir-format
 msgid "Crossing Issue"
-msgstr ""
+msgstr "Crossing Issue"
 
 #: lib/presentation_strings.ex:184
 #, elixir-autogen, elixir-format
 msgid "Crossing Malfunction"
-msgstr ""
+msgstr "Crossing Malfunction"
 
 #: lib/presentation_strings.ex:36
 #: lib/presentation_strings.ex:76
 #, elixir-autogen, elixir-format
 msgid "Delay"
-msgstr ""
+msgstr "Delay"
 
 #: lib/presentation_strings.ex:185
 #, elixir-autogen, elixir-format
 msgid "Demonstration"
-msgstr ""
+msgstr "Demonstration"
 
 #: lib/presentation_strings.ex:37
 #: lib/presentation_strings.ex:77
 #, elixir-autogen, elixir-format
 msgid "Detour"
-msgstr ""
+msgstr "Detour"
 
 #: lib/presentation_strings.ex:186
 #, elixir-autogen, elixir-format
 msgid "Disabled Bus"
-msgstr ""
+msgstr "Disabled Bus"
 
 #: lib/presentation_strings.ex:187
 #, elixir-autogen, elixir-format
 msgid "Disabled Train"
-msgstr ""
+msgstr "Disabled Train"
 
 #: lib/presentation_strings.ex:78
 #, elixir-autogen, elixir-format
 msgid "Dock Closure"
-msgstr ""
+msgstr "Dock Closure"
 
 #: lib/presentation_strings.ex:79
 #, elixir-autogen, elixir-format
 msgid "Dock Issue"
-msgstr ""
+msgstr "Dock Issue"
 
 #: lib/presentation_strings.ex:38
 #, elixir-autogen, elixir-format
 msgid "Dock closed"
-msgstr ""
+msgstr "Dock closed"
 
 #: lib/presentation_strings.ex:39
 #, elixir-autogen, elixir-format
 msgid "Dock issue"
-msgstr ""
+msgstr "Dock issue"
 
 #: lib/presentation_strings.ex:188
 #, elixir-autogen, elixir-format
 msgid "Drawbridge Being Raised"
-msgstr ""
+msgstr "Drawbridge Being Raised"
 
 #: lib/presentation_strings.ex:189
 #, elixir-autogen, elixir-format
 msgid "Drawbridge Issue"
-msgstr ""
+msgstr "Drawbridge Issue"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:8
 #, elixir-autogen, elixir-format
 msgid "Eastbound"
-msgstr ""
+msgstr "Eastbound"
 
 #: lib/presentation_strings.ex:190
 #, elixir-autogen, elixir-format
 msgid "Electrical Work"
-msgstr ""
+msgstr "Electrical Work"
 
 #: lib/presentation_strings.ex:80
 #, elixir-autogen, elixir-format
 msgid "Elevator Closure"
-msgstr ""
+msgstr "Elevator Closure"
 
 #: lib/presentation_strings.ex:40
 #, elixir-autogen, elixir-format
 msgid "Elevator closed"
-msgstr ""
+msgstr "Elevator closed"
 
 #: lib/presentation_strings.ex:81
 #, elixir-autogen, elixir-format
 msgid "Escalator Closure"
-msgstr ""
+msgstr "Escalator Closure"
 
 #: lib/presentation_strings.ex:41
 #, elixir-autogen, elixir-format
 msgid "Escalator closed"
-msgstr ""
+msgstr "Escalator closed"
 
 #: lib/presentation_strings.ex:82
 #, elixir-autogen, elixir-format
 msgid "Extra Service"
-msgstr ""
+msgstr "Extra Service"
 
 #: lib/presentation_strings.ex:42
 #, elixir-autogen, elixir-format
 msgid "Extra service"
-msgstr ""
+msgstr "Extra service"
 
 #: lib/presentation_strings.ex:83
 #, elixir-autogen, elixir-format
 msgid "Facility Issue"
-msgstr ""
+msgstr "Facility Issue"
 
 #: lib/presentation_strings.ex:43
 #, elixir-autogen, elixir-format
 msgid "Facility issue"
-msgstr ""
+msgstr "Facility issue"
 
 #: lib/presentation_strings.ex:191
 #, elixir-autogen, elixir-format
 msgid "Fire"
-msgstr ""
+msgstr "Fire"
 
 #: lib/presentation_strings.ex:192
 #, elixir-autogen, elixir-format
 msgid "Fire Department Activity"
-msgstr ""
+msgstr "Fire Department Activity"
 
 #: lib/presentation_strings.ex:193
 #, elixir-autogen, elixir-format
 msgid "Flooding"
-msgstr ""
+msgstr "Flooding"
 
 #: lib/presentation_strings.ex:194
 #, elixir-autogen, elixir-format
 msgid "Fog"
-msgstr ""
+msgstr "Fog"
 
 #: lib/presentation_strings.ex:195
 #, elixir-autogen, elixir-format
 msgid "Freight Train Interference"
-msgstr ""
+msgstr "Freight Train Interference"
 
 #: lib/presentation_strings.ex:196
 #, elixir-autogen, elixir-format
 msgid "Hazmat Condition"
-msgstr ""
+msgstr "Hazmat Condition"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:17
 #, elixir-autogen, elixir-format
 msgid "Heading"
-msgstr ""
+msgstr "Heading"
 
 #: lib/presentation_strings.ex:197
 #, elixir-autogen, elixir-format
 msgid "Heavy Ridership"
-msgstr ""
+msgstr "Heavy Ridership"
 
 #: lib/presentation_strings.ex:198
 #, elixir-autogen, elixir-format
 msgid "High Winds"
-msgstr ""
+msgstr "High Winds"
 
 #: lib/presentation_strings.ex:199
 #, elixir-autogen, elixir-format
 msgid "Holiday"
-msgstr ""
+msgstr "Holiday"
 
 #: lib/presentation_strings.ex:200
 #, elixir-autogen, elixir-format
 msgid "Hurricane"
-msgstr ""
+msgstr "Hurricane"
 
 #: lib/presentation_strings.ex:201
 #, elixir-autogen, elixir-format
 msgid "Ice In Harbor"
-msgstr ""
+msgstr "Ice In Harbor"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:10
 #, elixir-autogen, elixir-format
 msgid "Inbound"
-msgstr ""
+msgstr "Inbound"
 
 #: lib/presentation_strings.ex:202
 #, elixir-autogen, elixir-format
 msgid "Maintenance"
-msgstr ""
+msgstr "Maintenance"
 
 #: lib/presentation_strings.ex:203
 #, elixir-autogen, elixir-format
 msgid "Mechanical Issue"
-msgstr ""
+msgstr "Mechanical Issue"
 
 #: lib/presentation_strings.ex:204
 #, elixir-autogen, elixir-format
 msgid "Mechanical Problem"
-msgstr ""
+msgstr "Mechanical Problem"
 
 #: lib/presentation_strings.ex:205
 #, elixir-autogen, elixir-format
 msgid "Medical Emergency"
-msgstr ""
+msgstr "Medical Emergency"
 
 #: lib/presentation_strings.ex:84
 #, elixir-autogen, elixir-format
 msgid "Modified Service"
-msgstr ""
+msgstr "Modified Service"
 
 #: lib/presentation_strings.ex:44
 #, elixir-autogen, elixir-format
 msgid "Modified service"
-msgstr ""
+msgstr "Modified service"
 
 #: lib/mobile_app_backend/notifications/notification_title.ex:69
 #, elixir-autogen, elixir-format
 msgid "Multiple routes"
-msgstr ""
+msgstr "Multiple routes"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:282
 #, elixir-autogen, elixir-format
 msgid "Multiple trips"
-msgstr ""
+msgstr "Multiple trips"
 
 #: lib/presentation_strings.ex:85
 #, elixir-autogen, elixir-format
 msgid "No Service"
-msgstr ""
+msgstr "No Service"
 
 #: lib/presentation_strings.ex:45
 #, elixir-autogen, elixir-format
 msgid "No service"
-msgstr ""
+msgstr "No service"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:6
 #, elixir-autogen, elixir-format
 msgid "Northbound"
-msgstr ""
+msgstr "Northbound"
 
 #: lib/presentation_strings.ex:46
 #: lib/presentation_strings.ex:86
 #, elixir-autogen, elixir-format
 msgid "Notice"
-msgstr ""
+msgstr "Notice"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:11
 #, elixir-autogen, elixir-format
 msgid "Outbound"
-msgstr ""
+msgstr "Outbound"
 
 #: lib/presentation_strings.ex:206
 #, elixir-autogen, elixir-format
 msgid "Parade"
-msgstr ""
+msgstr "Parade"
 
 #: lib/presentation_strings.ex:87
 #, elixir-autogen, elixir-format
 msgid "Parking Closure"
-msgstr ""
+msgstr "Parking Closure"
 
 #: lib/presentation_strings.ex:88
 #, elixir-autogen, elixir-format
 msgid "Parking Issue"
-msgstr ""
+msgstr "Parking Issue"
 
 #: lib/presentation_strings.ex:47
 #, elixir-autogen, elixir-format
 msgid "Parking closed"
-msgstr ""
+msgstr "Parking closed"
 
 #: lib/presentation_strings.ex:48
 #, elixir-autogen, elixir-format
 msgid "Parking issue"
-msgstr ""
+msgstr "Parking issue"
 
 #: lib/presentation_strings.ex:207
 #, elixir-autogen, elixir-format
 msgid "Police Action"
-msgstr ""
+msgstr "Police Action"
 
 #: lib/presentation_strings.ex:208
 #, elixir-autogen, elixir-format
 msgid "Police Activity"
-msgstr ""
+msgstr "Police Activity"
 
 #: lib/presentation_strings.ex:89
 #, elixir-autogen, elixir-format
 msgid "Policy Change"
-msgstr ""
+msgstr "Policy Change"
 
 #: lib/presentation_strings.ex:49
 #, elixir-autogen, elixir-format
 msgid "Policy change"
-msgstr ""
+msgstr "Policy change"
 
 #: lib/presentation_strings.ex:209
 #, elixir-autogen, elixir-format
 msgid "Power Problem"
-msgstr ""
+msgstr "Power Problem"
 
 #: lib/presentation_strings.ex:210
 #, elixir-autogen, elixir-format
 msgid "Rail Defect"
-msgstr ""
+msgstr "Rail Defect"
 
 #: lib/presentation_strings.ex:90
 #, elixir-autogen, elixir-format
 msgid "Schedule Change"
-msgstr ""
+msgstr "Schedule Change"
 
 #: lib/presentation_strings.ex:50
 #, elixir-autogen, elixir-format
 msgid "Schedule change"
-msgstr ""
+msgstr "Schedule change"
 
 #: lib/presentation_strings.ex:91
 #, elixir-autogen, elixir-format
 msgid "Service Change"
-msgstr ""
+msgstr "Service Change"
 
 #: lib/presentation_strings.ex:51
 #, elixir-autogen, elixir-format
 msgid "Service change"
-msgstr ""
+msgstr "Service change"
 
 #: lib/presentation_strings.ex:61
 #, elixir-autogen, elixir-format
 msgid "Service suspended"
-msgstr ""
+msgstr "Service suspended"
 
 #: lib/presentation_strings.ex:211
 #, elixir-autogen, elixir-format
 msgid "Severe Weather"
-msgstr ""
+msgstr "Severe Weather"
 
 #: lib/presentation_strings.ex:92
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
-msgstr ""
+msgstr "Shuttle"
 
 #: lib/presentation_strings.ex:52
 #, elixir-autogen, elixir-format
 msgid "Shuttle buses"
-msgstr ""
+msgstr "Shuttle buses"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:298
 #, elixir-autogen, elixir-format
 msgid "Shuttle buses replace %{trip_identity} from **%{start_stop}** to **%{end_stop}**%{recurrence}"
-msgstr ""
+msgstr "Shuttle buses replace %{trip_identity} from **%{start_stop}** to **%{end_stop}**%{recurrence}"
 
 #: lib/presentation_strings.ex:212
 #, elixir-autogen, elixir-format
 msgid "Signal Issue"
-msgstr ""
+msgstr "Signal Issue"
 
 #: lib/presentation_strings.ex:213
 #, elixir-autogen, elixir-format
 msgid "Signal Problem"
-msgstr ""
+msgstr "Signal Problem"
 
 #: lib/presentation_strings.ex:214
 #, elixir-autogen, elixir-format
 msgid "Single Tracking"
-msgstr ""
+msgstr "Single Tracking"
 
 #: lib/presentation_strings.ex:215
 #, elixir-autogen, elixir-format
 msgid "Slippery Rail"
-msgstr ""
+msgstr "Slippery Rail"
 
 #: lib/presentation_strings.ex:216
 #, elixir-autogen, elixir-format
 msgid "Snow"
-msgstr ""
+msgstr "Snow"
 
 #: lib/presentation_strings.ex:93
 #, elixir-autogen, elixir-format
 msgid "Snow Route"
-msgstr ""
+msgstr "Snow Route"
 
 #: lib/presentation_strings.ex:53
 #, elixir-autogen, elixir-format
 msgid "Snow route"
-msgstr ""
+msgstr "Snow route"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:7
 #, elixir-autogen, elixir-format
 msgid "Southbound"
-msgstr ""
+msgstr "Southbound"
 
 #: lib/presentation_strings.ex:217
 #, elixir-autogen, elixir-format
 msgid "Special Event"
-msgstr ""
+msgstr "Special Event"
 
 #: lib/presentation_strings.ex:218
 #, elixir-autogen, elixir-format
 msgid "Speed Restriction"
-msgstr ""
+msgstr "Speed Restriction"
 
 #: lib/presentation_strings.ex:94
 #, elixir-autogen, elixir-format
 msgid "Station Closure"
-msgstr ""
+msgstr "Station Closure"
 
 #: lib/presentation_strings.ex:95
 #, elixir-autogen, elixir-format
 msgid "Station Issue"
-msgstr ""
+msgstr "Station Issue"
 
 #: lib/presentation_strings.ex:54
 #, elixir-autogen, elixir-format
 msgid "Station closed"
-msgstr ""
+msgstr "Station closed"
 
 #: lib/presentation_strings.ex:55
 #, elixir-autogen, elixir-format
 msgid "Station issue"
-msgstr ""
+msgstr "Station issue"
 
 #: lib/presentation_strings.ex:96
 #, elixir-autogen, elixir-format
 msgid "Stop Closure"
-msgstr ""
+msgstr "Stop Closure"
 
 #: lib/presentation_strings.ex:97
 #: lib/presentation_strings.ex:98
 #, elixir-autogen, elixir-format
 msgid "Stop Moved"
-msgstr ""
+msgstr "Stop Moved"
 
 #: lib/presentation_strings.ex:99
 #, elixir-autogen, elixir-format
 msgid "Stop Shoveling"
-msgstr ""
+msgstr "Stop Shoveling"
 
 #: lib/presentation_strings.ex:56
 #, elixir-autogen, elixir-format
 msgid "Stop closed"
-msgstr ""
+msgstr "Stop closed"
 
 #: lib/presentation_strings.ex:57
 #: lib/presentation_strings.ex:58
 #, elixir-autogen, elixir-format
 msgid "Stop moved"
-msgstr ""
+msgstr "Stop moved"
 
 #: lib/presentation_strings.ex:59
 #, elixir-autogen, elixir-format
 msgid "Stop shoveling"
-msgstr ""
+msgstr "Stop shoveling"
 
 #: lib/presentation_strings.ex:219
 #, elixir-autogen, elixir-format
 msgid "Strike"
-msgstr ""
+msgstr "Strike"
 
 #: lib/presentation_strings.ex:60
 #: lib/presentation_strings.ex:100
 #, elixir-autogen, elixir-format
 msgid "Summary"
-msgstr ""
+msgstr "Summary"
 
 #: lib/presentation_strings.ex:101
 #, elixir-autogen, elixir-format
 msgid "Suspension"
-msgstr ""
+msgstr "Suspension"
 
 #: lib/presentation_strings.ex:220
 #, elixir-autogen, elixir-format
 msgid "Switch Issue"
-msgstr ""
+msgstr "Switch Issue"
 
 #: lib/presentation_strings.ex:221
 #, elixir-autogen, elixir-format
 msgid "Switch Problem"
-msgstr ""
+msgstr "Switch Problem"
 
 #: lib/presentation_strings.ex:222
 #, elixir-autogen, elixir-format
 msgid "Technical Problem"
-msgstr ""
+msgstr "Technical Problem"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:263
 #, elixir-autogen, elixir-format
 msgid "This %{route_type}"
-msgstr ""
+msgstr "This %{route_type}"
 
 #: lib/presentation_strings.ex:223
 #, elixir-autogen, elixir-format
 msgid "Tie Replacement"
-msgstr ""
+msgstr "Tie Replacement"
 
 #: lib/presentation_strings.ex:102
 #, elixir-autogen, elixir-format
 msgid "Track Change"
-msgstr ""
+msgstr "Track Change"
 
 #: lib/presentation_strings.ex:224
 #, elixir-autogen, elixir-format
 msgid "Track Problem"
-msgstr ""
+msgstr "Track Problem"
 
 #: lib/presentation_strings.ex:225
 #, elixir-autogen, elixir-format
 msgid "Track Work"
-msgstr ""
+msgstr "Track Work"
 
 #: lib/presentation_strings.ex:62
 #, elixir-autogen, elixir-format
 msgid "Track change"
-msgstr ""
+msgstr "Track change"
 
 #: lib/presentation_strings.ex:226
 #, elixir-autogen, elixir-format
 msgid "Traffic"
-msgstr ""
+msgstr "Traffic"
 
 #: lib/presentation_strings.ex:227
 #, elixir-autogen, elixir-format
 msgid "Train Traffic"
-msgstr ""
+msgstr "Train Traffic"
 
 #: lib/presentation_strings.ex:35
 #, elixir-autogen, elixir-format
 msgid "Trip cancelled"
-msgstr ""
+msgstr "Trip cancelled"
 
 #: lib/presentation_strings.ex:228
 #, elixir-autogen, elixir-format
 msgid "Unruly Passenger"
-msgstr ""
+msgstr "Unruly Passenger"
 
 #: lib/presentation_strings.ex:229
 #, elixir-autogen, elixir-format
 msgid "Weather"
-msgstr ""
+msgstr "Weather"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:9
 #, elixir-autogen, elixir-format
 msgid "Westbound"
-msgstr ""
+msgstr "Westbound"
 
 #: lib/presentation_strings.ex:111
 #, elixir-autogen, elixir-format
 msgid "accident"
-msgstr ""
+msgstr "accident"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:424
 #, elixir-autogen, elixir-format
 msgid "affected by %{effect} %{day}"
-msgstr ""
+msgstr "affected by %{effect} %{day}"
 
 #: lib/presentation_strings.ex:114
 #, elixir-autogen, elixir-format
 msgid "an earlier mechanical problem"
-msgstr ""
+msgstr "an earlier mechanical problem"
 
 #: lib/presentation_strings.ex:115
 #, elixir-autogen, elixir-format
 msgid "an earlier signal problem"
-msgstr ""
+msgstr "an earlier signal problem"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:382
 #, elixir-autogen, elixir-format
 msgid "are cancelled %{day}"
-msgstr ""
+msgstr "are cancelled %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:417
 #, elixir-autogen, elixir-format
 msgid "are suspended %{day}"
-msgstr ""
+msgstr "are suspended %{day}"
 
 #: lib/presentation_strings.ex:116
 #, elixir-autogen, elixir-format
 msgid "autos impeding service"
-msgstr ""
+msgstr "autos impeding service"
 
 #: lib/presentation_strings.ex:12
 #, elixir-autogen, elixir-format
 msgid "bus"
-msgstr ""
+msgstr "bus"
 
 #: lib/presentation_strings.ex:13
 #, elixir-autogen, elixir-format
 msgid "buses"
-msgstr ""
+msgstr "buses"
 
 #: lib/presentation_strings.ex:118
 #, elixir-autogen, elixir-format
 msgid "congestion"
-msgstr ""
+msgstr "congestion"
 
 #: lib/presentation_strings.ex:119
 #, elixir-autogen, elixir-format
 msgid "construction"
-msgstr ""
+msgstr "construction"
 
 #: lib/presentation_strings.ex:120
 #, elixir-autogen, elixir-format
 msgid "crossing issue"
-msgstr ""
+msgstr "crossing issue"
 
 #: lib/presentation_strings.ex:121
 #, elixir-autogen, elixir-format
 msgid "crossing malfunction"
-msgstr ""
+msgstr "crossing malfunction"
 
 #: lib/presentation_strings.ex:122
 #, elixir-autogen, elixir-format
 msgid "demonstration"
-msgstr ""
+msgstr "demonstration"
 
 #: lib/presentation_strings.ex:123
 #, elixir-autogen, elixir-format
 msgid "disabled bus"
-msgstr ""
+msgstr "disabled bus"
 
 #: lib/presentation_strings.ex:124
 #, elixir-autogen, elixir-format
 msgid "disabled train"
-msgstr ""
+msgstr "disabled train"
 
 #: lib/presentation_strings.ex:125
 #, elixir-autogen, elixir-format
 msgid "drawbridge being raised"
-msgstr ""
+msgstr "drawbridge being raised"
 
 #: lib/presentation_strings.ex:126
 #, elixir-autogen, elixir-format
 msgid "drawbridge issue"
-msgstr ""
+msgstr "drawbridge issue"
 
 #: lib/presentation_strings.ex:127
 #, elixir-autogen, elixir-format
 msgid "electrical work"
-msgstr ""
+msgstr "electrical work"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:193
 #, elixir-autogen, elixir-format
 msgid "end of service"
-msgstr ""
+msgstr "end of service"
 
 #: lib/presentation_strings.ex:15
 #, elixir-autogen, elixir-format
 msgid "ferries"
-msgstr ""
+msgstr "ferries"
 
 #: lib/presentation_strings.ex:14
 #, elixir-autogen, elixir-format
 msgid "ferry"
-msgstr ""
+msgstr "ferry"
 
 #: lib/presentation_strings.ex:128
 #, elixir-autogen, elixir-format
 msgid "fire"
-msgstr ""
+msgstr "fire"
 
 #: lib/presentation_strings.ex:129
 #, elixir-autogen, elixir-format
 msgid "fire department activity"
-msgstr ""
+msgstr "fire department activity"
 
 #: lib/presentation_strings.ex:130
 #, elixir-autogen, elixir-format
 msgid "flooding"
-msgstr ""
+msgstr "flooding"
 
 #: lib/presentation_strings.ex:131
 #, elixir-autogen, elixir-format
 msgid "fog"
-msgstr ""
+msgstr "fog"
 
 #: lib/presentation_strings.ex:132
 #, elixir-autogen, elixir-format
 msgid "freight train interference"
-msgstr ""
+msgstr "freight train interference"
 
 #: lib/presentation_strings.ex:133
 #, elixir-autogen, elixir-format
 msgid "hazmat condition"
-msgstr ""
+msgstr "hazmat condition"
 
 #: lib/presentation_strings.ex:134
 #, elixir-autogen, elixir-format
 msgid "heavy ridership"
-msgstr ""
+msgstr "heavy ridership"
 
 #: lib/presentation_strings.ex:135
 #, elixir-autogen, elixir-format
 msgid "high winds"
-msgstr ""
+msgstr "high winds"
 
 #: lib/presentation_strings.ex:136
 #, elixir-autogen, elixir-format
 msgid "holiday"
-msgstr ""
+msgstr "holiday"
 
 #: lib/presentation_strings.ex:137
 #, elixir-autogen, elixir-format
 msgid "hurricane"
-msgstr ""
+msgstr "hurricane"
 
 #: lib/presentation_strings.ex:138
 #, elixir-autogen, elixir-format
 msgid "ice in harbor"
-msgstr ""
+msgstr "ice in harbor"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:385
 #, elixir-autogen, elixir-format
 msgid "is cancelled %{day}"
-msgstr ""
+msgstr "is cancelled %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:420
 #, elixir-autogen, elixir-format
 msgid "is suspended %{day}"
-msgstr ""
+msgstr "is suspended %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:239
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_recurrence_end_day_later_date"
-msgstr ""
+msgstr " until %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:247
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_recurrence_end_day_this_week"
-msgstr ""
+msgstr " until %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:144
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_timeframe_later_date"
-msgstr ""
+msgstr " through %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:152
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_timeframe_this_week"
-msgstr ""
+msgstr " through %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:160
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_timeframe_time"
-msgstr ""
+msgstr " through %{1}"
 
 #: lib/presentation_strings.ex:139
 #, elixir-autogen, elixir-format
 msgid "maintenance"
-msgstr ""
+msgstr "maintenance"
 
 #: lib/presentation_strings.ex:140
 #, elixir-autogen, elixir-format
 msgid "mechanical issue"
-msgstr ""
+msgstr "mechanical issue"
 
 #: lib/presentation_strings.ex:141
 #, elixir-autogen, elixir-format
 msgid "mechanical problem"
-msgstr ""
+msgstr "mechanical problem"
 
 #: lib/presentation_strings.ex:142
 #, elixir-autogen, elixir-format
 msgid "medical emergency"
-msgstr ""
+msgstr "medical emergency"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:333
 #, elixir-autogen, elixir-format
 msgid "multiple trips"
-msgstr ""
+msgstr "multiple trips"
 
 #: lib/presentation_strings.ex:143
 #, elixir-autogen, elixir-format
 msgid "parade"
-msgstr ""
+msgstr "parade"
 
 #: lib/presentation_strings.ex:144
 #, elixir-autogen, elixir-format
 msgid "police action"
-msgstr ""
+msgstr "police action"
 
 #: lib/presentation_strings.ex:145
 #, elixir-autogen, elixir-format
 msgid "police activity"
-msgstr ""
+msgstr "police activity"
 
 #: lib/presentation_strings.ex:146
 #, elixir-autogen, elixir-format
 msgid "power problem"
-msgstr ""
+msgstr "power problem"
 
 #: lib/presentation_strings.ex:147
 #, elixir-autogen, elixir-format
 msgid "rail defect"
-msgstr ""
+msgstr "rail defect"
 
 #: lib/presentation_strings.ex:148
 #, elixir-autogen, elixir-format
 msgid "severe weather"
-msgstr ""
+msgstr "severe weather"
 
 #: lib/presentation_strings.ex:149
 #, elixir-autogen, elixir-format
 msgid "signal issue"
-msgstr ""
+msgstr "signal issue"
 
 #: lib/presentation_strings.ex:150
 #, elixir-autogen, elixir-format
 msgid "signal problem"
-msgstr ""
+msgstr "signal problem"
 
 #: lib/presentation_strings.ex:151
 #, elixir-autogen, elixir-format
 msgid "single tracking"
-msgstr ""
+msgstr "single tracking"
 
 #: lib/presentation_strings.ex:152
 #, elixir-autogen, elixir-format
 msgid "slippery rail"
-msgstr ""
+msgstr "slippery rail"
 
 #: lib/presentation_strings.ex:153
 #, elixir-autogen, elixir-format
 msgid "snow"
-msgstr ""
+msgstr "snow"
 
 #: lib/presentation_strings.ex:154
 #, elixir-autogen, elixir-format
 msgid "special event"
-msgstr ""
+msgstr "special event"
 
 #: lib/presentation_strings.ex:155
 #, elixir-autogen, elixir-format
 msgid "speed restriction"
-msgstr ""
+msgstr "speed restriction"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:190
 #, elixir-autogen, elixir-format
 msgid "start of service"
-msgstr ""
+msgstr "start of service"
 
 #: lib/presentation_strings.ex:156
 #, elixir-autogen, elixir-format
 msgid "strike"
-msgstr ""
+msgstr "strike"
 
 #: lib/presentation_strings.ex:157
 #, elixir-autogen, elixir-format
 msgid "switch issue"
-msgstr ""
+msgstr "switch issue"
 
 #: lib/presentation_strings.ex:158
 #, elixir-autogen, elixir-format
 msgid "switch problem"
-msgstr ""
+msgstr "switch problem"
 
 #: lib/presentation_strings.ex:159
 #, elixir-autogen, elixir-format
 msgid "technical problem"
-msgstr ""
+msgstr "technical problem"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:320
 #, elixir-autogen, elixir-format
 msgid "the **%{time}** %{vehicle}"
-msgstr ""
+msgstr "the **%{time}** %{vehicle}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:328
 #, elixir-autogen, elixir-format
 msgid "this %{vehicle}"
-msgstr ""
+msgstr "this %{vehicle}"
 
 #: lib/presentation_strings.ex:160
 #, elixir-autogen, elixir-format
 msgid "tie replacement"
-msgstr ""
+msgstr "tie replacement"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:377
 #, elixir-autogen, elixir-format
 msgid "today"
-msgstr ""
+msgstr "today"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:377
 #, elixir-autogen, elixir-format
 msgid "tomorrow"
-msgstr ""
+msgstr "tomorrow"
 
 #: lib/presentation_strings.ex:161
 #, elixir-autogen, elixir-format
 msgid "track problem"
-msgstr ""
+msgstr "track problem"
 
 #: lib/presentation_strings.ex:162
 #, elixir-autogen, elixir-format
 msgid "track work"
-msgstr ""
+msgstr "track work"
 
 #: lib/presentation_strings.ex:163
 #, elixir-autogen, elixir-format
 msgid "traffic"
-msgstr ""
+msgstr "traffic"
 
 #: lib/presentation_strings.ex:16
 #, elixir-autogen, elixir-format
 msgid "train"
-msgstr ""
+msgstr "train"
 
 #: lib/presentation_strings.ex:164
 #, elixir-autogen, elixir-format
 msgid "train traffic"
-msgstr ""
+msgstr "train traffic"
 
 #: lib/presentation_strings.ex:17
 #, elixir-autogen, elixir-format
 msgid "trains"
-msgstr ""
+msgstr "trains"
 
 #: lib/presentation_strings.ex:165
 #, elixir-autogen, elixir-format
 msgid "unruly passenger"
-msgstr ""
+msgstr "unruly passenger"
 
 #: lib/presentation_strings.ex:166
 #, elixir-autogen, elixir-format
 msgid "weather"
-msgstr ""
+msgstr "weather"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:388
 #, elixir-autogen, elixir-format
 msgid "will not stop at %{stop_list} %{day}"
-msgstr ""
+msgstr "will not stop at %{stop_list} %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:411
 #, elixir-autogen, elixir-format
 msgid "will terminate at %{terminating_stop} %{day}"
-msgstr ""
+msgstr "will terminate at %{terminating_stop} %{day}"
 
 #: lib/mobile_app_backend_web/components/core_components.ex:484
 #, elixir-autogen, elixir-format, import-optional

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -1,176 +1,176 @@
-## This file is a PO Template file.
-##
-## "msgid"s here are often extracted from source code.
-## Add new messages manually only if they're dynamic
-## messages that can't be statically extracted.
-##
-## Run "mix gettext.extract" to bring this file up to
-## date. Leave "msgstr"s empty as changing them here has no
-## effect: edit them in PO (.po) files instead.
-#
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
 msgid ""
 msgstr ""
+"Language: es\n"
+"Plural-Forms: nplurals=3\n"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:101
 #, elixir-autogen, elixir-format
 msgid " at **%{stop_name}**"
-msgstr ""
+msgstr " en **%{stop_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:210
 #, elixir-autogen, elixir-format
 msgid " daily%{recurrence_text}"
-msgstr ""
+msgstr " a diario%{recurrence_text}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:434
 #, elixir-autogen, elixir-format
 msgid " due to %{cause}"
-msgstr ""
+msgstr " debido a %{cause}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:173
 #, elixir-autogen, elixir-format
 msgid " from %{start_time} to %{end_time}"
-msgstr ""
+msgstr " de %{start_time} a %{end_time}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:95
 #, elixir-autogen, elixir-format
 msgid " from **%{direction_name}** stops to **%{end_stop_name}**"
-msgstr ""
+msgstr " desde paradas en **%{direction_name}** hasta **%{end_stop_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:110
 #, elixir-autogen, elixir-format
 msgid " from **%{start_stop}** to **%{end_stop}**"
-msgstr ""
+msgstr " de **%{start_stop}** a **%{end_stop}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:104
 #, elixir-autogen, elixir-format
 msgid " from **%{stop_name}** to **%{direction_name}** stops"
-msgstr ""
+msgstr " desde **%{stop_name}** hasta paradas en **%{direction_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:121
 #, elixir-autogen, elixir-format
 msgid " on **%{mode_label}**"
-msgstr ""
+msgstr " en **%{mode_label}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:117
 #, elixir-autogen, elixir-format
 msgid " replacing **%{mode_label}**"
-msgstr ""
+msgstr " reemplazando **%{mode_label}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:219
 #, elixir-autogen, elixir-format
 msgid " some days%{recurrence_text}"
-msgstr ""
+msgstr " algunos días%{recurrence_text}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:168
 #, elixir-autogen, elixir-format
 msgid " starting **%{formatted_time}** today"
-msgstr ""
+msgstr " comenzando **%{formatted_time}** hoy"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:165
 #, elixir-autogen, elixir-format
 msgid " starting tomorrow"
-msgstr ""
+msgstr " a partir de mañana"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:138
 #, elixir-autogen, elixir-format
 msgid " through end of service"
-msgstr ""
+msgstr " hasta el final del servicio"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:141
 #, elixir-autogen, elixir-format
 msgid " through tomorrow"
-msgstr ""
+msgstr " hasta mañana"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:135
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:233
 #, elixir-autogen, elixir-format
 msgid " until further notice"
-msgstr ""
+msgstr " hasta nuevo aviso"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:236
 #, elixir-autogen, elixir-format
 msgid " until tomorrow"
-msgstr ""
+msgstr " hasta mañana"
 
 #: lib/mobile_app_backend/notifications/notification_title.ex:63
 #, elixir-autogen, elixir-format
 msgid "%{label} %{mode_label}"
-msgstr ""
+msgstr "%{label} %{mode_label}"
 
 #: lib/presentation_strings.ex:22
 #, elixir-autogen, elixir-format
 msgid "%{name} bus"
-msgstr ""
+msgstr "%{name} autobús"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:398
 #, elixir-autogen, elixir-format
 msgid "%{stop} and %{other_stops}"
-msgstr ""
+msgstr "%{stop} y %{other_stops}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:57
 #, elixir-autogen, elixir-format
 msgid "%{trip_identity} %{trip_effect}%{cause}%{recurrence}"
-msgstr ""
+msgstr "%{trip_identity} %{trip_effect}%{cause}%{recurrence}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:290
 #, elixir-autogen, elixir-format
 msgid "%{trip_identity} is replaced by shuttle buses from **%{start_stop}** to **%{end_stop}**%{recurrence}"
-msgstr ""
+msgstr "%{trip_identity} se reemplaza por autobuses lanzadera desde **%{start_stop}** hasta **%{end_stop}**%{recurrence}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:47
 #, elixir-autogen, elixir-format
 msgid "**%{effect_sentence_case}**%{summary_location}%{summary_timeframe}%{summary_recurrence}"
-msgstr ""
+msgstr "**%{effect_sentence_case}**%{summary_location}%{summary_timeframe}%{summary_recurrence}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:313
 #, elixir-autogen, elixir-format
 msgid "**%{time}** %{vehicle} from **%{from_stop}**"
-msgstr ""
+msgstr "**%{time}** %{vehicle} de **%{from_stop}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:268
 #, elixir-autogen, elixir-format
 msgid "**%{trip_time}** %{route_type} from **%{stop_name}**"
-msgstr ""
+msgstr "**%{trip_time}** %{route_type} de **%{stop_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:275
 #, elixir-autogen, elixir-format
 msgid "**%{trip_time}** %{route_type} to **%{headsign}**"
-msgstr ""
+msgstr "**%{trip_time}** %{route_type} a **%{headsign}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:28
 #, elixir-autogen, elixir-format
 msgid "**All clear:** Regular service%{location}"
-msgstr ""
+msgstr "**Todo despejado:** Servicio regular%{location}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:39
 #, elixir-autogen, elixir-format
 msgid "**Update:** %{effect_sentence_case}%{summary_location}%{summary_timeframe}%{summary_recurrence}"
-msgstr ""
+msgstr "**Actualización:** %{effect_sentence_case}%{summary_location}%{summary_timeframe}%{summary_recurrence}"
 
 #: lib/presentation_strings.ex:71
 #, elixir-autogen, elixir-format
 msgid "Access Issue"
-msgstr ""
+msgstr "Problema de accesibilidad"
 
 #: lib/presentation_strings.ex:31
 #, elixir-autogen, elixir-format
 msgid "Access issue"
-msgstr ""
+msgstr "Problema de accesibilidad"
 
 #: lib/presentation_strings.ex:174
 #, elixir-autogen, elixir-format
 msgid "Accident"
-msgstr ""
+msgstr "Accidente"
 
 #: lib/presentation_strings.ex:72
 #, elixir-autogen, elixir-format
 msgid "Additional Service"
-msgstr ""
+msgstr "Servicio adicional"
 
 #: lib/presentation_strings.ex:32
 #, elixir-autogen, elixir-format
 msgid "Additional service"
-msgstr ""
+msgstr "Servicio adicional"
 
 #: lib/presentation_strings.ex:63
 #: lib/presentation_strings.ex:64
@@ -178,1014 +178,1014 @@ msgstr ""
 #: lib/presentation_strings.ex:104
 #, elixir-autogen, elixir-format
 msgid "Alert"
-msgstr ""
+msgstr "Alerta"
 
 #: lib/presentation_strings.ex:73
 #, elixir-autogen, elixir-format
 msgid "Amber Alert"
-msgstr ""
+msgstr "Alerta Amber"
 
 #: lib/presentation_strings.ex:33
 #, elixir-autogen, elixir-format
 msgid "Amber alert"
-msgstr ""
+msgstr "Alerta Amber"
 
 #: lib/presentation_strings.ex:112
 #: lib/presentation_strings.ex:175
 #, elixir-autogen, elixir-format
 msgid "Amtrak"
-msgstr ""
+msgstr "Amtrak"
 
 #: lib/presentation_strings.ex:176
 #, elixir-autogen, elixir-format
 msgid "Amtrak Train Traffic"
-msgstr ""
+msgstr "Tráfico de trenes de Amtrak"
 
 #: lib/presentation_strings.ex:113
 #, elixir-autogen, elixir-format
 msgid "Amtrak train traffic"
-msgstr ""
+msgstr "tráfico de trenes de Amtrak"
 
 #: lib/presentation_strings.ex:177
 #, elixir-autogen, elixir-format
 msgid "An Earlier Mechanical Problem"
-msgstr ""
+msgstr "Un problema mecánico anterior"
 
 #: lib/presentation_strings.ex:178
 #, elixir-autogen, elixir-format
 msgid "An Earlier Signal Problem"
-msgstr ""
+msgstr "Un problema de señal anterior"
 
 #: lib/presentation_strings.ex:179
 #, elixir-autogen, elixir-format
 msgid "Autos Impeding Service"
-msgstr ""
+msgstr "Automóviles que obstaculizan el servicio"
 
 #: lib/presentation_strings.ex:74
 #, elixir-autogen, elixir-format
 msgid "Bike Issue"
-msgstr ""
+msgstr "Problema con la bicicleta"
 
 #: lib/presentation_strings.ex:34
 #, elixir-autogen, elixir-format
 msgid "Bike issue"
-msgstr ""
+msgstr "Problema con la bicicleta"
 
 #: lib/presentation_strings.ex:75
 #, elixir-autogen, elixir-format
 msgid "Cancellation"
-msgstr ""
+msgstr "Cancelación"
 
 #: lib/presentation_strings.ex:180
 #, elixir-autogen, elixir-format
 msgid "Coast Guard Restriction"
-msgstr ""
+msgstr "Restricción de la Guardia Costera"
 
 #: lib/presentation_strings.ex:117
 #, elixir-autogen, elixir-format
 msgid "Coast Guard restriction"
-msgstr ""
+msgstr "restricción de la Guardia Costera"
 
 #: lib/presentation_strings.ex:181
 #, elixir-autogen, elixir-format
 msgid "Congestion"
-msgstr ""
+msgstr "Congestión"
 
 #: lib/presentation_strings.ex:182
 #, elixir-autogen, elixir-format
 msgid "Construction"
-msgstr ""
+msgstr "Construcción"
 
 #: lib/presentation_strings.ex:183
 #, elixir-autogen, elixir-format
 msgid "Crossing Issue"
-msgstr ""
+msgstr "Problema en el cruce"
 
 #: lib/presentation_strings.ex:184
 #, elixir-autogen, elixir-format
 msgid "Crossing Malfunction"
-msgstr ""
+msgstr "Fallo en el cruce"
 
 #: lib/presentation_strings.ex:36
 #: lib/presentation_strings.ex:76
 #, elixir-autogen, elixir-format
 msgid "Delay"
-msgstr ""
+msgstr "Demora"
 
 #: lib/presentation_strings.ex:185
 #, elixir-autogen, elixir-format
 msgid "Demonstration"
-msgstr ""
+msgstr "Demostración"
 
 #: lib/presentation_strings.ex:37
 #: lib/presentation_strings.ex:77
 #, elixir-autogen, elixir-format
 msgid "Detour"
-msgstr ""
+msgstr "Desvío"
 
 #: lib/presentation_strings.ex:186
 #, elixir-autogen, elixir-format
 msgid "Disabled Bus"
-msgstr ""
+msgstr "Autobús averiado"
 
 #: lib/presentation_strings.ex:187
 #, elixir-autogen, elixir-format
 msgid "Disabled Train"
-msgstr ""
+msgstr "Tren averiado"
 
 #: lib/presentation_strings.ex:78
 #, elixir-autogen, elixir-format
 msgid "Dock Closure"
-msgstr ""
+msgstr "Cierre del muelle"
 
 #: lib/presentation_strings.ex:79
 #, elixir-autogen, elixir-format
 msgid "Dock Issue"
-msgstr ""
+msgstr "Problema con dársena"
 
 #: lib/presentation_strings.ex:38
 #, elixir-autogen, elixir-format
 msgid "Dock closed"
-msgstr ""
+msgstr "Dársena cerrada"
 
 #: lib/presentation_strings.ex:39
 #, elixir-autogen, elixir-format
 msgid "Dock issue"
-msgstr ""
+msgstr "Problema con dársena"
 
 #: lib/presentation_strings.ex:188
 #, elixir-autogen, elixir-format
 msgid "Drawbridge Being Raised"
-msgstr ""
+msgstr "Puente levadizo en elevación"
 
 #: lib/presentation_strings.ex:189
 #, elixir-autogen, elixir-format
 msgid "Drawbridge Issue"
-msgstr ""
+msgstr "Problema del puente levadizo"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:8
 #, elixir-autogen, elixir-format
 msgid "Eastbound"
-msgstr ""
+msgstr "En dirección este"
 
 #: lib/presentation_strings.ex:190
 #, elixir-autogen, elixir-format
 msgid "Electrical Work"
-msgstr ""
+msgstr "Trabajo eléctrico"
 
 #: lib/presentation_strings.ex:80
 #, elixir-autogen, elixir-format
 msgid "Elevator Closure"
-msgstr ""
+msgstr "Cierre del ascensor"
 
 #: lib/presentation_strings.ex:40
 #, elixir-autogen, elixir-format
 msgid "Elevator closed"
-msgstr ""
+msgstr "Ascensor fuera de servicio"
 
 #: lib/presentation_strings.ex:81
 #, elixir-autogen, elixir-format
 msgid "Escalator Closure"
-msgstr ""
+msgstr "Escalera mecánica fuera de servicio"
 
 #: lib/presentation_strings.ex:41
 #, elixir-autogen, elixir-format
 msgid "Escalator closed"
-msgstr ""
+msgstr "Escalera mecánica cerrada"
 
 #: lib/presentation_strings.ex:82
 #, elixir-autogen, elixir-format
 msgid "Extra Service"
-msgstr ""
+msgstr "Servicio extra"
 
 #: lib/presentation_strings.ex:42
 #, elixir-autogen, elixir-format
 msgid "Extra service"
-msgstr ""
+msgstr "Servicio extra"
 
 #: lib/presentation_strings.ex:83
 #, elixir-autogen, elixir-format
 msgid "Facility Issue"
-msgstr ""
+msgstr "Problema en las instalaciones"
 
 #: lib/presentation_strings.ex:43
 #, elixir-autogen, elixir-format
 msgid "Facility issue"
-msgstr ""
+msgstr "Problema en las instalaciones"
 
 #: lib/presentation_strings.ex:191
 #, elixir-autogen, elixir-format
 msgid "Fire"
-msgstr ""
+msgstr "Incendio"
 
 #: lib/presentation_strings.ex:192
 #, elixir-autogen, elixir-format
 msgid "Fire Department Activity"
-msgstr ""
+msgstr "Actividad del Departamento de Incendios"
 
 #: lib/presentation_strings.ex:193
 #, elixir-autogen, elixir-format
 msgid "Flooding"
-msgstr ""
+msgstr "Inundación"
 
 #: lib/presentation_strings.ex:194
 #, elixir-autogen, elixir-format
 msgid "Fog"
-msgstr ""
+msgstr "Niebla"
 
 #: lib/presentation_strings.ex:195
 #, elixir-autogen, elixir-format
 msgid "Freight Train Interference"
-msgstr ""
+msgstr "Interferencia con trenes de carga"
 
 #: lib/presentation_strings.ex:196
 #, elixir-autogen, elixir-format
 msgid "Hazmat Condition"
-msgstr ""
+msgstr "Condición de materiales peligrosos"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:17
 #, elixir-autogen, elixir-format
 msgid "Heading"
-msgstr ""
+msgstr "Rumbo"
 
 #: lib/presentation_strings.ex:197
 #, elixir-autogen, elixir-format
 msgid "Heavy Ridership"
-msgstr ""
+msgstr "Gran cantidad de pasajeros"
 
 #: lib/presentation_strings.ex:198
 #, elixir-autogen, elixir-format
 msgid "High Winds"
-msgstr ""
+msgstr "Vientos fuertes"
 
 #: lib/presentation_strings.ex:199
 #, elixir-autogen, elixir-format
 msgid "Holiday"
-msgstr ""
+msgstr "Día festivo"
 
 #: lib/presentation_strings.ex:200
 #, elixir-autogen, elixir-format
 msgid "Hurricane"
-msgstr ""
+msgstr "Huracán"
 
 #: lib/presentation_strings.ex:201
 #, elixir-autogen, elixir-format
 msgid "Ice In Harbor"
-msgstr ""
+msgstr "Hielo en el puerto"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:10
 #, elixir-autogen, elixir-format
 msgid "Inbound"
-msgstr ""
+msgstr "Entrante"
 
 #: lib/presentation_strings.ex:202
 #, elixir-autogen, elixir-format
 msgid "Maintenance"
-msgstr ""
+msgstr "Mantenimiento"
 
 #: lib/presentation_strings.ex:203
 #, elixir-autogen, elixir-format
 msgid "Mechanical Issue"
-msgstr ""
+msgstr "Problema mecánico"
 
 #: lib/presentation_strings.ex:204
 #, elixir-autogen, elixir-format
 msgid "Mechanical Problem"
-msgstr ""
+msgstr "Problema mecánico"
 
 #: lib/presentation_strings.ex:205
 #, elixir-autogen, elixir-format
 msgid "Medical Emergency"
-msgstr ""
+msgstr "Emergencia médica"
 
 #: lib/presentation_strings.ex:84
 #, elixir-autogen, elixir-format
 msgid "Modified Service"
-msgstr ""
+msgstr "Servicio modificado"
 
 #: lib/presentation_strings.ex:44
 #, elixir-autogen, elixir-format
 msgid "Modified service"
-msgstr ""
+msgstr "Servicio modificado"
 
 #: lib/mobile_app_backend/notifications/notification_title.ex:69
 #, elixir-autogen, elixir-format
 msgid "Multiple routes"
-msgstr ""
+msgstr "Múltiples rutas"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:282
 #, elixir-autogen, elixir-format
 msgid "Multiple trips"
-msgstr ""
+msgstr "Múltiples viajes"
 
 #: lib/presentation_strings.ex:85
 #, elixir-autogen, elixir-format
 msgid "No Service"
-msgstr ""
+msgstr "Sin servicio"
 
 #: lib/presentation_strings.ex:45
 #, elixir-autogen, elixir-format
 msgid "No service"
-msgstr ""
+msgstr "Sin servicio"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:6
 #, elixir-autogen, elixir-format
 msgid "Northbound"
-msgstr ""
+msgstr "En dirección norte"
 
 #: lib/presentation_strings.ex:46
 #: lib/presentation_strings.ex:86
 #, elixir-autogen, elixir-format
 msgid "Notice"
-msgstr ""
+msgstr "Aviso"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:11
 #, elixir-autogen, elixir-format
 msgid "Outbound"
-msgstr ""
+msgstr "Saliente"
 
 #: lib/presentation_strings.ex:206
 #, elixir-autogen, elixir-format
 msgid "Parade"
-msgstr ""
+msgstr "Desfile"
 
 #: lib/presentation_strings.ex:87
 #, elixir-autogen, elixir-format
 msgid "Parking Closure"
-msgstr ""
+msgstr "Cierre de estacionamiento"
 
 #: lib/presentation_strings.ex:88
 #, elixir-autogen, elixir-format
 msgid "Parking Issue"
-msgstr ""
+msgstr "Problema de estacionamiento"
 
 #: lib/presentation_strings.ex:47
 #, elixir-autogen, elixir-format
 msgid "Parking closed"
-msgstr ""
+msgstr "Estacionamiento cerrado"
 
 #: lib/presentation_strings.ex:48
 #, elixir-autogen, elixir-format
 msgid "Parking issue"
-msgstr ""
+msgstr "Problema de estacionamiento"
 
 #: lib/presentation_strings.ex:207
 #, elixir-autogen, elixir-format
 msgid "Police Action"
-msgstr ""
+msgstr "Acción policial"
 
 #: lib/presentation_strings.ex:208
 #, elixir-autogen, elixir-format
 msgid "Police Activity"
-msgstr ""
+msgstr "Actividad policial"
 
 #: lib/presentation_strings.ex:89
 #, elixir-autogen, elixir-format
 msgid "Policy Change"
-msgstr ""
+msgstr "Cambio de política"
 
 #: lib/presentation_strings.ex:49
 #, elixir-autogen, elixir-format
 msgid "Policy change"
-msgstr ""
+msgstr "Cambio de política"
 
 #: lib/presentation_strings.ex:209
 #, elixir-autogen, elixir-format
 msgid "Power Problem"
-msgstr ""
+msgstr "Problema de energía"
 
 #: lib/presentation_strings.ex:210
 #, elixir-autogen, elixir-format
 msgid "Rail Defect"
-msgstr ""
+msgstr "Defecto del riel"
 
 #: lib/presentation_strings.ex:90
 #, elixir-autogen, elixir-format
 msgid "Schedule Change"
-msgstr ""
+msgstr "Cambio de horario"
 
 #: lib/presentation_strings.ex:50
 #, elixir-autogen, elixir-format
 msgid "Schedule change"
-msgstr ""
+msgstr "Cambio de horario"
 
 #: lib/presentation_strings.ex:91
 #, elixir-autogen, elixir-format
 msgid "Service Change"
-msgstr ""
+msgstr "Cambio de servicio"
 
 #: lib/presentation_strings.ex:51
 #, elixir-autogen, elixir-format
 msgid "Service change"
-msgstr ""
+msgstr "Cambio de servicio"
 
 #: lib/presentation_strings.ex:61
 #, elixir-autogen, elixir-format
 msgid "Service suspended"
-msgstr ""
+msgstr "Servicio suspendido"
 
 #: lib/presentation_strings.ex:211
 #, elixir-autogen, elixir-format
 msgid "Severe Weather"
-msgstr ""
+msgstr "Clima severo"
 
 #: lib/presentation_strings.ex:92
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
-msgstr ""
+msgstr "Autobús de enlace"
 
 #: lib/presentation_strings.ex:52
 #, elixir-autogen, elixir-format
 msgid "Shuttle buses"
-msgstr ""
+msgstr "Autobuses de enlace"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:298
 #, elixir-autogen, elixir-format
 msgid "Shuttle buses replace %{trip_identity} from **%{start_stop}** to **%{end_stop}**%{recurrence}"
-msgstr ""
+msgstr "Los autobuses lanzadera reemplazan a %{trip_identity} desde **%{start_stop}** hasta **%{end_stop}**%{recurrence}"
 
 #: lib/presentation_strings.ex:212
 #, elixir-autogen, elixir-format
 msgid "Signal Issue"
-msgstr ""
+msgstr "Problema de señal"
 
 #: lib/presentation_strings.ex:213
 #, elixir-autogen, elixir-format
 msgid "Signal Problem"
-msgstr ""
+msgstr "Problema de señal"
 
 #: lib/presentation_strings.ex:214
 #, elixir-autogen, elixir-format
 msgid "Single Tracking"
-msgstr ""
+msgstr "Seguimiento único"
 
 #: lib/presentation_strings.ex:215
 #, elixir-autogen, elixir-format
 msgid "Slippery Rail"
-msgstr ""
+msgstr "Riel resbaloso"
 
 #: lib/presentation_strings.ex:216
 #, elixir-autogen, elixir-format
 msgid "Snow"
-msgstr ""
+msgstr "Nieve"
 
 #: lib/presentation_strings.ex:93
 #, elixir-autogen, elixir-format
 msgid "Snow Route"
-msgstr ""
+msgstr "Ruta con nieve"
 
 #: lib/presentation_strings.ex:53
 #, elixir-autogen, elixir-format
 msgid "Snow route"
-msgstr ""
+msgstr "Ruta de nieve"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:7
 #, elixir-autogen, elixir-format
 msgid "Southbound"
-msgstr ""
+msgstr "En dirección sur"
 
 #: lib/presentation_strings.ex:217
 #, elixir-autogen, elixir-format
 msgid "Special Event"
-msgstr ""
+msgstr "Evento especial"
 
 #: lib/presentation_strings.ex:218
 #, elixir-autogen, elixir-format
 msgid "Speed Restriction"
-msgstr ""
+msgstr "Restricción de velocidad"
 
 #: lib/presentation_strings.ex:94
 #, elixir-autogen, elixir-format
 msgid "Station Closure"
-msgstr ""
+msgstr "Cierre de estación"
 
 #: lib/presentation_strings.ex:95
 #, elixir-autogen, elixir-format
 msgid "Station Issue"
-msgstr ""
+msgstr "Problema en la estación"
 
 #: lib/presentation_strings.ex:54
 #, elixir-autogen, elixir-format
 msgid "Station closed"
-msgstr ""
+msgstr "Estación cerrada"
 
 #: lib/presentation_strings.ex:55
 #, elixir-autogen, elixir-format
 msgid "Station issue"
-msgstr ""
+msgstr "Problema en la estación"
 
 #: lib/presentation_strings.ex:96
 #, elixir-autogen, elixir-format
 msgid "Stop Closure"
-msgstr ""
+msgstr "Cierre de parada"
 
 #: lib/presentation_strings.ex:97
 #: lib/presentation_strings.ex:98
 #, elixir-autogen, elixir-format
 msgid "Stop Moved"
-msgstr ""
+msgstr "Parada modificada"
 
 #: lib/presentation_strings.ex:99
 #, elixir-autogen, elixir-format
 msgid "Stop Shoveling"
-msgstr ""
+msgstr "Trabajo de paleo en la parada"
 
 #: lib/presentation_strings.ex:56
 #, elixir-autogen, elixir-format
 msgid "Stop closed"
-msgstr ""
+msgstr "Parada cerrada"
 
 #: lib/presentation_strings.ex:57
 #: lib/presentation_strings.ex:58
 #, elixir-autogen, elixir-format
 msgid "Stop moved"
-msgstr ""
+msgstr "Parada modificada"
 
 #: lib/presentation_strings.ex:59
 #, elixir-autogen, elixir-format
 msgid "Stop shoveling"
-msgstr ""
+msgstr "Trabajo de paleo en la parada"
 
 #: lib/presentation_strings.ex:219
 #, elixir-autogen, elixir-format
 msgid "Strike"
-msgstr ""
+msgstr "Huelga"
 
 #: lib/presentation_strings.ex:60
 #: lib/presentation_strings.ex:100
 #, elixir-autogen, elixir-format
 msgid "Summary"
-msgstr ""
+msgstr "Resumen"
 
 #: lib/presentation_strings.ex:101
 #, elixir-autogen, elixir-format
 msgid "Suspension"
-msgstr ""
+msgstr "Suspensión"
 
 #: lib/presentation_strings.ex:220
 #, elixir-autogen, elixir-format
 msgid "Switch Issue"
-msgstr ""
+msgstr "Problema de cambio de carril"
 
 #: lib/presentation_strings.ex:221
 #, elixir-autogen, elixir-format
 msgid "Switch Problem"
-msgstr ""
+msgstr "Problema de cambio de carril"
 
 #: lib/presentation_strings.ex:222
 #, elixir-autogen, elixir-format
 msgid "Technical Problem"
-msgstr ""
+msgstr "Problema técnico"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:263
 #, elixir-autogen, elixir-format
 msgid "This %{route_type}"
-msgstr ""
+msgstr "Este %{route_type}"
 
 #: lib/presentation_strings.ex:223
 #, elixir-autogen, elixir-format
 msgid "Tie Replacement"
-msgstr ""
+msgstr "Reemplazo de traviesas"
 
 #: lib/presentation_strings.ex:102
 #, elixir-autogen, elixir-format
 msgid "Track Change"
-msgstr ""
+msgstr "Cambio de pista"
 
 #: lib/presentation_strings.ex:224
 #, elixir-autogen, elixir-format
 msgid "Track Problem"
-msgstr ""
+msgstr "Problema de vía"
 
 #: lib/presentation_strings.ex:225
 #, elixir-autogen, elixir-format
 msgid "Track Work"
-msgstr ""
+msgstr "Trabajo en vía"
 
 #: lib/presentation_strings.ex:62
 #, elixir-autogen, elixir-format
 msgid "Track change"
-msgstr ""
+msgstr "Cambio de pista"
 
 #: lib/presentation_strings.ex:226
 #, elixir-autogen, elixir-format
 msgid "Traffic"
-msgstr ""
+msgstr "Tráfico"
 
 #: lib/presentation_strings.ex:227
 #, elixir-autogen, elixir-format
 msgid "Train Traffic"
-msgstr ""
+msgstr "Tráfico de trenes"
 
 #: lib/presentation_strings.ex:35
 #, elixir-autogen, elixir-format
 msgid "Trip cancelled"
-msgstr ""
+msgstr "Viaje cancelado"
 
 #: lib/presentation_strings.ex:228
 #, elixir-autogen, elixir-format
 msgid "Unruly Passenger"
-msgstr ""
+msgstr "Pasajero indisciplinado"
 
 #: lib/presentation_strings.ex:229
 #, elixir-autogen, elixir-format
 msgid "Weather"
-msgstr ""
+msgstr "Clima"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:9
 #, elixir-autogen, elixir-format
 msgid "Westbound"
-msgstr ""
+msgstr "En dirección oeste"
 
 #: lib/presentation_strings.ex:111
 #, elixir-autogen, elixir-format
 msgid "accident"
-msgstr ""
+msgstr "accidente"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:424
 #, elixir-autogen, elixir-format
 msgid "affected by %{effect} %{day}"
-msgstr ""
+msgstr "afectado por %{effect} %{day}"
 
 #: lib/presentation_strings.ex:114
 #, elixir-autogen, elixir-format
 msgid "an earlier mechanical problem"
-msgstr ""
+msgstr "un problema mecánico anterior"
 
 #: lib/presentation_strings.ex:115
 #, elixir-autogen, elixir-format
 msgid "an earlier signal problem"
-msgstr ""
+msgstr "un problema de señal anterior"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:382
 #, elixir-autogen, elixir-format
 msgid "are cancelled %{day}"
-msgstr ""
+msgstr "se cancelan %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:417
 #, elixir-autogen, elixir-format
 msgid "are suspended %{day}"
-msgstr ""
+msgstr "están suspendidos %{day}"
 
 #: lib/presentation_strings.ex:116
 #, elixir-autogen, elixir-format
 msgid "autos impeding service"
-msgstr ""
+msgstr "autos que impiden el servicio"
 
 #: lib/presentation_strings.ex:12
 #, elixir-autogen, elixir-format
 msgid "bus"
-msgstr ""
+msgstr "autobús"
 
 #: lib/presentation_strings.ex:13
 #, elixir-autogen, elixir-format
 msgid "buses"
-msgstr ""
+msgstr "autobuses"
 
 #: lib/presentation_strings.ex:118
 #, elixir-autogen, elixir-format
 msgid "congestion"
-msgstr ""
+msgstr "congestión"
 
 #: lib/presentation_strings.ex:119
 #, elixir-autogen, elixir-format
 msgid "construction"
-msgstr ""
+msgstr "construcción"
 
 #: lib/presentation_strings.ex:120
 #, elixir-autogen, elixir-format
 msgid "crossing issue"
-msgstr ""
+msgstr "problema en el cruce"
 
 #: lib/presentation_strings.ex:121
 #, elixir-autogen, elixir-format
 msgid "crossing malfunction"
-msgstr ""
+msgstr "mal funcionamiento del cruce"
 
 #: lib/presentation_strings.ex:122
 #, elixir-autogen, elixir-format
 msgid "demonstration"
-msgstr ""
+msgstr "demostración"
 
 #: lib/presentation_strings.ex:123
 #, elixir-autogen, elixir-format
 msgid "disabled bus"
-msgstr ""
+msgstr "autobús averiado"
 
 #: lib/presentation_strings.ex:124
 #, elixir-autogen, elixir-format
 msgid "disabled train"
-msgstr ""
+msgstr "tren averiado"
 
 #: lib/presentation_strings.ex:125
 #, elixir-autogen, elixir-format
 msgid "drawbridge being raised"
-msgstr ""
+msgstr "puente levadizo levantado"
 
 #: lib/presentation_strings.ex:126
 #, elixir-autogen, elixir-format
 msgid "drawbridge issue"
-msgstr ""
+msgstr "problema del puente levadizo"
 
 #: lib/presentation_strings.ex:127
 #, elixir-autogen, elixir-format
 msgid "electrical work"
-msgstr ""
+msgstr "trabajo eléctrico"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:193
 #, elixir-autogen, elixir-format
 msgid "end of service"
-msgstr ""
+msgstr "fin del servicio"
 
 #: lib/presentation_strings.ex:15
 #, elixir-autogen, elixir-format
 msgid "ferries"
-msgstr ""
+msgstr "ferris"
 
 #: lib/presentation_strings.ex:14
 #, elixir-autogen, elixir-format
 msgid "ferry"
-msgstr ""
+msgstr "ferry"
 
 #: lib/presentation_strings.ex:128
 #, elixir-autogen, elixir-format
 msgid "fire"
-msgstr ""
+msgstr "fuego"
 
 #: lib/presentation_strings.ex:129
 #, elixir-autogen, elixir-format
 msgid "fire department activity"
-msgstr ""
+msgstr "actividad del departamento de bomberos"
 
 #: lib/presentation_strings.ex:130
 #, elixir-autogen, elixir-format
 msgid "flooding"
-msgstr ""
+msgstr "inundación"
 
 #: lib/presentation_strings.ex:131
 #, elixir-autogen, elixir-format
 msgid "fog"
-msgstr ""
+msgstr "niebla"
 
 #: lib/presentation_strings.ex:132
 #, elixir-autogen, elixir-format
 msgid "freight train interference"
-msgstr ""
+msgstr "interferencia del tren de mercancías"
 
 #: lib/presentation_strings.ex:133
 #, elixir-autogen, elixir-format
 msgid "hazmat condition"
-msgstr ""
+msgstr "condición de materiales peligrosos"
 
 #: lib/presentation_strings.ex:134
 #, elixir-autogen, elixir-format
 msgid "heavy ridership"
-msgstr ""
+msgstr "gran cantidad de pasajeros"
 
 #: lib/presentation_strings.ex:135
 #, elixir-autogen, elixir-format
 msgid "high winds"
-msgstr ""
+msgstr "fuertes vientos"
 
 #: lib/presentation_strings.ex:136
 #, elixir-autogen, elixir-format
 msgid "holiday"
-msgstr ""
+msgstr "día festivo"
 
 #: lib/presentation_strings.ex:137
 #, elixir-autogen, elixir-format
 msgid "hurricane"
-msgstr ""
+msgstr "huracán"
 
 #: lib/presentation_strings.ex:138
 #, elixir-autogen, elixir-format
 msgid "ice in harbor"
-msgstr ""
+msgstr "hielo en el puerto"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:385
 #, elixir-autogen, elixir-format
 msgid "is cancelled %{day}"
-msgstr ""
+msgstr "se cancela %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:420
 #, elixir-autogen, elixir-format
 msgid "is suspended %{day}"
-msgstr ""
+msgstr "está suspendido %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:239
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_recurrence_end_day_later_date"
-msgstr ""
+msgstr " hasta %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:247
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_recurrence_end_day_this_week"
-msgstr ""
+msgstr " hasta %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:144
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_timeframe_later_date"
-msgstr ""
+msgstr " hasta el %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:152
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_timeframe_this_week"
-msgstr ""
+msgstr " hasta el día %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:160
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_timeframe_time"
-msgstr ""
+msgstr " hasta las %{1}"
 
 #: lib/presentation_strings.ex:139
 #, elixir-autogen, elixir-format
 msgid "maintenance"
-msgstr ""
+msgstr "mantenimiento"
 
 #: lib/presentation_strings.ex:140
 #, elixir-autogen, elixir-format
 msgid "mechanical issue"
-msgstr ""
+msgstr "problema mecánico"
 
 #: lib/presentation_strings.ex:141
 #, elixir-autogen, elixir-format
 msgid "mechanical problem"
-msgstr ""
+msgstr "problema mecánico"
 
 #: lib/presentation_strings.ex:142
 #, elixir-autogen, elixir-format
 msgid "medical emergency"
-msgstr ""
+msgstr "emergencia médica"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:333
 #, elixir-autogen, elixir-format
 msgid "multiple trips"
-msgstr ""
+msgstr "múltiples viajes"
 
 #: lib/presentation_strings.ex:143
 #, elixir-autogen, elixir-format
 msgid "parade"
-msgstr ""
+msgstr "desfile"
 
 #: lib/presentation_strings.ex:144
 #, elixir-autogen, elixir-format
 msgid "police action"
-msgstr ""
+msgstr "acción policial"
 
 #: lib/presentation_strings.ex:145
 #, elixir-autogen, elixir-format
 msgid "police activity"
-msgstr ""
+msgstr "actividad policial"
 
 #: lib/presentation_strings.ex:146
 #, elixir-autogen, elixir-format
 msgid "power problem"
-msgstr ""
+msgstr "problema con el suministro de electricidad"
 
 #: lib/presentation_strings.ex:147
 #, elixir-autogen, elixir-format
 msgid "rail defect"
-msgstr ""
+msgstr "defecto del riel"
 
 #: lib/presentation_strings.ex:148
 #, elixir-autogen, elixir-format
 msgid "severe weather"
-msgstr ""
+msgstr "clima severo"
 
 #: lib/presentation_strings.ex:149
 #, elixir-autogen, elixir-format
 msgid "signal issue"
-msgstr ""
+msgstr "problema de señal"
 
 #: lib/presentation_strings.ex:150
 #, elixir-autogen, elixir-format
 msgid "signal problem"
-msgstr ""
+msgstr "problema de señal"
 
 #: lib/presentation_strings.ex:151
 #, elixir-autogen, elixir-format
 msgid "single tracking"
-msgstr ""
+msgstr "seguimiento único"
 
 #: lib/presentation_strings.ex:152
 #, elixir-autogen, elixir-format
 msgid "slippery rail"
-msgstr ""
+msgstr "carril resbaladizo"
 
 #: lib/presentation_strings.ex:153
 #, elixir-autogen, elixir-format
 msgid "snow"
-msgstr ""
+msgstr "nieve"
 
 #: lib/presentation_strings.ex:154
 #, elixir-autogen, elixir-format
 msgid "special event"
-msgstr ""
+msgstr "evento especial"
 
 #: lib/presentation_strings.ex:155
 #, elixir-autogen, elixir-format
 msgid "speed restriction"
-msgstr ""
+msgstr "restricción de velocidad"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:190
 #, elixir-autogen, elixir-format
 msgid "start of service"
-msgstr ""
+msgstr "inicio del servicio"
 
 #: lib/presentation_strings.ex:156
 #, elixir-autogen, elixir-format
 msgid "strike"
-msgstr ""
+msgstr "huelga"
 
 #: lib/presentation_strings.ex:157
 #, elixir-autogen, elixir-format
 msgid "switch issue"
-msgstr ""
+msgstr "problema de cambio de carril"
 
 #: lib/presentation_strings.ex:158
 #, elixir-autogen, elixir-format
 msgid "switch problem"
-msgstr ""
+msgstr "problema del interruptor"
 
 #: lib/presentation_strings.ex:159
 #, elixir-autogen, elixir-format
 msgid "technical problem"
-msgstr ""
+msgstr "problema técnico"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:320
 #, elixir-autogen, elixir-format
 msgid "the **%{time}** %{vehicle}"
-msgstr ""
+msgstr "el **%{time}** %{vehicle}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:328
 #, elixir-autogen, elixir-format
 msgid "this %{vehicle}"
-msgstr ""
+msgstr "este %{vehicle}"
 
 #: lib/presentation_strings.ex:160
 #, elixir-autogen, elixir-format
 msgid "tie replacement"
-msgstr ""
+msgstr "reemplazo de traviesas"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:377
 #, elixir-autogen, elixir-format
 msgid "today"
-msgstr ""
+msgstr "hoy"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:377
 #, elixir-autogen, elixir-format
 msgid "tomorrow"
-msgstr ""
+msgstr "mañana"
 
 #: lib/presentation_strings.ex:161
 #, elixir-autogen, elixir-format
 msgid "track problem"
-msgstr ""
+msgstr "problema en la vía"
 
 #: lib/presentation_strings.ex:162
 #, elixir-autogen, elixir-format
 msgid "track work"
-msgstr ""
+msgstr "trabajo en la vía"
 
 #: lib/presentation_strings.ex:163
 #, elixir-autogen, elixir-format
 msgid "traffic"
-msgstr ""
+msgstr "tráfico"
 
 #: lib/presentation_strings.ex:16
 #, elixir-autogen, elixir-format
 msgid "train"
-msgstr ""
+msgstr "tren"
 
 #: lib/presentation_strings.ex:164
 #, elixir-autogen, elixir-format
 msgid "train traffic"
-msgstr ""
+msgstr "tráfico de trenes"
 
 #: lib/presentation_strings.ex:17
 #, elixir-autogen, elixir-format
 msgid "trains"
-msgstr ""
+msgstr "trenes"
 
 #: lib/presentation_strings.ex:165
 #, elixir-autogen, elixir-format
 msgid "unruly passenger"
-msgstr ""
+msgstr "pasajero rebelde"
 
 #: lib/presentation_strings.ex:166
 #, elixir-autogen, elixir-format
 msgid "weather"
-msgstr ""
+msgstr "clima"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:388
 #, elixir-autogen, elixir-format
 msgid "will not stop at %{stop_list} %{day}"
-msgstr ""
+msgstr "no se detendrá en %{stop_list} %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:411
 #, elixir-autogen, elixir-format
 msgid "will terminate at %{terminating_stop} %{day}"
-msgstr ""
+msgstr "finalizará en %{terminating_stop} %{day}"
 
 #: lib/mobile_app_backend_web/components/core_components.ex:484
 #, elixir-autogen, elixir-format, import-optional

--- a/priv/gettext/es/LC_MESSAGES/errors.po
+++ b/priv/gettext/es/LC_MESSAGES/errors.po
@@ -1,0 +1,12 @@
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: es\n"
+"Plural-Forms: nplurals=3\n"

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -1,176 +1,176 @@
-## This file is a PO Template file.
-##
-## "msgid"s here are often extracted from source code.
-## Add new messages manually only if they're dynamic
-## messages that can't be statically extracted.
-##
-## Run "mix gettext.extract" to bring this file up to
-## date. Leave "msgstr"s empty as changing them here has no
-## effect: edit them in PO (.po) files instead.
-#
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
 msgid ""
 msgstr ""
+"Language: fr\n"
+"Plural-Forms: nplurals=3\n"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:101
 #, elixir-autogen, elixir-format
 msgid " at **%{stop_name}**"
-msgstr ""
+msgstr " à **%{stop_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:210
 #, elixir-autogen, elixir-format
 msgid " daily%{recurrence_text}"
-msgstr ""
+msgstr " tous les jours%{recurrence_text}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:434
 #, elixir-autogen, elixir-format
 msgid " due to %{cause}"
-msgstr ""
+msgstr " en raison de %{cause}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:173
 #, elixir-autogen, elixir-format
 msgid " from %{start_time} to %{end_time}"
-msgstr ""
+msgstr " de %{start_time} à %{end_time}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:95
 #, elixir-autogen, elixir-format
 msgid " from **%{direction_name}** stops to **%{end_stop_name}**"
-msgstr ""
+msgstr " depuis les arrêts en direction de **%{direction_name}** jusqu’à **%{end_stop_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:110
 #, elixir-autogen, elixir-format
 msgid " from **%{start_stop}** to **%{end_stop}**"
-msgstr ""
+msgstr " de **%{start_stop}** à **%{end_stop}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:104
 #, elixir-autogen, elixir-format
 msgid " from **%{stop_name}** to **%{direction_name}** stops"
-msgstr ""
+msgstr " de **%{stop_name}** aux arrêts en direction de **%{direction_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:121
 #, elixir-autogen, elixir-format
 msgid " on **%{mode_label}**"
-msgstr ""
+msgstr " sur **%{mode_label}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:117
 #, elixir-autogen, elixir-format
 msgid " replacing **%{mode_label}**"
-msgstr ""
+msgstr " remplacer **%{mode_label}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:219
 #, elixir-autogen, elixir-format
 msgid " some days%{recurrence_text}"
-msgstr ""
+msgstr " certains jours%{recurrence_text}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:168
 #, elixir-autogen, elixir-format
 msgid " starting **%{formatted_time}** today"
-msgstr ""
+msgstr " à partir de **%{formatted_time}** aujourd’hui"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:165
 #, elixir-autogen, elixir-format
 msgid " starting tomorrow"
-msgstr ""
+msgstr " à partir de demain"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:138
 #, elixir-autogen, elixir-format
 msgid " through end of service"
-msgstr ""
+msgstr " jusqu’à la fin du service"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:141
 #, elixir-autogen, elixir-format
 msgid " through tomorrow"
-msgstr ""
+msgstr " jusqu’à demain"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:135
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:233
 #, elixir-autogen, elixir-format
 msgid " until further notice"
-msgstr ""
+msgstr " jusqu’à nouvel ordre"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:236
 #, elixir-autogen, elixir-format
 msgid " until tomorrow"
-msgstr ""
+msgstr " jusqu’à demain"
 
 #: lib/mobile_app_backend/notifications/notification_title.ex:63
 #, elixir-autogen, elixir-format
 msgid "%{label} %{mode_label}"
-msgstr ""
+msgstr "%{mode_label} %{label}"
 
 #: lib/presentation_strings.ex:22
 #, elixir-autogen, elixir-format
 msgid "%{name} bus"
-msgstr ""
+msgstr "Bus %{name}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:398
 #, elixir-autogen, elixir-format
 msgid "%{stop} and %{other_stops}"
-msgstr ""
+msgstr "%{stop} et %{other_stops}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:57
 #, elixir-autogen, elixir-format
 msgid "%{trip_identity} %{trip_effect}%{cause}%{recurrence}"
-msgstr ""
+msgstr "%{trip_identity} %{trip_effect}%{cause}%{recurrence}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:290
 #, elixir-autogen, elixir-format
 msgid "%{trip_identity} is replaced by shuttle buses from **%{start_stop}** to **%{end_stop}**%{recurrence}"
-msgstr ""
+msgstr "%{trip_identity} est remplacé par des navettes entre **%{start_stop}** et **%{end_stop}**%{recurrence}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:47
 #, elixir-autogen, elixir-format
 msgid "**%{effect_sentence_case}**%{summary_location}%{summary_timeframe}%{summary_recurrence}"
-msgstr ""
+msgstr "**%{effect_sentence_case}**%{summary_location}%{summary_timeframe}%{summary_recurrence}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:313
 #, elixir-autogen, elixir-format
 msgid "**%{time}** %{vehicle} from **%{from_stop}**"
-msgstr ""
+msgstr "**%{time}** %{vehicle} de **%{from_stop}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:268
 #, elixir-autogen, elixir-format
 msgid "**%{trip_time}** %{route_type} from **%{stop_name}**"
-msgstr ""
+msgstr "**%{trip_time}** %{route_type} de **%{stop_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:275
 #, elixir-autogen, elixir-format
 msgid "**%{trip_time}** %{route_type} to **%{headsign}**"
-msgstr ""
+msgstr "**%{trip_time}** %{route_type} à **%{headsign}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:28
 #, elixir-autogen, elixir-format
 msgid "**All clear:** Regular service%{location}"
-msgstr ""
+msgstr "**Tout est clair :** Service normal %{location}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:39
 #, elixir-autogen, elixir-format
 msgid "**Update:** %{effect_sentence_case}%{summary_location}%{summary_timeframe}%{summary_recurrence}"
-msgstr ""
+msgstr "**Mise à jour :** %{effect_sentence_case}%{summary_location}%{summary_timeframe}%{summary_recurrence}"
 
 #: lib/presentation_strings.ex:71
 #, elixir-autogen, elixir-format
 msgid "Access Issue"
-msgstr ""
+msgstr "Problème d’accès"
 
 #: lib/presentation_strings.ex:31
 #, elixir-autogen, elixir-format
 msgid "Access issue"
-msgstr ""
+msgstr "Problème d’accès"
 
 #: lib/presentation_strings.ex:174
 #, elixir-autogen, elixir-format
 msgid "Accident"
-msgstr ""
+msgstr "Accident"
 
 #: lib/presentation_strings.ex:72
 #, elixir-autogen, elixir-format
 msgid "Additional Service"
-msgstr ""
+msgstr "Service supplémentaire"
 
 #: lib/presentation_strings.ex:32
 #, elixir-autogen, elixir-format
 msgid "Additional service"
-msgstr ""
+msgstr "Service supplémentaire"
 
 #: lib/presentation_strings.ex:63
 #: lib/presentation_strings.ex:64
@@ -178,1014 +178,1014 @@ msgstr ""
 #: lib/presentation_strings.ex:104
 #, elixir-autogen, elixir-format
 msgid "Alert"
-msgstr ""
+msgstr "Alerte"
 
 #: lib/presentation_strings.ex:73
 #, elixir-autogen, elixir-format
 msgid "Amber Alert"
-msgstr ""
+msgstr "Alerte Amber"
 
 #: lib/presentation_strings.ex:33
 #, elixir-autogen, elixir-format
 msgid "Amber alert"
-msgstr ""
+msgstr "Alerte Amber"
 
 #: lib/presentation_strings.ex:112
 #: lib/presentation_strings.ex:175
 #, elixir-autogen, elixir-format
 msgid "Amtrak"
-msgstr ""
+msgstr "Amtrak"
 
 #: lib/presentation_strings.ex:176
 #, elixir-autogen, elixir-format
 msgid "Amtrak Train Traffic"
-msgstr ""
+msgstr "Trafic ferroviaire d’Amtrak"
 
 #: lib/presentation_strings.ex:113
 #, elixir-autogen, elixir-format
 msgid "Amtrak train traffic"
-msgstr ""
+msgstr "trafic ferroviaire d’Amtrak"
 
 #: lib/presentation_strings.ex:177
 #, elixir-autogen, elixir-format
 msgid "An Earlier Mechanical Problem"
-msgstr ""
+msgstr "Un problème mécanique antérieur"
 
 #: lib/presentation_strings.ex:178
 #, elixir-autogen, elixir-format
 msgid "An Earlier Signal Problem"
-msgstr ""
+msgstr "Un problème signalétique antérieur"
 
 #: lib/presentation_strings.ex:179
 #, elixir-autogen, elixir-format
 msgid "Autos Impeding Service"
-msgstr ""
+msgstr "Véhicules obstruant le service"
 
 #: lib/presentation_strings.ex:74
 #, elixir-autogen, elixir-format
 msgid "Bike Issue"
-msgstr ""
+msgstr "Problème de vélo"
 
 #: lib/presentation_strings.ex:34
 #, elixir-autogen, elixir-format
 msgid "Bike issue"
-msgstr ""
+msgstr "Problème de vélo"
 
 #: lib/presentation_strings.ex:75
 #, elixir-autogen, elixir-format
 msgid "Cancellation"
-msgstr ""
+msgstr "Annulation"
 
 #: lib/presentation_strings.ex:180
 #, elixir-autogen, elixir-format
 msgid "Coast Guard Restriction"
-msgstr ""
+msgstr "Restriction des garde-côtes"
 
 #: lib/presentation_strings.ex:117
 #, elixir-autogen, elixir-format
 msgid "Coast Guard restriction"
-msgstr ""
+msgstr "Restriction des garde-côtes"
 
 #: lib/presentation_strings.ex:181
 #, elixir-autogen, elixir-format
 msgid "Congestion"
-msgstr ""
+msgstr "Encombrement"
 
 #: lib/presentation_strings.ex:182
 #, elixir-autogen, elixir-format
 msgid "Construction"
-msgstr ""
+msgstr "Chantier"
 
 #: lib/presentation_strings.ex:183
 #, elixir-autogen, elixir-format
 msgid "Crossing Issue"
-msgstr ""
+msgstr "Problème de passage à niveau"
 
 #: lib/presentation_strings.ex:184
 #, elixir-autogen, elixir-format
 msgid "Crossing Malfunction"
-msgstr ""
+msgstr "Dysfonctionnement du passage à niveau"
 
 #: lib/presentation_strings.ex:36
 #: lib/presentation_strings.ex:76
 #, elixir-autogen, elixir-format
 msgid "Delay"
-msgstr ""
+msgstr "Retard"
 
 #: lib/presentation_strings.ex:185
 #, elixir-autogen, elixir-format
 msgid "Demonstration"
-msgstr ""
+msgstr "Manifestation"
 
 #: lib/presentation_strings.ex:37
 #: lib/presentation_strings.ex:77
 #, elixir-autogen, elixir-format
 msgid "Detour"
-msgstr ""
+msgstr "Déviation"
 
 #: lib/presentation_strings.ex:186
 #, elixir-autogen, elixir-format
 msgid "Disabled Bus"
-msgstr ""
+msgstr "Bus hors service"
 
 #: lib/presentation_strings.ex:187
 #, elixir-autogen, elixir-format
 msgid "Disabled Train"
-msgstr ""
+msgstr "Train hors service"
 
 #: lib/presentation_strings.ex:78
 #, elixir-autogen, elixir-format
 msgid "Dock Closure"
-msgstr ""
+msgstr "Fermeture du quai"
 
 #: lib/presentation_strings.ex:79
 #, elixir-autogen, elixir-format
 msgid "Dock Issue"
-msgstr ""
+msgstr "Problème de quai"
 
 #: lib/presentation_strings.ex:38
 #, elixir-autogen, elixir-format
 msgid "Dock closed"
-msgstr ""
+msgstr "Quai fermé"
 
 #: lib/presentation_strings.ex:39
 #, elixir-autogen, elixir-format
 msgid "Dock issue"
-msgstr ""
+msgstr "Problème de quai"
 
 #: lib/presentation_strings.ex:188
 #, elixir-autogen, elixir-format
 msgid "Drawbridge Being Raised"
-msgstr ""
+msgstr "Élévation du pont"
 
 #: lib/presentation_strings.ex:189
 #, elixir-autogen, elixir-format
 msgid "Drawbridge Issue"
-msgstr ""
+msgstr "Problème du pont-levis"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:8
 #, elixir-autogen, elixir-format
 msgid "Eastbound"
-msgstr ""
+msgstr "En direction de l’est"
 
 #: lib/presentation_strings.ex:190
 #, elixir-autogen, elixir-format
 msgid "Electrical Work"
-msgstr ""
+msgstr "Travaux électriques"
 
 #: lib/presentation_strings.ex:80
 #, elixir-autogen, elixir-format
 msgid "Elevator Closure"
-msgstr ""
+msgstr "Fermeture de l’ascenseur"
 
 #: lib/presentation_strings.ex:40
 #, elixir-autogen, elixir-format
 msgid "Elevator closed"
-msgstr ""
+msgstr "Ascenseur fermé"
 
 #: lib/presentation_strings.ex:81
 #, elixir-autogen, elixir-format
 msgid "Escalator Closure"
-msgstr ""
+msgstr "Escalator hors service"
 
 #: lib/presentation_strings.ex:41
 #, elixir-autogen, elixir-format
 msgid "Escalator closed"
-msgstr ""
+msgstr "Escalator hors service"
 
 #: lib/presentation_strings.ex:82
 #, elixir-autogen, elixir-format
 msgid "Extra Service"
-msgstr ""
+msgstr "Service supplémentaire"
 
 #: lib/presentation_strings.ex:42
 #, elixir-autogen, elixir-format
 msgid "Extra service"
-msgstr ""
+msgstr "Service supplémentaire"
 
 #: lib/presentation_strings.ex:83
 #, elixir-autogen, elixir-format
 msgid "Facility Issue"
-msgstr ""
+msgstr "Problème d’infrastructure"
 
 #: lib/presentation_strings.ex:43
 #, elixir-autogen, elixir-format
 msgid "Facility issue"
-msgstr ""
+msgstr "Problème d’infrastructure"
 
 #: lib/presentation_strings.ex:191
 #, elixir-autogen, elixir-format
 msgid "Fire"
-msgstr ""
+msgstr "Incendie"
 
 #: lib/presentation_strings.ex:192
 #, elixir-autogen, elixir-format
 msgid "Fire Department Activity"
-msgstr ""
+msgstr "Intervention des pompiers"
 
 #: lib/presentation_strings.ex:193
 #, elixir-autogen, elixir-format
 msgid "Flooding"
-msgstr ""
+msgstr "Inondation"
 
 #: lib/presentation_strings.ex:194
 #, elixir-autogen, elixir-format
 msgid "Fog"
-msgstr ""
+msgstr "Brouillard"
 
 #: lib/presentation_strings.ex:195
 #, elixir-autogen, elixir-format
 msgid "Freight Train Interference"
-msgstr ""
+msgstr "Interférence avec un train de marchandises"
 
 #: lib/presentation_strings.ex:196
 #, elixir-autogen, elixir-format
 msgid "Hazmat Condition"
-msgstr ""
+msgstr "Présence de matières dangereuses"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:17
 #, elixir-autogen, elixir-format
 msgid "Heading"
-msgstr ""
+msgstr "En route"
 
 #: lib/presentation_strings.ex:197
 #, elixir-autogen, elixir-format
 msgid "Heavy Ridership"
-msgstr ""
+msgstr "Affluence importante"
 
 #: lib/presentation_strings.ex:198
 #, elixir-autogen, elixir-format
 msgid "High Winds"
-msgstr ""
+msgstr "Vents forts"
 
 #: lib/presentation_strings.ex:199
 #, elixir-autogen, elixir-format
 msgid "Holiday"
-msgstr ""
+msgstr "Fêtes"
 
 #: lib/presentation_strings.ex:200
 #, elixir-autogen, elixir-format
 msgid "Hurricane"
-msgstr ""
+msgstr "Ouragan"
 
 #: lib/presentation_strings.ex:201
 #, elixir-autogen, elixir-format
 msgid "Ice In Harbor"
-msgstr ""
+msgstr "Glace dans le port"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:10
 #, elixir-autogen, elixir-format
 msgid "Inbound"
-msgstr ""
+msgstr "En direction du centre"
 
 #: lib/presentation_strings.ex:202
 #, elixir-autogen, elixir-format
 msgid "Maintenance"
-msgstr ""
+msgstr "Maintenance"
 
 #: lib/presentation_strings.ex:203
 #, elixir-autogen, elixir-format
 msgid "Mechanical Issue"
-msgstr ""
+msgstr "Problème mécanique"
 
 #: lib/presentation_strings.ex:204
 #, elixir-autogen, elixir-format
 msgid "Mechanical Problem"
-msgstr ""
+msgstr "Problème mécanique"
 
 #: lib/presentation_strings.ex:205
 #, elixir-autogen, elixir-format
 msgid "Medical Emergency"
-msgstr ""
+msgstr "Urgence médicale"
 
 #: lib/presentation_strings.ex:84
 #, elixir-autogen, elixir-format
 msgid "Modified Service"
-msgstr ""
+msgstr "Service modifié"
 
 #: lib/presentation_strings.ex:44
 #, elixir-autogen, elixir-format
 msgid "Modified service"
-msgstr ""
+msgstr "Service modifié"
 
 #: lib/mobile_app_backend/notifications/notification_title.ex:69
 #, elixir-autogen, elixir-format
 msgid "Multiple routes"
-msgstr ""
+msgstr "Plusieurs itinéraires"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:282
 #, elixir-autogen, elixir-format
 msgid "Multiple trips"
-msgstr ""
+msgstr "Plusieurs voyages"
 
 #: lib/presentation_strings.ex:85
 #, elixir-autogen, elixir-format
 msgid "No Service"
-msgstr ""
+msgstr "Pas de service"
 
 #: lib/presentation_strings.ex:45
 #, elixir-autogen, elixir-format
 msgid "No service"
-msgstr ""
+msgstr "Aucun service"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:6
 #, elixir-autogen, elixir-format
 msgid "Northbound"
-msgstr ""
+msgstr "En direction du nord"
 
 #: lib/presentation_strings.ex:46
 #: lib/presentation_strings.ex:86
 #, elixir-autogen, elixir-format
 msgid "Notice"
-msgstr ""
+msgstr "Avis"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:11
 #, elixir-autogen, elixir-format
 msgid "Outbound"
-msgstr ""
+msgstr "Sortant du centre"
 
 #: lib/presentation_strings.ex:206
 #, elixir-autogen, elixir-format
 msgid "Parade"
-msgstr ""
+msgstr "Défilé"
 
 #: lib/presentation_strings.ex:87
 #, elixir-autogen, elixir-format
 msgid "Parking Closure"
-msgstr ""
+msgstr "Fermeture du parking"
 
 #: lib/presentation_strings.ex:88
 #, elixir-autogen, elixir-format
 msgid "Parking Issue"
-msgstr ""
+msgstr "Problème de parking"
 
 #: lib/presentation_strings.ex:47
 #, elixir-autogen, elixir-format
 msgid "Parking closed"
-msgstr ""
+msgstr "Parking fermé"
 
 #: lib/presentation_strings.ex:48
 #, elixir-autogen, elixir-format
 msgid "Parking issue"
-msgstr ""
+msgstr "Problème de parking"
 
 #: lib/presentation_strings.ex:207
 #, elixir-autogen, elixir-format
 msgid "Police Action"
-msgstr ""
+msgstr "Intervention policière"
 
 #: lib/presentation_strings.ex:208
 #, elixir-autogen, elixir-format
 msgid "Police Activity"
-msgstr ""
+msgstr "Intervention policière"
 
 #: lib/presentation_strings.ex:89
 #, elixir-autogen, elixir-format
 msgid "Policy Change"
-msgstr ""
+msgstr "Changement de politique"
 
 #: lib/presentation_strings.ex:49
 #, elixir-autogen, elixir-format
 msgid "Policy change"
-msgstr ""
+msgstr "Changement de politique"
 
 #: lib/presentation_strings.ex:209
 #, elixir-autogen, elixir-format
 msgid "Power Problem"
-msgstr ""
+msgstr "Problème électrique"
 
 #: lib/presentation_strings.ex:210
 #, elixir-autogen, elixir-format
 msgid "Rail Defect"
-msgstr ""
+msgstr "Défaut sur les rails"
 
 #: lib/presentation_strings.ex:90
 #, elixir-autogen, elixir-format
 msgid "Schedule Change"
-msgstr ""
+msgstr "Changement d’horaire"
 
 #: lib/presentation_strings.ex:50
 #, elixir-autogen, elixir-format
 msgid "Schedule change"
-msgstr ""
+msgstr "Changement d’horaire"
 
 #: lib/presentation_strings.ex:91
 #, elixir-autogen, elixir-format
 msgid "Service Change"
-msgstr ""
+msgstr "Changement de service"
 
 #: lib/presentation_strings.ex:51
 #, elixir-autogen, elixir-format
 msgid "Service change"
-msgstr ""
+msgstr "Changement de service"
 
 #: lib/presentation_strings.ex:61
 #, elixir-autogen, elixir-format
 msgid "Service suspended"
-msgstr ""
+msgstr "Service interrompu"
 
 #: lib/presentation_strings.ex:211
 #, elixir-autogen, elixir-format
 msgid "Severe Weather"
-msgstr ""
+msgstr "Temps violents"
 
 #: lib/presentation_strings.ex:92
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
-msgstr ""
+msgstr "Navette"
 
 #: lib/presentation_strings.ex:52
 #, elixir-autogen, elixir-format
 msgid "Shuttle buses"
-msgstr ""
+msgstr "Navettes"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:298
 #, elixir-autogen, elixir-format
 msgid "Shuttle buses replace %{trip_identity} from **%{start_stop}** to **%{end_stop}**%{recurrence}"
-msgstr ""
+msgstr "Des navettes remplacent %{trip_identity} de **%{start_stop}** à **%{end_stop}**%{recurrence}"
 
 #: lib/presentation_strings.ex:212
 #, elixir-autogen, elixir-format
 msgid "Signal Issue"
-msgstr ""
+msgstr "Problème de signal"
 
 #: lib/presentation_strings.ex:213
 #, elixir-autogen, elixir-format
 msgid "Signal Problem"
-msgstr ""
+msgstr "Problème signalétique"
 
 #: lib/presentation_strings.ex:214
 #, elixir-autogen, elixir-format
 msgid "Single Tracking"
-msgstr ""
+msgstr "Suivi unique"
 
 #: lib/presentation_strings.ex:215
 #, elixir-autogen, elixir-format
 msgid "Slippery Rail"
-msgstr ""
+msgstr "Chaussée glissante"
 
 #: lib/presentation_strings.ex:216
 #, elixir-autogen, elixir-format
 msgid "Snow"
-msgstr ""
+msgstr "Neige"
 
 #: lib/presentation_strings.ex:93
 #, elixir-autogen, elixir-format
 msgid "Snow Route"
-msgstr ""
+msgstr "Route enneigée"
 
 #: lib/presentation_strings.ex:53
 #, elixir-autogen, elixir-format
 msgid "Snow route"
-msgstr ""
+msgstr "Route enneigée"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:7
 #, elixir-autogen, elixir-format
 msgid "Southbound"
-msgstr ""
+msgstr "En direction du sud"
 
 #: lib/presentation_strings.ex:217
 #, elixir-autogen, elixir-format
 msgid "Special Event"
-msgstr ""
+msgstr "Événement spécial"
 
 #: lib/presentation_strings.ex:218
 #, elixir-autogen, elixir-format
 msgid "Speed Restriction"
-msgstr ""
+msgstr "Restriction de vitesse"
 
 #: lib/presentation_strings.ex:94
 #, elixir-autogen, elixir-format
 msgid "Station Closure"
-msgstr ""
+msgstr "Fermeture de la station"
 
 #: lib/presentation_strings.ex:95
 #, elixir-autogen, elixir-format
 msgid "Station Issue"
-msgstr ""
+msgstr "Problème de station"
 
 #: lib/presentation_strings.ex:54
 #, elixir-autogen, elixir-format
 msgid "Station closed"
-msgstr ""
+msgstr "Station fermée"
 
 #: lib/presentation_strings.ex:55
 #, elixir-autogen, elixir-format
 msgid "Station issue"
-msgstr ""
+msgstr "Problème de station"
 
 #: lib/presentation_strings.ex:96
 #, elixir-autogen, elixir-format
 msgid "Stop Closure"
-msgstr ""
+msgstr "Fermeture de l’arrêt"
 
 #: lib/presentation_strings.ex:97
 #: lib/presentation_strings.ex:98
 #, elixir-autogen, elixir-format
 msgid "Stop Moved"
-msgstr ""
+msgstr "Arrêt reporté"
 
 #: lib/presentation_strings.ex:99
 #, elixir-autogen, elixir-format
 msgid "Stop Shoveling"
-msgstr ""
+msgstr "Déneigement de l’arrêt"
 
 #: lib/presentation_strings.ex:56
 #, elixir-autogen, elixir-format
 msgid "Stop closed"
-msgstr ""
+msgstr "Arrêt fermé"
 
 #: lib/presentation_strings.ex:57
 #: lib/presentation_strings.ex:58
 #, elixir-autogen, elixir-format
 msgid "Stop moved"
-msgstr ""
+msgstr "Arrêt reporté"
 
 #: lib/presentation_strings.ex:59
 #, elixir-autogen, elixir-format
 msgid "Stop shoveling"
-msgstr ""
+msgstr "Déneigement de l’arrêt"
 
 #: lib/presentation_strings.ex:219
 #, elixir-autogen, elixir-format
 msgid "Strike"
-msgstr ""
+msgstr "Grève"
 
 #: lib/presentation_strings.ex:60
 #: lib/presentation_strings.ex:100
 #, elixir-autogen, elixir-format
 msgid "Summary"
-msgstr ""
+msgstr "Résumé"
 
 #: lib/presentation_strings.ex:101
 #, elixir-autogen, elixir-format
 msgid "Suspension"
-msgstr ""
+msgstr "Interruption"
 
 #: lib/presentation_strings.ex:220
 #, elixir-autogen, elixir-format
 msgid "Switch Issue"
-msgstr ""
+msgstr "Problème de commutation"
 
 #: lib/presentation_strings.ex:221
 #, elixir-autogen, elixir-format
 msgid "Switch Problem"
-msgstr ""
+msgstr "Problème d’aiguillage"
 
 #: lib/presentation_strings.ex:222
 #, elixir-autogen, elixir-format
 msgid "Technical Problem"
-msgstr ""
+msgstr "Problème technique"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:263
 #, elixir-autogen, elixir-format
 msgid "This %{route_type}"
-msgstr ""
+msgstr "Ce %{route_type}"
 
 #: lib/presentation_strings.ex:223
 #, elixir-autogen, elixir-format
 msgid "Tie Replacement"
-msgstr ""
+msgstr "Remplacement de traverses"
 
 #: lib/presentation_strings.ex:102
 #, elixir-autogen, elixir-format
 msgid "Track Change"
-msgstr ""
+msgstr "Changement de voie"
 
 #: lib/presentation_strings.ex:224
 #, elixir-autogen, elixir-format
 msgid "Track Problem"
-msgstr ""
+msgstr "Problème sur la voie"
 
 #: lib/presentation_strings.ex:225
 #, elixir-autogen, elixir-format
 msgid "Track Work"
-msgstr ""
+msgstr "Travaux sur la voie"
 
 #: lib/presentation_strings.ex:62
 #, elixir-autogen, elixir-format
 msgid "Track change"
-msgstr ""
+msgstr "Changement de voie"
 
 #: lib/presentation_strings.ex:226
 #, elixir-autogen, elixir-format
 msgid "Traffic"
-msgstr ""
+msgstr "Trafic"
 
 #: lib/presentation_strings.ex:227
 #, elixir-autogen, elixir-format
 msgid "Train Traffic"
-msgstr ""
+msgstr "Trafic ferroviaire"
 
 #: lib/presentation_strings.ex:35
 #, elixir-autogen, elixir-format
 msgid "Trip cancelled"
-msgstr ""
+msgstr "Trajet annulé"
 
 #: lib/presentation_strings.ex:228
 #, elixir-autogen, elixir-format
 msgid "Unruly Passenger"
-msgstr ""
+msgstr "Passager indiscipliné"
 
 #: lib/presentation_strings.ex:229
 #, elixir-autogen, elixir-format
 msgid "Weather"
-msgstr ""
+msgstr "Météo"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:9
 #, elixir-autogen, elixir-format
 msgid "Westbound"
-msgstr ""
+msgstr "En direction de l’ouest"
 
 #: lib/presentation_strings.ex:111
 #, elixir-autogen, elixir-format
 msgid "accident"
-msgstr ""
+msgstr "accident"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:424
 #, elixir-autogen, elixir-format
 msgid "affected by %{effect} %{day}"
-msgstr ""
+msgstr "affecté par %{effect} %{day}"
 
 #: lib/presentation_strings.ex:114
 #, elixir-autogen, elixir-format
 msgid "an earlier mechanical problem"
-msgstr ""
+msgstr "un problème mécanique antérieur"
 
 #: lib/presentation_strings.ex:115
 #, elixir-autogen, elixir-format
 msgid "an earlier signal problem"
-msgstr ""
+msgstr "un problème de signal antérieur"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:382
 #, elixir-autogen, elixir-format
 msgid "are cancelled %{day}"
-msgstr ""
+msgstr "sont annulés %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:417
 #, elixir-autogen, elixir-format
 msgid "are suspended %{day}"
-msgstr ""
+msgstr "sont suspendus %{day}"
 
 #: lib/presentation_strings.ex:116
 #, elixir-autogen, elixir-format
 msgid "autos impeding service"
-msgstr ""
+msgstr "des automobiles gênent le service"
 
 #: lib/presentation_strings.ex:12
 #, elixir-autogen, elixir-format
 msgid "bus"
-msgstr ""
+msgstr "bus"
 
 #: lib/presentation_strings.ex:13
 #, elixir-autogen, elixir-format
 msgid "buses"
-msgstr ""
+msgstr "bus"
 
 #: lib/presentation_strings.ex:118
 #, elixir-autogen, elixir-format
 msgid "congestion"
-msgstr ""
+msgstr "encombrement"
 
 #: lib/presentation_strings.ex:119
 #, elixir-autogen, elixir-format
 msgid "construction"
-msgstr ""
+msgstr "construction"
 
 #: lib/presentation_strings.ex:120
 #, elixir-autogen, elixir-format
 msgid "crossing issue"
-msgstr ""
+msgstr "problème de passage à niveau"
 
 #: lib/presentation_strings.ex:121
 #, elixir-autogen, elixir-format
 msgid "crossing malfunction"
-msgstr ""
+msgstr "dysfonctionnement du passage à niveau"
 
 #: lib/presentation_strings.ex:122
 #, elixir-autogen, elixir-format
 msgid "demonstration"
-msgstr ""
+msgstr "manifestation"
 
 #: lib/presentation_strings.ex:123
 #, elixir-autogen, elixir-format
 msgid "disabled bus"
-msgstr ""
+msgstr "autobus en panne"
 
 #: lib/presentation_strings.ex:124
 #, elixir-autogen, elixir-format
 msgid "disabled train"
-msgstr ""
+msgstr "train en panne"
 
 #: lib/presentation_strings.ex:125
 #, elixir-autogen, elixir-format
 msgid "drawbridge being raised"
-msgstr ""
+msgstr "le pont est relevé"
 
 #: lib/presentation_strings.ex:126
 #, elixir-autogen, elixir-format
 msgid "drawbridge issue"
-msgstr ""
+msgstr "problème du pont-levis"
 
 #: lib/presentation_strings.ex:127
 #, elixir-autogen, elixir-format
 msgid "electrical work"
-msgstr ""
+msgstr "travaux électriques"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:193
 #, elixir-autogen, elixir-format
 msgid "end of service"
-msgstr ""
+msgstr "fin de service"
 
 #: lib/presentation_strings.ex:15
 #, elixir-autogen, elixir-format
 msgid "ferries"
-msgstr ""
+msgstr "ferrys"
 
 #: lib/presentation_strings.ex:14
 #, elixir-autogen, elixir-format
 msgid "ferry"
-msgstr ""
+msgstr "ferry"
 
 #: lib/presentation_strings.ex:128
 #, elixir-autogen, elixir-format
 msgid "fire"
-msgstr ""
+msgstr "incendie"
 
 #: lib/presentation_strings.ex:129
 #, elixir-autogen, elixir-format
 msgid "fire department activity"
-msgstr ""
+msgstr "intervention des pompiers"
 
 #: lib/presentation_strings.ex:130
 #, elixir-autogen, elixir-format
 msgid "flooding"
-msgstr ""
+msgstr "inondation"
 
 #: lib/presentation_strings.ex:131
 #, elixir-autogen, elixir-format
 msgid "fog"
-msgstr ""
+msgstr "brouillard"
 
 #: lib/presentation_strings.ex:132
 #, elixir-autogen, elixir-format
 msgid "freight train interference"
-msgstr ""
+msgstr "interférence des trains de marchandises"
 
 #: lib/presentation_strings.ex:133
 #, elixir-autogen, elixir-format
 msgid "hazmat condition"
-msgstr ""
+msgstr "incident impliquant des matières dangereuses"
 
 #: lib/presentation_strings.ex:134
 #, elixir-autogen, elixir-format
 msgid "heavy ridership"
-msgstr ""
+msgstr "affluence importante"
 
 #: lib/presentation_strings.ex:135
 #, elixir-autogen, elixir-format
 msgid "high winds"
-msgstr ""
+msgstr "vents violents"
 
 #: lib/presentation_strings.ex:136
 #, elixir-autogen, elixir-format
 msgid "holiday"
-msgstr ""
+msgstr "vacances"
 
 #: lib/presentation_strings.ex:137
 #, elixir-autogen, elixir-format
 msgid "hurricane"
-msgstr ""
+msgstr "ouragan"
 
 #: lib/presentation_strings.ex:138
 #, elixir-autogen, elixir-format
 msgid "ice in harbor"
-msgstr ""
+msgstr "glace dans le port"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:385
 #, elixir-autogen, elixir-format
 msgid "is cancelled %{day}"
-msgstr ""
+msgstr "est annulé %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:420
 #, elixir-autogen, elixir-format
 msgid "is suspended %{day}"
-msgstr ""
+msgstr "est suspendu %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:239
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_recurrence_end_day_later_date"
-msgstr ""
+msgstr " jusqu’à %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:247
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_recurrence_end_day_this_week"
-msgstr ""
+msgstr " jusqu’à %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:144
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_timeframe_later_date"
-msgstr ""
+msgstr " jusqu’au %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:152
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_timeframe_this_week"
-msgstr ""
+msgstr " jusqu’à %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:160
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_timeframe_time"
-msgstr ""
+msgstr " jusqu’à %{1}"
 
 #: lib/presentation_strings.ex:139
 #, elixir-autogen, elixir-format
 msgid "maintenance"
-msgstr ""
+msgstr "entretien"
 
 #: lib/presentation_strings.ex:140
 #, elixir-autogen, elixir-format
 msgid "mechanical issue"
-msgstr ""
+msgstr "problème mécanique"
 
 #: lib/presentation_strings.ex:141
 #, elixir-autogen, elixir-format
 msgid "mechanical problem"
-msgstr ""
+msgstr "problème mécanique"
 
 #: lib/presentation_strings.ex:142
 #, elixir-autogen, elixir-format
 msgid "medical emergency"
-msgstr ""
+msgstr "urgence médicale"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:333
 #, elixir-autogen, elixir-format
 msgid "multiple trips"
-msgstr ""
+msgstr "plusieurs voyages"
 
 #: lib/presentation_strings.ex:143
 #, elixir-autogen, elixir-format
 msgid "parade"
-msgstr ""
+msgstr "défilé"
 
 #: lib/presentation_strings.ex:144
 #, elixir-autogen, elixir-format
 msgid "police action"
-msgstr ""
+msgstr "action policière"
 
 #: lib/presentation_strings.ex:145
 #, elixir-autogen, elixir-format
 msgid "police activity"
-msgstr ""
+msgstr "intervention policière"
 
 #: lib/presentation_strings.ex:146
 #, elixir-autogen, elixir-format
 msgid "power problem"
-msgstr ""
+msgstr "problème d’alimentation"
 
 #: lib/presentation_strings.ex:147
 #, elixir-autogen, elixir-format
 msgid "rail defect"
-msgstr ""
+msgstr "défaut sur les rails"
 
 #: lib/presentation_strings.ex:148
 #, elixir-autogen, elixir-format
 msgid "severe weather"
-msgstr ""
+msgstr "temps violent"
 
 #: lib/presentation_strings.ex:149
 #, elixir-autogen, elixir-format
 msgid "signal issue"
-msgstr ""
+msgstr "problème de signal"
 
 #: lib/presentation_strings.ex:150
 #, elixir-autogen, elixir-format
 msgid "signal problem"
-msgstr ""
+msgstr "problème de signal"
 
 #: lib/presentation_strings.ex:151
 #, elixir-autogen, elixir-format
 msgid "single tracking"
-msgstr ""
+msgstr "suivi unique"
 
 #: lib/presentation_strings.ex:152
 #, elixir-autogen, elixir-format
 msgid "slippery rail"
-msgstr ""
+msgstr "rail glissant"
 
 #: lib/presentation_strings.ex:153
 #, elixir-autogen, elixir-format
 msgid "snow"
-msgstr ""
+msgstr "neige"
 
 #: lib/presentation_strings.ex:154
 #, elixir-autogen, elixir-format
 msgid "special event"
-msgstr ""
+msgstr "événement spécial"
 
 #: lib/presentation_strings.ex:155
 #, elixir-autogen, elixir-format
 msgid "speed restriction"
-msgstr ""
+msgstr "réduction de la vitesse"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:190
 #, elixir-autogen, elixir-format
 msgid "start of service"
-msgstr ""
+msgstr "début du service"
 
 #: lib/presentation_strings.ex:156
 #, elixir-autogen, elixir-format
 msgid "strike"
-msgstr ""
+msgstr "grève"
 
 #: lib/presentation_strings.ex:157
 #, elixir-autogen, elixir-format
 msgid "switch issue"
-msgstr ""
+msgstr "problème de commutation"
 
 #: lib/presentation_strings.ex:158
 #, elixir-autogen, elixir-format
 msgid "switch problem"
-msgstr ""
+msgstr "problème de commutation"
 
 #: lib/presentation_strings.ex:159
 #, elixir-autogen, elixir-format
 msgid "technical problem"
-msgstr ""
+msgstr "problème technique"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:320
 #, elixir-autogen, elixir-format
 msgid "the **%{time}** %{vehicle}"
-msgstr ""
+msgstr "le **%{time}** %{vehicle}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:328
 #, elixir-autogen, elixir-format
 msgid "this %{vehicle}"
-msgstr ""
+msgstr "ce %{vehicle}"
 
 #: lib/presentation_strings.ex:160
 #, elixir-autogen, elixir-format
 msgid "tie replacement"
-msgstr ""
+msgstr "remplacement de traverses"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:377
 #, elixir-autogen, elixir-format
 msgid "today"
-msgstr ""
+msgstr "aujourd’hui"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:377
 #, elixir-autogen, elixir-format
 msgid "tomorrow"
-msgstr ""
+msgstr "demain"
 
 #: lib/presentation_strings.ex:161
 #, elixir-autogen, elixir-format
 msgid "track problem"
-msgstr ""
+msgstr "problème de voie"
 
 #: lib/presentation_strings.ex:162
 #, elixir-autogen, elixir-format
 msgid "track work"
-msgstr ""
+msgstr "travaux sur la voie"
 
 #: lib/presentation_strings.ex:163
 #, elixir-autogen, elixir-format
 msgid "traffic"
-msgstr ""
+msgstr "trafic"
 
 #: lib/presentation_strings.ex:16
 #, elixir-autogen, elixir-format
 msgid "train"
-msgstr ""
+msgstr "train"
 
 #: lib/presentation_strings.ex:164
 #, elixir-autogen, elixir-format
 msgid "train traffic"
-msgstr ""
+msgstr "trafic ferroviaire"
 
 #: lib/presentation_strings.ex:17
 #, elixir-autogen, elixir-format
 msgid "trains"
-msgstr ""
+msgstr "trains"
 
 #: lib/presentation_strings.ex:165
 #, elixir-autogen, elixir-format
 msgid "unruly passenger"
-msgstr ""
+msgstr "passager indiscipliné"
 
 #: lib/presentation_strings.ex:166
 #, elixir-autogen, elixir-format
 msgid "weather"
-msgstr ""
+msgstr "météo"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:388
 #, elixir-autogen, elixir-format
 msgid "will not stop at %{stop_list} %{day}"
-msgstr ""
+msgstr "ne s’arrêtera pas à %{stop_list} %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:411
 #, elixir-autogen, elixir-format
 msgid "will terminate at %{terminating_stop} %{day}"
-msgstr ""
+msgstr "se terminera à %{terminating_stop} %{day}"
 
 #: lib/mobile_app_backend_web/components/core_components.ex:484
 #, elixir-autogen, elixir-format, import-optional

--- a/priv/gettext/fr/LC_MESSAGES/errors.po
+++ b/priv/gettext/fr/LC_MESSAGES/errors.po
@@ -1,0 +1,12 @@
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: fr\n"
+"Plural-Forms: nplurals=3\n"

--- a/priv/gettext/ht/LC_MESSAGES/default.po
+++ b/priv/gettext/ht/LC_MESSAGES/default.po
@@ -1,176 +1,176 @@
-## This file is a PO Template file.
-##
-## "msgid"s here are often extracted from source code.
-## Add new messages manually only if they're dynamic
-## messages that can't be statically extracted.
-##
-## Run "mix gettext.extract" to bring this file up to
-## date. Leave "msgstr"s empty as changing them here has no
-## effect: edit them in PO (.po) files instead.
-#
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
 msgid ""
 msgstr ""
+"Language: ht\n"
+"Plural-Forms: nplurals=3\n"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:101
 #, elixir-autogen, elixir-format
 msgid " at **%{stop_name}**"
-msgstr ""
+msgstr " nan **%{stop_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:210
 #, elixir-autogen, elixir-format
 msgid " daily%{recurrence_text}"
-msgstr ""
+msgstr " chak jou%{recurrence_text}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:434
 #, elixir-autogen, elixir-format
 msgid " due to %{cause}"
-msgstr ""
+msgstr " akòz %{cause}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:173
 #, elixir-autogen, elixir-format
 msgid " from %{start_time} to %{end_time}"
-msgstr ""
+msgstr " soti nan %{start_time} rive nan %{end_time}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:95
 #, elixir-autogen, elixir-format
 msgid " from **%{direction_name}** stops to **%{end_stop_name}**"
-msgstr ""
+msgstr " soti nan **%{direction_name}** sispann rive nan **%{end_stop_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:110
 #, elixir-autogen, elixir-format
 msgid " from **%{start_stop}** to **%{end_stop}**"
-msgstr ""
+msgstr " soti nan **%{start_stop}** a **%{end_stop}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:104
 #, elixir-autogen, elixir-format
 msgid " from **%{stop_name}** to **%{direction_name}** stops"
-msgstr ""
+msgstr " soti nan **%{stop_name}** rive nan **%{direction_name}** sispann"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:121
 #, elixir-autogen, elixir-format
 msgid " on **%{mode_label}**"
-msgstr ""
+msgstr " sou **%{mode_label}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:117
 #, elixir-autogen, elixir-format
 msgid " replacing **%{mode_label}**"
-msgstr ""
+msgstr " ranplase **%{mode_label}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:219
 #, elixir-autogen, elixir-format
 msgid " some days%{recurrence_text}"
-msgstr ""
+msgstr " kèk jou%{recurrence_text}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:168
 #, elixir-autogen, elixir-format
 msgid " starting **%{formatted_time}** today"
-msgstr ""
+msgstr " kòmanse **%{formatted_time}** jodi a"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:165
 #, elixir-autogen, elixir-format
 msgid " starting tomorrow"
-msgstr ""
+msgstr " kòmanse demen"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:138
 #, elixir-autogen, elixir-format
 msgid " through end of service"
-msgstr ""
+msgstr " jiska fen sèvis la"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:141
 #, elixir-autogen, elixir-format
 msgid " through tomorrow"
-msgstr ""
+msgstr " jiska demen"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:135
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:233
 #, elixir-autogen, elixir-format
 msgid " until further notice"
-msgstr ""
+msgstr " jiskaske yo bay lòt avi"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:236
 #, elixir-autogen, elixir-format
 msgid " until tomorrow"
-msgstr ""
+msgstr " jiska demen"
 
 #: lib/mobile_app_backend/notifications/notification_title.ex:63
 #, elixir-autogen, elixir-format
 msgid "%{label} %{mode_label}"
-msgstr ""
+msgstr "%{label} %{mode_label}"
 
 #: lib/presentation_strings.ex:22
 #, elixir-autogen, elixir-format
 msgid "%{name} bus"
-msgstr ""
+msgstr "%{name} bis"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:398
 #, elixir-autogen, elixir-format
 msgid "%{stop} and %{other_stops}"
-msgstr ""
+msgstr "%{stop} ak %{other_stops}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:57
 #, elixir-autogen, elixir-format
 msgid "%{trip_identity} %{trip_effect}%{cause}%{recurrence}"
-msgstr ""
+msgstr "%{trip_identity} %{trip_effect}%{cause}%{recurrence}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:290
 #, elixir-autogen, elixir-format
 msgid "%{trip_identity} is replaced by shuttle buses from **%{start_stop}** to **%{end_stop}**%{recurrence}"
-msgstr ""
+msgstr "Yo ranplase %{trip_identity} ak bis navèt soti **%{start_stop}** pou rive **%{end_stop}**%{recurrence}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:47
 #, elixir-autogen, elixir-format
 msgid "**%{effect_sentence_case}**%{summary_location}%{summary_timeframe}%{summary_recurrence}"
-msgstr ""
+msgstr "**%{effect_sentence_case}**%{summary_location}%{summary_timeframe}%{summary_recurrence}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:313
 #, elixir-autogen, elixir-format
 msgid "**%{time}** %{vehicle} from **%{from_stop}**"
-msgstr ""
+msgstr "**%{time}** %{vehicle} soti nan **%{from_stop}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:268
 #, elixir-autogen, elixir-format
 msgid "**%{trip_time}** %{route_type} from **%{stop_name}**"
-msgstr ""
+msgstr "**%{trip_time}** %{route_type} soti nan **%{stop_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:275
 #, elixir-autogen, elixir-format
 msgid "**%{trip_time}** %{route_type} to **%{headsign}**"
-msgstr ""
+msgstr "**%{trip_time}** %{route_type} pou rive nan **%{headsign}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:28
 #, elixir-autogen, elixir-format
 msgid "**All clear:** Regular service%{location}"
-msgstr ""
+msgstr "**Tout bagay klè:** Sèvis regilye %{location}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:39
 #, elixir-autogen, elixir-format
 msgid "**Update:** %{effect_sentence_case}%{summary_location}%{summary_timeframe}%{summary_recurrence}"
-msgstr ""
+msgstr "**Mizajou:** %{effect_sentence_case}%{summary_location}%{summary_timeframe}%{summary_recurrence}"
 
 #: lib/presentation_strings.ex:71
 #, elixir-autogen, elixir-format
 msgid "Access Issue"
-msgstr ""
+msgstr "Pwoblèm Aksè"
 
 #: lib/presentation_strings.ex:31
 #, elixir-autogen, elixir-format
 msgid "Access issue"
-msgstr ""
+msgstr "Pwoblèm aksè"
 
 #: lib/presentation_strings.ex:174
 #, elixir-autogen, elixir-format
 msgid "Accident"
-msgstr ""
+msgstr "Aksidan"
 
 #: lib/presentation_strings.ex:72
 #, elixir-autogen, elixir-format
 msgid "Additional Service"
-msgstr ""
+msgstr "Plis Sèvis"
 
 #: lib/presentation_strings.ex:32
 #, elixir-autogen, elixir-format
 msgid "Additional service"
-msgstr ""
+msgstr "Plis sèvis"
 
 #: lib/presentation_strings.ex:63
 #: lib/presentation_strings.ex:64
@@ -178,1014 +178,1014 @@ msgstr ""
 #: lib/presentation_strings.ex:104
 #, elixir-autogen, elixir-format
 msgid "Alert"
-msgstr ""
+msgstr "Avètisman"
 
 #: lib/presentation_strings.ex:73
 #, elixir-autogen, elixir-format
 msgid "Amber Alert"
-msgstr ""
+msgstr "Avètisman Amber"
 
 #: lib/presentation_strings.ex:33
 #, elixir-autogen, elixir-format
 msgid "Amber alert"
-msgstr ""
+msgstr "Avètisman amber"
 
 #: lib/presentation_strings.ex:112
 #: lib/presentation_strings.ex:175
 #, elixir-autogen, elixir-format
 msgid "Amtrak"
-msgstr ""
+msgstr "Amtrak"
 
 #: lib/presentation_strings.ex:176
 #, elixir-autogen, elixir-format
 msgid "Amtrak Train Traffic"
-msgstr ""
+msgstr "Trafik tren Amtrak"
 
 #: lib/presentation_strings.ex:113
 #, elixir-autogen, elixir-format
 msgid "Amtrak train traffic"
-msgstr ""
+msgstr "Trafik tren Amtrak"
 
 #: lib/presentation_strings.ex:177
 #, elixir-autogen, elixir-format
 msgid "An Earlier Mechanical Problem"
-msgstr ""
+msgstr "Yon Pwoblèm Mekanik Ki Rive Pi Bonè"
 
 #: lib/presentation_strings.ex:178
 #, elixir-autogen, elixir-format
 msgid "An Earlier Signal Problem"
-msgstr ""
+msgstr "Yon Siyal Ki Rive Pi Bonè"
 
 #: lib/presentation_strings.ex:179
 #, elixir-autogen, elixir-format
 msgid "Autos Impeding Service"
-msgstr ""
+msgstr "Machin Ki Bloke Sèvis la"
 
 #: lib/presentation_strings.ex:74
 #, elixir-autogen, elixir-format
 msgid "Bike Issue"
-msgstr ""
+msgstr "Pwoblèm Bisiklèt"
 
 #: lib/presentation_strings.ex:34
 #, elixir-autogen, elixir-format
 msgid "Bike issue"
-msgstr ""
+msgstr "Pwoblèm bisiklèt"
 
 #: lib/presentation_strings.ex:75
 #, elixir-autogen, elixir-format
 msgid "Cancellation"
-msgstr ""
+msgstr "Anilasyon"
 
 #: lib/presentation_strings.ex:180
 #, elixir-autogen, elixir-format
 msgid "Coast Guard Restriction"
-msgstr ""
+msgstr "Gad Kot Mete Restriksyon"
 
 #: lib/presentation_strings.ex:117
 #, elixir-autogen, elixir-format
 msgid "Coast Guard restriction"
-msgstr ""
+msgstr "Restriksyon Gad Kòt"
 
 #: lib/presentation_strings.ex:181
 #, elixir-autogen, elixir-format
 msgid "Congestion"
-msgstr ""
+msgstr "Blokis"
 
 #: lib/presentation_strings.ex:182
 #, elixir-autogen, elixir-format
 msgid "Construction"
-msgstr ""
+msgstr "Konstriksyon"
 
 #: lib/presentation_strings.ex:183
 #, elixir-autogen, elixir-format
 msgid "Crossing Issue"
-msgstr ""
+msgstr "Pwoblèm nan Pasaj a Nivo yo"
 
 #: lib/presentation_strings.ex:184
 #, elixir-autogen, elixir-format
 msgid "Crossing Malfunction"
-msgstr ""
+msgstr "Pasaj a Nivo ki p ap Fonksyone"
 
 #: lib/presentation_strings.ex:36
 #: lib/presentation_strings.ex:76
 #, elixir-autogen, elixir-format
 msgid "Delay"
-msgstr ""
+msgstr "Reta"
 
 #: lib/presentation_strings.ex:185
 #, elixir-autogen, elixir-format
 msgid "Demonstration"
-msgstr ""
+msgstr "Demonstrasyon"
 
 #: lib/presentation_strings.ex:37
 #: lib/presentation_strings.ex:77
 #, elixir-autogen, elixir-format
 msgid "Detour"
-msgstr ""
+msgstr "Detou"
 
 #: lib/presentation_strings.ex:186
 #, elixir-autogen, elixir-format
 msgid "Disabled Bus"
-msgstr ""
+msgstr "Bis Ki Pa Aktif"
 
 #: lib/presentation_strings.ex:187
 #, elixir-autogen, elixir-format
 msgid "Disabled Train"
-msgstr ""
+msgstr "Tren Ki Pa Aktif"
 
 #: lib/presentation_strings.ex:78
 #, elixir-autogen, elixir-format
 msgid "Dock Closure"
-msgstr ""
+msgstr "Waf la Fèmen"
 
 #: lib/presentation_strings.ex:79
 #, elixir-autogen, elixir-format
 msgid "Dock Issue"
-msgstr ""
+msgstr "Pwoblèm Waf"
 
 #: lib/presentation_strings.ex:38
 #, elixir-autogen, elixir-format
 msgid "Dock closed"
-msgstr ""
+msgstr "Waf fèmen"
 
 #: lib/presentation_strings.ex:39
 #, elixir-autogen, elixir-format
 msgid "Dock issue"
-msgstr ""
+msgstr "Pwoblèm waf"
 
 #: lib/presentation_strings.ex:188
 #, elixir-autogen, elixir-format
 msgid "Drawbridge Being Raised"
-msgstr ""
+msgstr "Y ap Leve Pon ki ka Bouje a"
 
 #: lib/presentation_strings.ex:189
 #, elixir-autogen, elixir-format
 msgid "Drawbridge Issue"
-msgstr ""
+msgstr "Pwoblèm Pon Levab"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:8
 #, elixir-autogen, elixir-format
 msgid "Eastbound"
-msgstr ""
+msgstr "Pran direksyon lès"
 
 #: lib/presentation_strings.ex:190
 #, elixir-autogen, elixir-format
 msgid "Electrical Work"
-msgstr ""
+msgstr "Travay Elektrik"
 
 #: lib/presentation_strings.ex:80
 #, elixir-autogen, elixir-format
 msgid "Elevator Closure"
-msgstr ""
+msgstr "Fèmti Asansè"
 
 #: lib/presentation_strings.ex:40
 #, elixir-autogen, elixir-format
 msgid "Elevator closed"
-msgstr ""
+msgstr "Asansè a fèmen"
 
 #: lib/presentation_strings.ex:81
 #, elixir-autogen, elixir-format
 msgid "Escalator Closure"
-msgstr ""
+msgstr "Fèmti Eskalye"
 
 #: lib/presentation_strings.ex:41
 #, elixir-autogen, elixir-format
 msgid "Escalator closed"
-msgstr ""
+msgstr "Fèmti eskalye"
 
 #: lib/presentation_strings.ex:82
 #, elixir-autogen, elixir-format
 msgid "Extra Service"
-msgstr ""
+msgstr "Sèvis Anplis"
 
 #: lib/presentation_strings.ex:42
 #, elixir-autogen, elixir-format
 msgid "Extra service"
-msgstr ""
+msgstr "Sèvis anplis"
 
 #: lib/presentation_strings.ex:83
 #, elixir-autogen, elixir-format
 msgid "Facility Issue"
-msgstr ""
+msgstr "Pwoblèm Lokal"
 
 #: lib/presentation_strings.ex:43
 #, elixir-autogen, elixir-format
 msgid "Facility issue"
-msgstr ""
+msgstr "Pwoblèm lokal"
 
 #: lib/presentation_strings.ex:191
 #, elixir-autogen, elixir-format
 msgid "Fire"
-msgstr ""
+msgstr "Dife"
 
 #: lib/presentation_strings.ex:192
 #, elixir-autogen, elixir-format
 msgid "Fire Department Activity"
-msgstr ""
+msgstr "Aktivite Ponpye"
 
 #: lib/presentation_strings.ex:193
 #, elixir-autogen, elixir-format
 msgid "Flooding"
-msgstr ""
+msgstr "Inondasyon"
 
 #: lib/presentation_strings.ex:194
 #, elixir-autogen, elixir-format
 msgid "Fog"
-msgstr ""
+msgstr "Bwouya"
 
 #: lib/presentation_strings.ex:195
 #, elixir-autogen, elixir-format
 msgid "Freight Train Interference"
-msgstr ""
+msgstr "Blokaj Nan Tren Machandiz"
 
 #: lib/presentation_strings.ex:196
 #, elixir-autogen, elixir-format
 msgid "Hazmat Condition"
-msgstr ""
+msgstr "Eta Matyè Danjere"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:17
 #, elixir-autogen, elixir-format
 msgid "Heading"
-msgstr ""
+msgstr "Prale nan direksyon"
 
 #: lib/presentation_strings.ex:197
 #, elixir-autogen, elixir-format
 msgid "Heavy Ridership"
-msgstr ""
+msgstr "Anpil Moun Ap Pase la"
 
 #: lib/presentation_strings.ex:198
 #, elixir-autogen, elixir-format
 msgid "High Winds"
-msgstr ""
+msgstr "Gwo Van"
 
 #: lib/presentation_strings.ex:199
 #, elixir-autogen, elixir-format
 msgid "Holiday"
-msgstr ""
+msgstr "Vakans"
 
 #: lib/presentation_strings.ex:200
 #, elixir-autogen, elixir-format
 msgid "Hurricane"
-msgstr ""
+msgstr "Siklòn"
 
 #: lib/presentation_strings.ex:201
 #, elixir-autogen, elixir-format
 msgid "Ice In Harbor"
-msgstr ""
+msgstr "Glas Nan Pò a"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:10
 #, elixir-autogen, elixir-format
 msgid "Inbound"
-msgstr ""
+msgstr "Antran"
 
 #: lib/presentation_strings.ex:202
 #, elixir-autogen, elixir-format
 msgid "Maintenance"
-msgstr ""
+msgstr "Antretyen"
 
 #: lib/presentation_strings.ex:203
 #, elixir-autogen, elixir-format
 msgid "Mechanical Issue"
-msgstr ""
+msgstr "Pwoblèm Mekanik"
 
 #: lib/presentation_strings.ex:204
 #, elixir-autogen, elixir-format
 msgid "Mechanical Problem"
-msgstr ""
+msgstr "Pwoblèm Mekanik"
 
 #: lib/presentation_strings.ex:205
 #, elixir-autogen, elixir-format
 msgid "Medical Emergency"
-msgstr ""
+msgstr "Ijans Medikal"
 
 #: lib/presentation_strings.ex:84
 #, elixir-autogen, elixir-format
 msgid "Modified Service"
-msgstr ""
+msgstr "Sèvis Modifye"
 
 #: lib/presentation_strings.ex:44
 #, elixir-autogen, elixir-format
 msgid "Modified service"
-msgstr ""
+msgstr "Sèvis modifye"
 
 #: lib/mobile_app_backend/notifications/notification_title.ex:69
 #, elixir-autogen, elixir-format
 msgid "Multiple routes"
-msgstr ""
+msgstr "Plizyè wout"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:282
 #, elixir-autogen, elixir-format
 msgid "Multiple trips"
-msgstr ""
+msgstr "Plizyè vwayaj"
 
 #: lib/presentation_strings.ex:85
 #, elixir-autogen, elixir-format
 msgid "No Service"
-msgstr ""
+msgstr "Pa gen Sèvis"
 
 #: lib/presentation_strings.ex:45
 #, elixir-autogen, elixir-format
 msgid "No service"
-msgstr ""
+msgstr "Pa gen sèvis"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:6
 #, elixir-autogen, elixir-format
 msgid "Northbound"
-msgstr ""
+msgstr "Nan direksyon nò"
 
 #: lib/presentation_strings.ex:46
 #: lib/presentation_strings.ex:86
 #, elixir-autogen, elixir-format
 msgid "Notice"
-msgstr ""
+msgstr "Avi"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:11
 #, elixir-autogen, elixir-format
 msgid "Outbound"
-msgstr ""
+msgstr "Soti"
 
 #: lib/presentation_strings.ex:206
 #, elixir-autogen, elixir-format
 msgid "Parade"
-msgstr ""
+msgstr "Parad"
 
 #: lib/presentation_strings.ex:87
 #, elixir-autogen, elixir-format
 msgid "Parking Closure"
-msgstr ""
+msgstr "Fèmti Pakin"
 
 #: lib/presentation_strings.ex:88
 #, elixir-autogen, elixir-format
 msgid "Parking Issue"
-msgstr ""
+msgstr "Pwoblèm Pakin"
 
 #: lib/presentation_strings.ex:47
 #, elixir-autogen, elixir-format
 msgid "Parking closed"
-msgstr ""
+msgstr "Pakin fèmen"
 
 #: lib/presentation_strings.ex:48
 #, elixir-autogen, elixir-format
 msgid "Parking issue"
-msgstr ""
+msgstr "Pwoblèm pakin"
 
 #: lib/presentation_strings.ex:207
 #, elixir-autogen, elixir-format
 msgid "Police Action"
-msgstr ""
+msgstr "Aksyon Polis"
 
 #: lib/presentation_strings.ex:208
 #, elixir-autogen, elixir-format
 msgid "Police Activity"
-msgstr ""
+msgstr "Aktivite Polis"
 
 #: lib/presentation_strings.ex:89
 #, elixir-autogen, elixir-format
 msgid "Policy Change"
-msgstr ""
+msgstr "Chanjman Règleman"
 
 #: lib/presentation_strings.ex:49
 #, elixir-autogen, elixir-format
 msgid "Policy change"
-msgstr ""
+msgstr "Chanjman règleman"
 
 #: lib/presentation_strings.ex:209
 #, elixir-autogen, elixir-format
 msgid "Power Problem"
-msgstr ""
+msgstr "Pwoblèm Kouran"
 
 #: lib/presentation_strings.ex:210
 #, elixir-autogen, elixir-format
 msgid "Rail Defect"
-msgstr ""
+msgstr "Defo nan ray tren yo"
 
 #: lib/presentation_strings.ex:90
 #, elixir-autogen, elixir-format
 msgid "Schedule Change"
-msgstr ""
+msgstr "Chanjman Orè"
 
 #: lib/presentation_strings.ex:50
 #, elixir-autogen, elixir-format
 msgid "Schedule change"
-msgstr ""
+msgstr "Chanjman orè"
 
 #: lib/presentation_strings.ex:91
 #, elixir-autogen, elixir-format
 msgid "Service Change"
-msgstr ""
+msgstr "Chanjman Sèvis"
 
 #: lib/presentation_strings.ex:51
 #, elixir-autogen, elixir-format
 msgid "Service change"
-msgstr ""
+msgstr "Chanjman sèvis"
 
 #: lib/presentation_strings.ex:61
 #, elixir-autogen, elixir-format
 msgid "Service suspended"
-msgstr ""
+msgstr "Sèvis ki kanpe"
 
 #: lib/presentation_strings.ex:211
 #, elixir-autogen, elixir-format
 msgid "Severe Weather"
-msgstr ""
+msgstr "Move Tan"
 
 #: lib/presentation_strings.ex:92
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
-msgstr ""
+msgstr "Navèt"
 
 #: lib/presentation_strings.ex:52
 #, elixir-autogen, elixir-format
 msgid "Shuttle buses"
-msgstr ""
+msgstr "Otobis k ap fè lanavèt"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:298
 #, elixir-autogen, elixir-format
 msgid "Shuttle buses replace %{trip_identity} from **%{start_stop}** to **%{end_stop}**%{recurrence}"
-msgstr ""
+msgstr "Otobis navèt yo ranplase %{trip_identity} soti **%{start_stop}** pou rive **%{end_stop}**%{recurrence}"
 
 #: lib/presentation_strings.ex:212
 #, elixir-autogen, elixir-format
 msgid "Signal Issue"
-msgstr ""
+msgstr "Pwoblèm Siyal"
 
 #: lib/presentation_strings.ex:213
 #, elixir-autogen, elixir-format
 msgid "Signal Problem"
-msgstr ""
+msgstr "Pwoblèm Siyal"
 
 #: lib/presentation_strings.ex:214
 #, elixir-autogen, elixir-format
 msgid "Single Tracking"
-msgstr ""
+msgstr "Yon sèl ray pou de direksyon"
 
 #: lib/presentation_strings.ex:215
 #, elixir-autogen, elixir-format
 msgid "Slippery Rail"
-msgstr ""
+msgstr "Ray ki Glise"
 
 #: lib/presentation_strings.ex:216
 #, elixir-autogen, elixir-format
 msgid "Snow"
-msgstr ""
+msgstr "Nèj"
 
 #: lib/presentation_strings.ex:93
 #, elixir-autogen, elixir-format
 msgid "Snow Route"
-msgstr ""
+msgstr "Wout denèjman"
 
 #: lib/presentation_strings.ex:53
 #, elixir-autogen, elixir-format
 msgid "Snow route"
-msgstr ""
+msgstr "Wout denèjman"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:7
 #, elixir-autogen, elixir-format
 msgid "Southbound"
-msgstr ""
+msgstr "Nan direksyon sid"
 
 #: lib/presentation_strings.ex:217
 #, elixir-autogen, elixir-format
 msgid "Special Event"
-msgstr ""
+msgstr "Evènman Espesyal"
 
 #: lib/presentation_strings.ex:218
 #, elixir-autogen, elixir-format
 msgid "Speed Restriction"
-msgstr ""
+msgstr "Limit Vitès"
 
 #: lib/presentation_strings.ex:94
 #, elixir-autogen, elixir-format
 msgid "Station Closure"
-msgstr ""
+msgstr "Estasyon Fèmen"
 
 #: lib/presentation_strings.ex:95
 #, elixir-autogen, elixir-format
 msgid "Station Issue"
-msgstr ""
+msgstr "Pwoblèm Estasyon"
 
 #: lib/presentation_strings.ex:54
 #, elixir-autogen, elixir-format
 msgid "Station closed"
-msgstr ""
+msgstr "Estasyon fèmen"
 
 #: lib/presentation_strings.ex:55
 #, elixir-autogen, elixir-format
 msgid "Station issue"
-msgstr ""
+msgstr "Pwoblèm estasyon"
 
 #: lib/presentation_strings.ex:96
 #, elixir-autogen, elixir-format
 msgid "Stop Closure"
-msgstr ""
+msgstr "Fèmti Arè"
 
 #: lib/presentation_strings.ex:97
 #: lib/presentation_strings.ex:98
 #, elixir-autogen, elixir-format
 msgid "Stop Moved"
-msgstr ""
+msgstr "Arè Fèmen"
 
 #: lib/presentation_strings.ex:99
 #, elixir-autogen, elixir-format
 msgid "Stop Shoveling"
-msgstr ""
+msgstr "Arè Denèjman"
 
 #: lib/presentation_strings.ex:56
 #, elixir-autogen, elixir-format
 msgid "Stop closed"
-msgstr ""
+msgstr "Arè a fèmen"
 
 #: lib/presentation_strings.ex:57
 #: lib/presentation_strings.ex:58
 #, elixir-autogen, elixir-format
 msgid "Stop moved"
-msgstr ""
+msgstr "Arè Fèmen"
 
 #: lib/presentation_strings.ex:59
 #, elixir-autogen, elixir-format
 msgid "Stop shoveling"
-msgstr ""
+msgstr "Arè denèjman"
 
 #: lib/presentation_strings.ex:219
 #, elixir-autogen, elixir-format
 msgid "Strike"
-msgstr ""
+msgstr "Grèv"
 
 #: lib/presentation_strings.ex:60
 #: lib/presentation_strings.ex:100
 #, elixir-autogen, elixir-format
 msgid "Summary"
-msgstr ""
+msgstr "Rezime"
 
 #: lib/presentation_strings.ex:101
 #, elixir-autogen, elixir-format
 msgid "Suspension"
-msgstr ""
+msgstr "Sispansyon"
 
 #: lib/presentation_strings.ex:220
 #, elixir-autogen, elixir-format
 msgid "Switch Issue"
-msgstr ""
+msgstr "Pwoblèm nan switch ray"
 
 #: lib/presentation_strings.ex:221
 #, elixir-autogen, elixir-format
 msgid "Switch Problem"
-msgstr ""
+msgstr "Pann nan switch ray"
 
 #: lib/presentation_strings.ex:222
 #, elixir-autogen, elixir-format
 msgid "Technical Problem"
-msgstr ""
+msgstr "Pwoblèm Teknik"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:263
 #, elixir-autogen, elixir-format
 msgid "This %{route_type}"
-msgstr ""
+msgstr "Sa a %{route_type}"
 
 #: lib/presentation_strings.ex:223
 #, elixir-autogen, elixir-format
 msgid "Tie Replacement"
-msgstr ""
+msgstr "Ranplasman kòd"
 
 #: lib/presentation_strings.ex:102
 #, elixir-autogen, elixir-format
 msgid "Track Change"
-msgstr ""
+msgstr "Suiv Chanjman"
 
 #: lib/presentation_strings.ex:224
 #, elixir-autogen, elixir-format
 msgid "Track Problem"
-msgstr ""
+msgstr "Pwoblèm sou Ray"
 
 #: lib/presentation_strings.ex:225
 #, elixir-autogen, elixir-format
 msgid "Track Work"
-msgstr ""
+msgstr "Travay sou Ray"
 
 #: lib/presentation_strings.ex:62
 #, elixir-autogen, elixir-format
 msgid "Track change"
-msgstr ""
+msgstr "Suiv chanjman"
 
 #: lib/presentation_strings.ex:226
 #, elixir-autogen, elixir-format
 msgid "Traffic"
-msgstr ""
+msgstr "Sikilasyon"
 
 #: lib/presentation_strings.ex:227
 #, elixir-autogen, elixir-format
 msgid "Train Traffic"
-msgstr ""
+msgstr "Trafik tren"
 
 #: lib/presentation_strings.ex:35
 #, elixir-autogen, elixir-format
 msgid "Trip cancelled"
-msgstr ""
+msgstr "Vwayaj la anile"
 
 #: lib/presentation_strings.ex:228
 #, elixir-autogen, elixir-format
 msgid "Unruly Passenger"
-msgstr ""
+msgstr "Pasaje Ki Pa Respekte Règ"
 
 #: lib/presentation_strings.ex:229
 #, elixir-autogen, elixir-format
 msgid "Weather"
-msgstr ""
+msgstr "Tan"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:9
 #, elixir-autogen, elixir-format
 msgid "Westbound"
-msgstr ""
+msgstr "Pran direksyon lwès"
 
 #: lib/presentation_strings.ex:111
 #, elixir-autogen, elixir-format
 msgid "accident"
-msgstr ""
+msgstr "aksidan"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:424
 #, elixir-autogen, elixir-format
 msgid "affected by %{effect} %{day}"
-msgstr ""
+msgstr "afekte pa %{effect} %{day}"
 
 #: lib/presentation_strings.ex:114
 #, elixir-autogen, elixir-format
 msgid "an earlier mechanical problem"
-msgstr ""
+msgstr "yon pwoblèm mekanik ki te pase anvan"
 
 #: lib/presentation_strings.ex:115
 #, elixir-autogen, elixir-format
 msgid "an earlier signal problem"
-msgstr ""
+msgstr "yon pwoblèm siyal ki te pase anvan"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:382
 #, elixir-autogen, elixir-format
 msgid "are cancelled %{day}"
-msgstr ""
+msgstr "yo anile %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:417
 #, elixir-autogen, elixir-format
 msgid "are suspended %{day}"
-msgstr ""
+msgstr "yo sispann %{day}"
 
 #: lib/presentation_strings.ex:116
 #, elixir-autogen, elixir-format
 msgid "autos impeding service"
-msgstr ""
+msgstr "oto ap anpeche sèvis la"
 
 #: lib/presentation_strings.ex:12
 #, elixir-autogen, elixir-format
 msgid "bus"
-msgstr ""
+msgstr "bis"
 
 #: lib/presentation_strings.ex:13
 #, elixir-autogen, elixir-format
 msgid "buses"
-msgstr ""
+msgstr "bis yo"
 
 #: lib/presentation_strings.ex:118
 #, elixir-autogen, elixir-format
 msgid "congestion"
-msgstr ""
+msgstr "anbouteyaj"
 
 #: lib/presentation_strings.ex:119
 #, elixir-autogen, elixir-format
 msgid "construction"
-msgstr ""
+msgstr "konstriksyon"
 
 #: lib/presentation_strings.ex:120
 #, elixir-autogen, elixir-format
 msgid "crossing issue"
-msgstr ""
+msgstr "pwoblèm nan pasaj a nivo"
 
 #: lib/presentation_strings.ex:121
 #, elixir-autogen, elixir-format
 msgid "crossing malfunction"
-msgstr ""
+msgstr "malfonksyònman nan pasaj a nivo"
 
 #: lib/presentation_strings.ex:122
 #, elixir-autogen, elixir-format
 msgid "demonstration"
-msgstr ""
+msgstr "manifestasyon"
 
 #: lib/presentation_strings.ex:123
 #, elixir-autogen, elixir-format
 msgid "disabled bus"
-msgstr ""
+msgstr "otobis anpann"
 
 #: lib/presentation_strings.ex:124
 #, elixir-autogen, elixir-format
 msgid "disabled train"
-msgstr ""
+msgstr "tren anpann"
 
 #: lib/presentation_strings.ex:125
 #, elixir-autogen, elixir-format
 msgid "drawbridge being raised"
-msgstr ""
+msgstr "pon levasyon ap monte"
 
 #: lib/presentation_strings.ex:126
 #, elixir-autogen, elixir-format
 msgid "drawbridge issue"
-msgstr ""
+msgstr "pwoblèm pon leve"
 
 #: lib/presentation_strings.ex:127
 #, elixir-autogen, elixir-format
 msgid "electrical work"
-msgstr ""
+msgstr "travay elektrik"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:193
 #, elixir-autogen, elixir-format
 msgid "end of service"
-msgstr ""
+msgstr "fen sèvis"
 
 #: lib/presentation_strings.ex:15
 #, elixir-autogen, elixir-format
 msgid "ferries"
-msgstr ""
+msgstr "bato yo"
 
 #: lib/presentation_strings.ex:14
 #, elixir-autogen, elixir-format
 msgid "ferry"
-msgstr ""
+msgstr "bato"
 
 #: lib/presentation_strings.ex:128
 #, elixir-autogen, elixir-format
 msgid "fire"
-msgstr ""
+msgstr "dife"
 
 #: lib/presentation_strings.ex:129
 #, elixir-autogen, elixir-format
 msgid "fire department activity"
-msgstr ""
+msgstr "aktivite ponpye"
 
 #: lib/presentation_strings.ex:130
 #, elixir-autogen, elixir-format
 msgid "flooding"
-msgstr ""
+msgstr "inondasyon"
 
 #: lib/presentation_strings.ex:131
 #, elixir-autogen, elixir-format
 msgid "fog"
-msgstr ""
+msgstr "bwouya"
 
 #: lib/presentation_strings.ex:132
 #, elixir-autogen, elixir-format
 msgid "freight train interference"
-msgstr ""
+msgstr "entèferans tren machandiz"
 
 #: lib/presentation_strings.ex:133
 #, elixir-autogen, elixir-format
 msgid "hazmat condition"
-msgstr ""
+msgstr "kondisyon danje"
 
 #: lib/presentation_strings.ex:134
 #, elixir-autogen, elixir-format
 msgid "heavy ridership"
-msgstr ""
+msgstr "Anpil pasaje"
 
 #: lib/presentation_strings.ex:135
 #, elixir-autogen, elixir-format
 msgid "high winds"
-msgstr ""
+msgstr "gwo van"
 
 #: lib/presentation_strings.ex:136
 #, elixir-autogen, elixir-format
 msgid "holiday"
-msgstr ""
+msgstr "jou ferye"
 
 #: lib/presentation_strings.ex:137
 #, elixir-autogen, elixir-format
 msgid "hurricane"
-msgstr ""
+msgstr "siklòn"
 
 #: lib/presentation_strings.ex:138
 #, elixir-autogen, elixir-format
 msgid "ice in harbor"
-msgstr ""
+msgstr "glas nan pò"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:385
 #, elixir-autogen, elixir-format
 msgid "is cancelled %{day}"
-msgstr ""
+msgstr "anile %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:420
 #, elixir-autogen, elixir-format
 msgid "is suspended %{day}"
-msgstr ""
+msgstr "sispann %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:239
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_recurrence_end_day_later_date"
-msgstr ""
+msgstr " jiska %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:247
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_recurrence_end_day_this_week"
-msgstr ""
+msgstr " jiska %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:144
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_timeframe_later_date"
-msgstr ""
+msgstr " jiska %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:152
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_timeframe_this_week"
-msgstr ""
+msgstr " jiska %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:160
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_timeframe_time"
-msgstr ""
+msgstr " jiska %{1}"
 
 #: lib/presentation_strings.ex:139
 #, elixir-autogen, elixir-format
 msgid "maintenance"
-msgstr ""
+msgstr "antretyen"
 
 #: lib/presentation_strings.ex:140
 #, elixir-autogen, elixir-format
 msgid "mechanical issue"
-msgstr ""
+msgstr "pwoblèm mekanik"
 
 #: lib/presentation_strings.ex:141
 #, elixir-autogen, elixir-format
 msgid "mechanical problem"
-msgstr ""
+msgstr "pwoblèm mekanik"
 
 #: lib/presentation_strings.ex:142
 #, elixir-autogen, elixir-format
 msgid "medical emergency"
-msgstr ""
+msgstr "ijans medikal"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:333
 #, elixir-autogen, elixir-format
 msgid "multiple trips"
-msgstr ""
+msgstr "plizyè vwayaj"
 
 #: lib/presentation_strings.ex:143
 #, elixir-autogen, elixir-format
 msgid "parade"
-msgstr ""
+msgstr "parad"
 
 #: lib/presentation_strings.ex:144
 #, elixir-autogen, elixir-format
 msgid "police action"
-msgstr ""
+msgstr "aksyon lapolis"
 
 #: lib/presentation_strings.ex:145
 #, elixir-autogen, elixir-format
 msgid "police activity"
-msgstr ""
+msgstr "aktivite lapolis"
 
 #: lib/presentation_strings.ex:146
 #, elixir-autogen, elixir-format
 msgid "power problem"
-msgstr ""
+msgstr "pwoblèm kouran"
 
 #: lib/presentation_strings.ex:147
 #, elixir-autogen, elixir-format
 msgid "rail defect"
-msgstr ""
+msgstr "defo nan ray"
 
 #: lib/presentation_strings.ex:148
 #, elixir-autogen, elixir-format
 msgid "severe weather"
-msgstr ""
+msgstr "move tan"
 
 #: lib/presentation_strings.ex:149
 #, elixir-autogen, elixir-format
 msgid "signal issue"
-msgstr ""
+msgstr "pwoblèm siyal"
 
 #: lib/presentation_strings.ex:150
 #, elixir-autogen, elixir-format
 msgid "signal problem"
-msgstr ""
+msgstr "pann siyal"
 
 #: lib/presentation_strings.ex:151
 #, elixir-autogen, elixir-format
 msgid "single tracking"
-msgstr ""
+msgstr "yon sèl ray pou de direksyon"
 
 #: lib/presentation_strings.ex:152
 #, elixir-autogen, elixir-format
 msgid "slippery rail"
-msgstr ""
+msgstr "ray glise"
 
 #: lib/presentation_strings.ex:153
 #, elixir-autogen, elixir-format
 msgid "snow"
-msgstr ""
+msgstr "nèj"
 
 #: lib/presentation_strings.ex:154
 #, elixir-autogen, elixir-format
 msgid "special event"
-msgstr ""
+msgstr "evènman espesyal"
 
 #: lib/presentation_strings.ex:155
 #, elixir-autogen, elixir-format
 msgid "speed restriction"
-msgstr ""
+msgstr "restriksyon vitès"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:190
 #, elixir-autogen, elixir-format
 msgid "start of service"
-msgstr ""
+msgstr "kòmansman sèvis"
 
 #: lib/presentation_strings.ex:156
 #, elixir-autogen, elixir-format
 msgid "strike"
-msgstr ""
+msgstr "grèv"
 
 #: lib/presentation_strings.ex:157
 #, elixir-autogen, elixir-format
 msgid "switch issue"
-msgstr ""
+msgstr "pwoblèm nan switch ray"
 
 #: lib/presentation_strings.ex:158
 #, elixir-autogen, elixir-format
 msgid "switch problem"
-msgstr ""
+msgstr "pann nan switch ray"
 
 #: lib/presentation_strings.ex:159
 #, elixir-autogen, elixir-format
 msgid "technical problem"
-msgstr ""
+msgstr "pwoblèm teknik"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:320
 #, elixir-autogen, elixir-format
 msgid "the **%{time}** %{vehicle}"
-msgstr ""
+msgstr "**%{time}** %{vehicle} la"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:328
 #, elixir-autogen, elixir-format
 msgid "this %{vehicle}"
-msgstr ""
+msgstr "sa a %{vehicle}"
 
 #: lib/presentation_strings.ex:160
 #, elixir-autogen, elixir-format
 msgid "tie replacement"
-msgstr ""
+msgstr "ranplasman mare"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:377
 #, elixir-autogen, elixir-format
 msgid "today"
-msgstr ""
+msgstr "jodi a"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:377
 #, elixir-autogen, elixir-format
 msgid "tomorrow"
-msgstr ""
+msgstr "demen"
 
 #: lib/presentation_strings.ex:161
 #, elixir-autogen, elixir-format
 msgid "track problem"
-msgstr ""
+msgstr "pwoblèm sou ray"
 
 #: lib/presentation_strings.ex:162
 #, elixir-autogen, elixir-format
 msgid "track work"
-msgstr ""
+msgstr "travay ap fèt sou ray"
 
 #: lib/presentation_strings.ex:163
 #, elixir-autogen, elixir-format
 msgid "traffic"
-msgstr ""
+msgstr "trafik"
 
 #: lib/presentation_strings.ex:16
 #, elixir-autogen, elixir-format
 msgid "train"
-msgstr ""
+msgstr "tren"
 
 #: lib/presentation_strings.ex:164
 #, elixir-autogen, elixir-format
 msgid "train traffic"
-msgstr ""
+msgstr "trafik tren"
 
 #: lib/presentation_strings.ex:17
 #, elixir-autogen, elixir-format
 msgid "trains"
-msgstr ""
+msgstr "tren yo"
 
 #: lib/presentation_strings.ex:165
 #, elixir-autogen, elixir-format
 msgid "unruly passenger"
-msgstr ""
+msgstr "pasaje ap fè dezòd"
 
 #: lib/presentation_strings.ex:166
 #, elixir-autogen, elixir-format
 msgid "weather"
-msgstr ""
+msgstr "move tan"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:388
 #, elixir-autogen, elixir-format
 msgid "will not stop at %{stop_list} %{day}"
-msgstr ""
+msgstr "p ap rete nan %{stop_list} %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:411
 #, elixir-autogen, elixir-format
 msgid "will terminate at %{terminating_stop} %{day}"
-msgstr ""
+msgstr "ap fini nan %{terminating_stop} %{day}"
 
 #: lib/mobile_app_backend_web/components/core_components.ex:484
 #, elixir-autogen, elixir-format, import-optional

--- a/priv/gettext/ht/LC_MESSAGES/errors.po
+++ b/priv/gettext/ht/LC_MESSAGES/errors.po
@@ -1,0 +1,12 @@
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: ht\n"
+"Plural-Forms: nplurals=3\n"

--- a/priv/gettext/pt-BR/LC_MESSAGES/default.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/default.po
@@ -1,176 +1,176 @@
-## This file is a PO Template file.
-##
-## "msgid"s here are often extracted from source code.
-## Add new messages manually only if they're dynamic
-## messages that can't be statically extracted.
-##
-## Run "mix gettext.extract" to bring this file up to
-## date. Leave "msgstr"s empty as changing them here has no
-## effect: edit them in PO (.po) files instead.
-#
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
 msgid ""
 msgstr ""
+"Language: pt-BR\n"
+"Plural-Forms: nplurals=3\n"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:101
 #, elixir-autogen, elixir-format
 msgid " at **%{stop_name}**"
-msgstr ""
+msgstr " em **%{stop_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:210
 #, elixir-autogen, elixir-format
 msgid " daily%{recurrence_text}"
-msgstr ""
+msgstr " diário%{recurrence_text}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:434
 #, elixir-autogen, elixir-format
 msgid " due to %{cause}"
-msgstr ""
+msgstr " devido a %{cause}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:173
 #, elixir-autogen, elixir-format
 msgid " from %{start_time} to %{end_time}"
-msgstr ""
+msgstr " de %{start_time} para %{end_time}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:95
 #, elixir-autogen, elixir-format
 msgid " from **%{direction_name}** stops to **%{end_stop_name}**"
-msgstr ""
+msgstr " de **%{direction_name}** paradas a **%{end_stop_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:110
 #, elixir-autogen, elixir-format
 msgid " from **%{start_stop}** to **%{end_stop}**"
-msgstr ""
+msgstr " de **%{start_stop}** até **%{end_stop}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:104
 #, elixir-autogen, elixir-format
 msgid " from **%{stop_name}** to **%{direction_name}** stops"
-msgstr ""
+msgstr " de **%{stop_name}** a **%{direction_name}** paradas"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:121
 #, elixir-autogen, elixir-format
 msgid " on **%{mode_label}**"
-msgstr ""
+msgstr " em **%{mode_label}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:117
 #, elixir-autogen, elixir-format
 msgid " replacing **%{mode_label}**"
-msgstr ""
+msgstr " substituindo **%{mode_label}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:219
 #, elixir-autogen, elixir-format
 msgid " some days%{recurrence_text}"
-msgstr ""
+msgstr " alguns dias%{recurrence_text}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:168
 #, elixir-autogen, elixir-format
 msgid " starting **%{formatted_time}** today"
-msgstr ""
+msgstr " começando **%{formatted_time}** hoje"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:165
 #, elixir-autogen, elixir-format
 msgid " starting tomorrow"
-msgstr ""
+msgstr " a partir de amanhã"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:138
 #, elixir-autogen, elixir-format
 msgid " through end of service"
-msgstr ""
+msgstr " até o fim do serviço"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:141
 #, elixir-autogen, elixir-format
 msgid " through tomorrow"
-msgstr ""
+msgstr " até amanhã"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:135
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:233
 #, elixir-autogen, elixir-format
 msgid " until further notice"
-msgstr ""
+msgstr " até novo aviso"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:236
 #, elixir-autogen, elixir-format
 msgid " until tomorrow"
-msgstr ""
+msgstr " até amanhã"
 
 #: lib/mobile_app_backend/notifications/notification_title.ex:63
 #, elixir-autogen, elixir-format
 msgid "%{label} %{mode_label}"
-msgstr ""
+msgstr "%{label} %{mode_label}"
 
 #: lib/presentation_strings.ex:22
 #, elixir-autogen, elixir-format
 msgid "%{name} bus"
-msgstr ""
+msgstr "%{name} ônibus"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:398
 #, elixir-autogen, elixir-format
 msgid "%{stop} and %{other_stops}"
-msgstr ""
+msgstr "%{stop} e %{other_stops}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:57
 #, elixir-autogen, elixir-format
 msgid "%{trip_identity} %{trip_effect}%{cause}%{recurrence}"
-msgstr ""
+msgstr "%{trip_identity} %{trip_effect}%{cause}%{recurrence}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:290
 #, elixir-autogen, elixir-format
 msgid "%{trip_identity} is replaced by shuttle buses from **%{start_stop}** to **%{end_stop}**%{recurrence}"
-msgstr ""
+msgstr "%{trip_identity} é substituído por ônibus de transporte de **%{start_stop}** para **%{end_stop}**%{recurrence}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:47
 #, elixir-autogen, elixir-format
 msgid "**%{effect_sentence_case}**%{summary_location}%{summary_timeframe}%{summary_recurrence}"
-msgstr ""
+msgstr "**%{effect_sentence_case}**%{summary_location}%{summary_timeframe}%{summary_recurrence}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:313
 #, elixir-autogen, elixir-format
 msgid "**%{time}** %{vehicle} from **%{from_stop}**"
-msgstr ""
+msgstr "**%{time}** %{vehicle} de **%{from_stop}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:268
 #, elixir-autogen, elixir-format
 msgid "**%{trip_time}** %{route_type} from **%{stop_name}**"
-msgstr ""
+msgstr "**%{trip_time}** %{route_type} de **%{stop_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:275
 #, elixir-autogen, elixir-format
 msgid "**%{trip_time}** %{route_type} to **%{headsign}**"
-msgstr ""
+msgstr "**%{trip_time}** %{route_type} para **%{headsign}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:28
 #, elixir-autogen, elixir-format
 msgid "**All clear:** Regular service%{location}"
-msgstr ""
+msgstr "**Tudo certo:** Serviço regular%{location}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:39
 #, elixir-autogen, elixir-format
 msgid "**Update:** %{effect_sentence_case}%{summary_location}%{summary_timeframe}%{summary_recurrence}"
-msgstr ""
+msgstr "**Atualização:** %{effect_sentence_case}%{summary_location}%{summary_timeframe}%{summary_recurrence}"
 
 #: lib/presentation_strings.ex:71
 #, elixir-autogen, elixir-format
 msgid "Access Issue"
-msgstr ""
+msgstr "Problema de acesso"
 
 #: lib/presentation_strings.ex:31
 #, elixir-autogen, elixir-format
 msgid "Access issue"
-msgstr ""
+msgstr "Problema de acesso"
 
 #: lib/presentation_strings.ex:174
 #, elixir-autogen, elixir-format
 msgid "Accident"
-msgstr ""
+msgstr "Acidente"
 
 #: lib/presentation_strings.ex:72
 #, elixir-autogen, elixir-format
 msgid "Additional Service"
-msgstr ""
+msgstr "Serviço adicional"
 
 #: lib/presentation_strings.ex:32
 #, elixir-autogen, elixir-format
 msgid "Additional service"
-msgstr ""
+msgstr "Serviço adicional"
 
 #: lib/presentation_strings.ex:63
 #: lib/presentation_strings.ex:64
@@ -178,1014 +178,1014 @@ msgstr ""
 #: lib/presentation_strings.ex:104
 #, elixir-autogen, elixir-format
 msgid "Alert"
-msgstr ""
+msgstr "Alerta"
 
 #: lib/presentation_strings.ex:73
 #, elixir-autogen, elixir-format
 msgid "Amber Alert"
-msgstr ""
+msgstr "Alerta amarelo"
 
 #: lib/presentation_strings.ex:33
 #, elixir-autogen, elixir-format
 msgid "Amber alert"
-msgstr ""
+msgstr "Alerta amarelo"
 
 #: lib/presentation_strings.ex:112
 #: lib/presentation_strings.ex:175
 #, elixir-autogen, elixir-format
 msgid "Amtrak"
-msgstr ""
+msgstr "Amtrak"
 
 #: lib/presentation_strings.ex:176
 #, elixir-autogen, elixir-format
 msgid "Amtrak Train Traffic"
-msgstr ""
+msgstr "Tráfego de trens da Amtrak"
 
 #: lib/presentation_strings.ex:113
 #, elixir-autogen, elixir-format
 msgid "Amtrak train traffic"
-msgstr ""
+msgstr "Tráfego de trens da Amtrak"
 
 #: lib/presentation_strings.ex:177
 #, elixir-autogen, elixir-format
 msgid "An Earlier Mechanical Problem"
-msgstr ""
+msgstr "Um problema mecânico anterior"
 
 #: lib/presentation_strings.ex:178
 #, elixir-autogen, elixir-format
 msgid "An Earlier Signal Problem"
-msgstr ""
+msgstr "Um problema de sinal anterior"
 
 #: lib/presentation_strings.ex:179
 #, elixir-autogen, elixir-format
 msgid "Autos Impeding Service"
-msgstr ""
+msgstr "Carros impedindo serviço"
 
 #: lib/presentation_strings.ex:74
 #, elixir-autogen, elixir-format
 msgid "Bike Issue"
-msgstr ""
+msgstr "Problema com bicicleta"
 
 #: lib/presentation_strings.ex:34
 #, elixir-autogen, elixir-format
 msgid "Bike issue"
-msgstr ""
+msgstr "Problema com bicicleta"
 
 #: lib/presentation_strings.ex:75
 #, elixir-autogen, elixir-format
 msgid "Cancellation"
-msgstr ""
+msgstr "Cancelamento"
 
 #: lib/presentation_strings.ex:180
 #, elixir-autogen, elixir-format
 msgid "Coast Guard Restriction"
-msgstr ""
+msgstr "Restrição da Guarda Costeira"
 
 #: lib/presentation_strings.ex:117
 #, elixir-autogen, elixir-format
 msgid "Coast Guard restriction"
-msgstr ""
+msgstr "Restrição da Guarda Costeira"
 
 #: lib/presentation_strings.ex:181
 #, elixir-autogen, elixir-format
 msgid "Congestion"
-msgstr ""
+msgstr "Congestionamento"
 
 #: lib/presentation_strings.ex:182
 #, elixir-autogen, elixir-format
 msgid "Construction"
-msgstr ""
+msgstr "Obras"
 
 #: lib/presentation_strings.ex:183
 #, elixir-autogen, elixir-format
 msgid "Crossing Issue"
-msgstr ""
+msgstr "Problema de travessia"
 
 #: lib/presentation_strings.ex:184
 #, elixir-autogen, elixir-format
 msgid "Crossing Malfunction"
-msgstr ""
+msgstr "Problemas no cruzamento"
 
 #: lib/presentation_strings.ex:36
 #: lib/presentation_strings.ex:76
 #, elixir-autogen, elixir-format
 msgid "Delay"
-msgstr ""
+msgstr "Atraso"
 
 #: lib/presentation_strings.ex:185
 #, elixir-autogen, elixir-format
 msgid "Demonstration"
-msgstr ""
+msgstr "Manifestação"
 
 #: lib/presentation_strings.ex:37
 #: lib/presentation_strings.ex:77
 #, elixir-autogen, elixir-format
 msgid "Detour"
-msgstr ""
+msgstr "Desvio"
 
 #: lib/presentation_strings.ex:186
 #, elixir-autogen, elixir-format
 msgid "Disabled Bus"
-msgstr ""
+msgstr "Ônibus desativado"
 
 #: lib/presentation_strings.ex:187
 #, elixir-autogen, elixir-format
 msgid "Disabled Train"
-msgstr ""
+msgstr "Trem desativado"
 
 #: lib/presentation_strings.ex:78
 #, elixir-autogen, elixir-format
 msgid "Dock Closure"
-msgstr ""
+msgstr "Fechamento de doca"
 
 #: lib/presentation_strings.ex:79
 #, elixir-autogen, elixir-format
 msgid "Dock Issue"
-msgstr ""
+msgstr "Problema na doca"
 
 #: lib/presentation_strings.ex:38
 #, elixir-autogen, elixir-format
 msgid "Dock closed"
-msgstr ""
+msgstr "Doca fechada"
 
 #: lib/presentation_strings.ex:39
 #, elixir-autogen, elixir-format
 msgid "Dock issue"
-msgstr ""
+msgstr "Problema na doca"
 
 #: lib/presentation_strings.ex:188
 #, elixir-autogen, elixir-format
 msgid "Drawbridge Being Raised"
-msgstr ""
+msgstr "Ponte móvel em elevação"
 
 #: lib/presentation_strings.ex:189
 #, elixir-autogen, elixir-format
 msgid "Drawbridge Issue"
-msgstr ""
+msgstr "Problema da ponte levadiça"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:8
 #, elixir-autogen, elixir-format
 msgid "Eastbound"
-msgstr ""
+msgstr "Sentido leste"
 
 #: lib/presentation_strings.ex:190
 #, elixir-autogen, elixir-format
 msgid "Electrical Work"
-msgstr ""
+msgstr "Obra elétrica"
 
 #: lib/presentation_strings.ex:80
 #, elixir-autogen, elixir-format
 msgid "Elevator Closure"
-msgstr ""
+msgstr "Fechamento de elevador"
 
 #: lib/presentation_strings.ex:40
 #, elixir-autogen, elixir-format
 msgid "Elevator closed"
-msgstr ""
+msgstr "Elevador fechado"
 
 #: lib/presentation_strings.ex:81
 #, elixir-autogen, elixir-format
 msgid "Escalator Closure"
-msgstr ""
+msgstr "Fechamento de escada rolante"
 
 #: lib/presentation_strings.ex:41
 #, elixir-autogen, elixir-format
 msgid "Escalator closed"
-msgstr ""
+msgstr "Escada rolante fechada"
 
 #: lib/presentation_strings.ex:82
 #, elixir-autogen, elixir-format
 msgid "Extra Service"
-msgstr ""
+msgstr "Serviço extra"
 
 #: lib/presentation_strings.ex:42
 #, elixir-autogen, elixir-format
 msgid "Extra service"
-msgstr ""
+msgstr "Serviço extra"
 
 #: lib/presentation_strings.ex:83
 #, elixir-autogen, elixir-format
 msgid "Facility Issue"
-msgstr ""
+msgstr "Problema nas instalações"
 
 #: lib/presentation_strings.ex:43
 #, elixir-autogen, elixir-format
 msgid "Facility issue"
-msgstr ""
+msgstr "Problema nas instalações"
 
 #: lib/presentation_strings.ex:191
 #, elixir-autogen, elixir-format
 msgid "Fire"
-msgstr ""
+msgstr "Incêndio"
 
 #: lib/presentation_strings.ex:192
 #, elixir-autogen, elixir-format
 msgid "Fire Department Activity"
-msgstr ""
+msgstr "Atividade do corpo de bombeiros"
 
 #: lib/presentation_strings.ex:193
 #, elixir-autogen, elixir-format
 msgid "Flooding"
-msgstr ""
+msgstr "Inundação"
 
 #: lib/presentation_strings.ex:194
 #, elixir-autogen, elixir-format
 msgid "Fog"
-msgstr ""
+msgstr "Neblina"
 
 #: lib/presentation_strings.ex:195
 #, elixir-autogen, elixir-format
 msgid "Freight Train Interference"
-msgstr ""
+msgstr "Interferência de trem de carga"
 
 #: lib/presentation_strings.ex:196
 #, elixir-autogen, elixir-format
 msgid "Hazmat Condition"
-msgstr ""
+msgstr "Condição de material perigoso"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:17
 #, elixir-autogen, elixir-format
 msgid "Heading"
-msgstr ""
+msgstr "Rumo"
 
 #: lib/presentation_strings.ex:197
 #, elixir-autogen, elixir-format
 msgid "Heavy Ridership"
-msgstr ""
+msgstr "Excesso de passageiros"
 
 #: lib/presentation_strings.ex:198
 #, elixir-autogen, elixir-format
 msgid "High Winds"
-msgstr ""
+msgstr "Ventos fortes"
 
 #: lib/presentation_strings.ex:199
 #, elixir-autogen, elixir-format
 msgid "Holiday"
-msgstr ""
+msgstr "Feriado"
 
 #: lib/presentation_strings.ex:200
 #, elixir-autogen, elixir-format
 msgid "Hurricane"
-msgstr ""
+msgstr "Furacão"
 
 #: lib/presentation_strings.ex:201
 #, elixir-autogen, elixir-format
 msgid "Ice In Harbor"
-msgstr ""
+msgstr "Gelo no porto"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:10
 #, elixir-autogen, elixir-format
 msgid "Inbound"
-msgstr ""
+msgstr "Entrada"
 
 #: lib/presentation_strings.ex:202
 #, elixir-autogen, elixir-format
 msgid "Maintenance"
-msgstr ""
+msgstr "Manutenção"
 
 #: lib/presentation_strings.ex:203
 #, elixir-autogen, elixir-format
 msgid "Mechanical Issue"
-msgstr ""
+msgstr "Problema mecânico"
 
 #: lib/presentation_strings.ex:204
 #, elixir-autogen, elixir-format
 msgid "Mechanical Problem"
-msgstr ""
+msgstr "Problema mecânico"
 
 #: lib/presentation_strings.ex:205
 #, elixir-autogen, elixir-format
 msgid "Medical Emergency"
-msgstr ""
+msgstr "Emergência médica"
 
 #: lib/presentation_strings.ex:84
 #, elixir-autogen, elixir-format
 msgid "Modified Service"
-msgstr ""
+msgstr "Serviço modificado"
 
 #: lib/presentation_strings.ex:44
 #, elixir-autogen, elixir-format
 msgid "Modified service"
-msgstr ""
+msgstr "Serviço modificado"
 
 #: lib/mobile_app_backend/notifications/notification_title.ex:69
 #, elixir-autogen, elixir-format
 msgid "Multiple routes"
-msgstr ""
+msgstr "Rotas múltiplas"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:282
 #, elixir-autogen, elixir-format
 msgid "Multiple trips"
-msgstr ""
+msgstr "Várias viagens"
 
 #: lib/presentation_strings.ex:85
 #, elixir-autogen, elixir-format
 msgid "No Service"
-msgstr ""
+msgstr "Sem serviço"
 
 #: lib/presentation_strings.ex:45
 #, elixir-autogen, elixir-format
 msgid "No service"
-msgstr ""
+msgstr "Sem serviço"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:6
 #, elixir-autogen, elixir-format
 msgid "Northbound"
-msgstr ""
+msgstr "Sentido norte"
 
 #: lib/presentation_strings.ex:46
 #: lib/presentation_strings.ex:86
 #, elixir-autogen, elixir-format
 msgid "Notice"
-msgstr ""
+msgstr "Perceber"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:11
 #, elixir-autogen, elixir-format
 msgid "Outbound"
-msgstr ""
+msgstr "Saída"
 
 #: lib/presentation_strings.ex:206
 #, elixir-autogen, elixir-format
 msgid "Parade"
-msgstr ""
+msgstr "Desfile"
 
 #: lib/presentation_strings.ex:87
 #, elixir-autogen, elixir-format
 msgid "Parking Closure"
-msgstr ""
+msgstr "Fechamento de estacionamento"
 
 #: lib/presentation_strings.ex:88
 #, elixir-autogen, elixir-format
 msgid "Parking Issue"
-msgstr ""
+msgstr "Problema no estacionamento"
 
 #: lib/presentation_strings.ex:47
 #, elixir-autogen, elixir-format
 msgid "Parking closed"
-msgstr ""
+msgstr "Estacionamento fechado"
 
 #: lib/presentation_strings.ex:48
 #, elixir-autogen, elixir-format
 msgid "Parking issue"
-msgstr ""
+msgstr "Problema no estacionamento"
 
 #: lib/presentation_strings.ex:207
 #, elixir-autogen, elixir-format
 msgid "Police Action"
-msgstr ""
+msgstr "Ação policial"
 
 #: lib/presentation_strings.ex:208
 #, elixir-autogen, elixir-format
 msgid "Police Activity"
-msgstr ""
+msgstr "Atividade policial"
 
 #: lib/presentation_strings.ex:89
 #, elixir-autogen, elixir-format
 msgid "Policy Change"
-msgstr ""
+msgstr "Alteração de política"
 
 #: lib/presentation_strings.ex:49
 #, elixir-autogen, elixir-format
 msgid "Policy change"
-msgstr ""
+msgstr "Alteração de política"
 
 #: lib/presentation_strings.ex:209
 #, elixir-autogen, elixir-format
 msgid "Power Problem"
-msgstr ""
+msgstr "Problema de energia"
 
 #: lib/presentation_strings.ex:210
 #, elixir-autogen, elixir-format
 msgid "Rail Defect"
-msgstr ""
+msgstr "Defeito nos trilhos"
 
 #: lib/presentation_strings.ex:90
 #, elixir-autogen, elixir-format
 msgid "Schedule Change"
-msgstr ""
+msgstr "Alteração de horário"
 
 #: lib/presentation_strings.ex:50
 #, elixir-autogen, elixir-format
 msgid "Schedule change"
-msgstr ""
+msgstr "Alteração de horário"
 
 #: lib/presentation_strings.ex:91
 #, elixir-autogen, elixir-format
 msgid "Service Change"
-msgstr ""
+msgstr "Troca de serviço"
 
 #: lib/presentation_strings.ex:51
 #, elixir-autogen, elixir-format
 msgid "Service change"
-msgstr ""
+msgstr "Troca de serviço"
 
 #: lib/presentation_strings.ex:61
 #, elixir-autogen, elixir-format
 msgid "Service suspended"
-msgstr ""
+msgstr "Serviço suspenso"
 
 #: lib/presentation_strings.ex:211
 #, elixir-autogen, elixir-format
 msgid "Severe Weather"
-msgstr ""
+msgstr "Tempo ruim"
 
 #: lib/presentation_strings.ex:92
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
-msgstr ""
+msgstr "Ônibus vai-e-vem"
 
 #: lib/presentation_strings.ex:52
 #, elixir-autogen, elixir-format
 msgid "Shuttle buses"
-msgstr ""
+msgstr "Ônibus de transferência"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:298
 #, elixir-autogen, elixir-format
 msgid "Shuttle buses replace %{trip_identity} from **%{start_stop}** to **%{end_stop}**%{recurrence}"
-msgstr ""
+msgstr "Ônibus de transporte substituem %{trip_identity} de **%{start_stop}** a **%{end_stop}**%{recurrence}"
 
 #: lib/presentation_strings.ex:212
 #, elixir-autogen, elixir-format
 msgid "Signal Issue"
-msgstr ""
+msgstr "Problema de sinal"
 
 #: lib/presentation_strings.ex:213
 #, elixir-autogen, elixir-format
 msgid "Signal Problem"
-msgstr ""
+msgstr "Problema de sinal"
 
 #: lib/presentation_strings.ex:214
 #, elixir-autogen, elixir-format
 msgid "Single Tracking"
-msgstr ""
+msgstr "Via única"
 
 #: lib/presentation_strings.ex:215
 #, elixir-autogen, elixir-format
 msgid "Slippery Rail"
-msgstr ""
+msgstr "Trilho escorregadio"
 
 #: lib/presentation_strings.ex:216
 #, elixir-autogen, elixir-format
 msgid "Snow"
-msgstr ""
+msgstr "Neve"
 
 #: lib/presentation_strings.ex:93
 #, elixir-autogen, elixir-format
 msgid "Snow Route"
-msgstr ""
+msgstr "Rota de neve"
 
 #: lib/presentation_strings.ex:53
 #, elixir-autogen, elixir-format
 msgid "Snow route"
-msgstr ""
+msgstr "Rota da neve"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:7
 #, elixir-autogen, elixir-format
 msgid "Southbound"
-msgstr ""
+msgstr "Sentido sul"
 
 #: lib/presentation_strings.ex:217
 #, elixir-autogen, elixir-format
 msgid "Special Event"
-msgstr ""
+msgstr "Evento especial"
 
 #: lib/presentation_strings.ex:218
 #, elixir-autogen, elixir-format
 msgid "Speed Restriction"
-msgstr ""
+msgstr "Restrição de velocidade"
 
 #: lib/presentation_strings.ex:94
 #, elixir-autogen, elixir-format
 msgid "Station Closure"
-msgstr ""
+msgstr "Fechamento de estação"
 
 #: lib/presentation_strings.ex:95
 #, elixir-autogen, elixir-format
 msgid "Station Issue"
-msgstr ""
+msgstr "Problema na estação"
 
 #: lib/presentation_strings.ex:54
 #, elixir-autogen, elixir-format
 msgid "Station closed"
-msgstr ""
+msgstr "Estação fechada"
 
 #: lib/presentation_strings.ex:55
 #, elixir-autogen, elixir-format
 msgid "Station issue"
-msgstr ""
+msgstr "Problema na estação"
 
 #: lib/presentation_strings.ex:96
 #, elixir-autogen, elixir-format
 msgid "Stop Closure"
-msgstr ""
+msgstr "Fechamento de parada"
 
 #: lib/presentation_strings.ex:97
 #: lib/presentation_strings.ex:98
 #, elixir-autogen, elixir-format
 msgid "Stop Moved"
-msgstr ""
+msgstr "Parada movimentada"
 
 #: lib/presentation_strings.ex:99
 #, elixir-autogen, elixir-format
 msgid "Stop Shoveling"
-msgstr ""
+msgstr "Remoção de neve na parada"
 
 #: lib/presentation_strings.ex:56
 #, elixir-autogen, elixir-format
 msgid "Stop closed"
-msgstr ""
+msgstr "Parada fechada"
 
 #: lib/presentation_strings.ex:57
 #: lib/presentation_strings.ex:58
 #, elixir-autogen, elixir-format
 msgid "Stop moved"
-msgstr ""
+msgstr "Parada movimentada"
 
 #: lib/presentation_strings.ex:59
 #, elixir-autogen, elixir-format
 msgid "Stop shoveling"
-msgstr ""
+msgstr "Remoção de neve na parada"
 
 #: lib/presentation_strings.ex:219
 #, elixir-autogen, elixir-format
 msgid "Strike"
-msgstr ""
+msgstr "Greve"
 
 #: lib/presentation_strings.ex:60
 #: lib/presentation_strings.ex:100
 #, elixir-autogen, elixir-format
 msgid "Summary"
-msgstr ""
+msgstr "Resumo"
 
 #: lib/presentation_strings.ex:101
 #, elixir-autogen, elixir-format
 msgid "Suspension"
-msgstr ""
+msgstr "Suspensão"
 
 #: lib/presentation_strings.ex:220
 #, elixir-autogen, elixir-format
 msgid "Switch Issue"
-msgstr ""
+msgstr "Problema na agulha"
 
 #: lib/presentation_strings.ex:221
 #, elixir-autogen, elixir-format
 msgid "Switch Problem"
-msgstr ""
+msgstr "Problema de troca"
 
 #: lib/presentation_strings.ex:222
 #, elixir-autogen, elixir-format
 msgid "Technical Problem"
-msgstr ""
+msgstr "Problema técnico"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:263
 #, elixir-autogen, elixir-format
 msgid "This %{route_type}"
-msgstr ""
+msgstr "Este %{route_type}"
 
 #: lib/presentation_strings.ex:223
 #, elixir-autogen, elixir-format
 msgid "Tie Replacement"
-msgstr ""
+msgstr "Troca de pneu"
 
 #: lib/presentation_strings.ex:102
 #, elixir-autogen, elixir-format
 msgid "Track Change"
-msgstr ""
+msgstr "Alteração de trilho"
 
 #: lib/presentation_strings.ex:224
 #, elixir-autogen, elixir-format
 msgid "Track Problem"
-msgstr ""
+msgstr "Problema de trilho"
 
 #: lib/presentation_strings.ex:225
 #, elixir-autogen, elixir-format
 msgid "Track Work"
-msgstr ""
+msgstr "Obras no trilho"
 
 #: lib/presentation_strings.ex:62
 #, elixir-autogen, elixir-format
 msgid "Track change"
-msgstr ""
+msgstr "Alteração de trilho"
 
 #: lib/presentation_strings.ex:226
 #, elixir-autogen, elixir-format
 msgid "Traffic"
-msgstr ""
+msgstr "Tráfego"
 
 #: lib/presentation_strings.ex:227
 #, elixir-autogen, elixir-format
 msgid "Train Traffic"
-msgstr ""
+msgstr "Tráfego de trem"
 
 #: lib/presentation_strings.ex:35
 #, elixir-autogen, elixir-format
 msgid "Trip cancelled"
-msgstr ""
+msgstr "Viagem cancelada"
 
 #: lib/presentation_strings.ex:228
 #, elixir-autogen, elixir-format
 msgid "Unruly Passenger"
-msgstr ""
+msgstr "Passageiro indisciplinado"
 
 #: lib/presentation_strings.ex:229
 #, elixir-autogen, elixir-format
 msgid "Weather"
-msgstr ""
+msgstr "Clima"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:9
 #, elixir-autogen, elixir-format
 msgid "Westbound"
-msgstr ""
+msgstr "Sentido oeste"
 
 #: lib/presentation_strings.ex:111
 #, elixir-autogen, elixir-format
 msgid "accident"
-msgstr ""
+msgstr "acidente"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:424
 #, elixir-autogen, elixir-format
 msgid "affected by %{effect} %{day}"
-msgstr ""
+msgstr "afetado por %{effect} %{day}"
 
 #: lib/presentation_strings.ex:114
 #, elixir-autogen, elixir-format
 msgid "an earlier mechanical problem"
-msgstr ""
+msgstr "um problema mecânico anterior"
 
 #: lib/presentation_strings.ex:115
 #, elixir-autogen, elixir-format
 msgid "an earlier signal problem"
-msgstr ""
+msgstr "um problema de sinal anterior"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:382
 #, elixir-autogen, elixir-format
 msgid "are cancelled %{day}"
-msgstr ""
+msgstr "são cancelados %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:417
 #, elixir-autogen, elixir-format
 msgid "are suspended %{day}"
-msgstr ""
+msgstr "estão suspensos %{day}"
 
 #: lib/presentation_strings.ex:116
 #, elixir-autogen, elixir-format
 msgid "autos impeding service"
-msgstr ""
+msgstr "veículos impedindo o serviço"
 
 #: lib/presentation_strings.ex:12
 #, elixir-autogen, elixir-format
 msgid "bus"
-msgstr ""
+msgstr "ônibus"
 
 #: lib/presentation_strings.ex:13
 #, elixir-autogen, elixir-format
 msgid "buses"
-msgstr ""
+msgstr "ônibus"
 
 #: lib/presentation_strings.ex:118
 #, elixir-autogen, elixir-format
 msgid "congestion"
-msgstr ""
+msgstr "congestionamento"
 
 #: lib/presentation_strings.ex:119
 #, elixir-autogen, elixir-format
 msgid "construction"
-msgstr ""
+msgstr "construção"
 
 #: lib/presentation_strings.ex:120
 #, elixir-autogen, elixir-format
 msgid "crossing issue"
-msgstr ""
+msgstr "problema de travessia"
 
 #: lib/presentation_strings.ex:121
 #, elixir-autogen, elixir-format
 msgid "crossing malfunction"
-msgstr ""
+msgstr "mau funcionamento do cruzamento"
 
 #: lib/presentation_strings.ex:122
 #, elixir-autogen, elixir-format
 msgid "demonstration"
-msgstr ""
+msgstr "manifestação"
 
 #: lib/presentation_strings.ex:123
 #, elixir-autogen, elixir-format
 msgid "disabled bus"
-msgstr ""
+msgstr "ônibus com defeito"
 
 #: lib/presentation_strings.ex:124
 #, elixir-autogen, elixir-format
 msgid "disabled train"
-msgstr ""
+msgstr "trem com defeito"
 
 #: lib/presentation_strings.ex:125
 #, elixir-autogen, elixir-format
 msgid "drawbridge being raised"
-msgstr ""
+msgstr "ponte levadiça sendo levantada"
 
 #: lib/presentation_strings.ex:126
 #, elixir-autogen, elixir-format
 msgid "drawbridge issue"
-msgstr ""
+msgstr "problema da ponte levadiça"
 
 #: lib/presentation_strings.ex:127
 #, elixir-autogen, elixir-format
 msgid "electrical work"
-msgstr ""
+msgstr "serviço elétrico"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:193
 #, elixir-autogen, elixir-format
 msgid "end of service"
-msgstr ""
+msgstr "fim do serviço"
 
 #: lib/presentation_strings.ex:15
 #, elixir-autogen, elixir-format
 msgid "ferries"
-msgstr ""
+msgstr "balsas"
 
 #: lib/presentation_strings.ex:14
 #, elixir-autogen, elixir-format
 msgid "ferry"
-msgstr ""
+msgstr "balsa"
 
 #: lib/presentation_strings.ex:128
 #, elixir-autogen, elixir-format
 msgid "fire"
-msgstr ""
+msgstr "incêndio"
 
 #: lib/presentation_strings.ex:129
 #, elixir-autogen, elixir-format
 msgid "fire department activity"
-msgstr ""
+msgstr "atividade do corpo de bombeiros"
 
 #: lib/presentation_strings.ex:130
 #, elixir-autogen, elixir-format
 msgid "flooding"
-msgstr ""
+msgstr "inundação"
 
 #: lib/presentation_strings.ex:131
 #, elixir-autogen, elixir-format
 msgid "fog"
-msgstr ""
+msgstr "névoa"
 
 #: lib/presentation_strings.ex:132
 #, elixir-autogen, elixir-format
 msgid "freight train interference"
-msgstr ""
+msgstr "interferência de trem de carga"
 
 #: lib/presentation_strings.ex:133
 #, elixir-autogen, elixir-format
 msgid "hazmat condition"
-msgstr ""
+msgstr "condição de materiais perigosos"
 
 #: lib/presentation_strings.ex:134
 #, elixir-autogen, elixir-format
 msgid "heavy ridership"
-msgstr ""
+msgstr "grande volume de passageiros"
 
 #: lib/presentation_strings.ex:135
 #, elixir-autogen, elixir-format
 msgid "high winds"
-msgstr ""
+msgstr "ventos fortes"
 
 #: lib/presentation_strings.ex:136
 #, elixir-autogen, elixir-format
 msgid "holiday"
-msgstr ""
+msgstr "feriado"
 
 #: lib/presentation_strings.ex:137
 #, elixir-autogen, elixir-format
 msgid "hurricane"
-msgstr ""
+msgstr "furacão"
 
 #: lib/presentation_strings.ex:138
 #, elixir-autogen, elixir-format
 msgid "ice in harbor"
-msgstr ""
+msgstr "gelo no porto"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:385
 #, elixir-autogen, elixir-format
 msgid "is cancelled %{day}"
-msgstr ""
+msgstr "está cancelado %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:420
 #, elixir-autogen, elixir-format
 msgid "is suspended %{day}"
-msgstr ""
+msgstr "está suspenso %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:239
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_recurrence_end_day_later_date"
-msgstr ""
+msgstr " até %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:247
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_recurrence_end_day_this_week"
-msgstr ""
+msgstr " até %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:144
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_timeframe_later_date"
-msgstr ""
+msgstr " até %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:152
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_timeframe_this_week"
-msgstr ""
+msgstr " até %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:160
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_timeframe_time"
-msgstr ""
+msgstr " até %{1}"
 
 #: lib/presentation_strings.ex:139
 #, elixir-autogen, elixir-format
 msgid "maintenance"
-msgstr ""
+msgstr "manutenção"
 
 #: lib/presentation_strings.ex:140
 #, elixir-autogen, elixir-format
 msgid "mechanical issue"
-msgstr ""
+msgstr "problema mecânico"
 
 #: lib/presentation_strings.ex:141
 #, elixir-autogen, elixir-format
 msgid "mechanical problem"
-msgstr ""
+msgstr "problema mecânico"
 
 #: lib/presentation_strings.ex:142
 #, elixir-autogen, elixir-format
 msgid "medical emergency"
-msgstr ""
+msgstr "emergência médica"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:333
 #, elixir-autogen, elixir-format
 msgid "multiple trips"
-msgstr ""
+msgstr "múltiplas viagens"
 
 #: lib/presentation_strings.ex:143
 #, elixir-autogen, elixir-format
 msgid "parade"
-msgstr ""
+msgstr "desfile"
 
 #: lib/presentation_strings.ex:144
 #, elixir-autogen, elixir-format
 msgid "police action"
-msgstr ""
+msgstr "ação policial"
 
 #: lib/presentation_strings.ex:145
 #, elixir-autogen, elixir-format
 msgid "police activity"
-msgstr ""
+msgstr "atividade policial"
 
 #: lib/presentation_strings.ex:146
 #, elixir-autogen, elixir-format
 msgid "power problem"
-msgstr ""
+msgstr "problema de energia"
 
 #: lib/presentation_strings.ex:147
 #, elixir-autogen, elixir-format
 msgid "rail defect"
-msgstr ""
+msgstr "defeito nos trilhos"
 
 #: lib/presentation_strings.ex:148
 #, elixir-autogen, elixir-format
 msgid "severe weather"
-msgstr ""
+msgstr "clima severo"
 
 #: lib/presentation_strings.ex:149
 #, elixir-autogen, elixir-format
 msgid "signal issue"
-msgstr ""
+msgstr "problema de sinal"
 
 #: lib/presentation_strings.ex:150
 #, elixir-autogen, elixir-format
 msgid "signal problem"
-msgstr ""
+msgstr "problema de sinal"
 
 #: lib/presentation_strings.ex:151
 #, elixir-autogen, elixir-format
 msgid "single tracking"
-msgstr ""
+msgstr "via única"
 
 #: lib/presentation_strings.ex:152
 #, elixir-autogen, elixir-format
 msgid "slippery rail"
-msgstr ""
+msgstr "trilho escorregadio"
 
 #: lib/presentation_strings.ex:153
 #, elixir-autogen, elixir-format
 msgid "snow"
-msgstr ""
+msgstr "neve"
 
 #: lib/presentation_strings.ex:154
 #, elixir-autogen, elixir-format
 msgid "special event"
-msgstr ""
+msgstr "evento especial"
 
 #: lib/presentation_strings.ex:155
 #, elixir-autogen, elixir-format
 msgid "speed restriction"
-msgstr ""
+msgstr "restrição de velocidade"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:190
 #, elixir-autogen, elixir-format
 msgid "start of service"
-msgstr ""
+msgstr "início do serviço"
 
 #: lib/presentation_strings.ex:156
 #, elixir-autogen, elixir-format
 msgid "strike"
-msgstr ""
+msgstr "greve"
 
 #: lib/presentation_strings.ex:157
 #, elixir-autogen, elixir-format
 msgid "switch issue"
-msgstr ""
+msgstr "problema na agulha"
 
 #: lib/presentation_strings.ex:158
 #, elixir-autogen, elixir-format
 msgid "switch problem"
-msgstr ""
+msgstr "problema na agulha"
 
 #: lib/presentation_strings.ex:159
 #, elixir-autogen, elixir-format
 msgid "technical problem"
-msgstr ""
+msgstr "problema técnico"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:320
 #, elixir-autogen, elixir-format
 msgid "the **%{time}** %{vehicle}"
-msgstr ""
+msgstr "o **%{time}** %{vehicle}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:328
 #, elixir-autogen, elixir-format
 msgid "this %{vehicle}"
-msgstr ""
+msgstr "este %{vehicle}"
 
 #: lib/presentation_strings.ex:160
 #, elixir-autogen, elixir-format
 msgid "tie replacement"
-msgstr ""
+msgstr "substituição de dormentes"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:377
 #, elixir-autogen, elixir-format
 msgid "today"
-msgstr ""
+msgstr "hoje"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:377
 #, elixir-autogen, elixir-format
 msgid "tomorrow"
-msgstr ""
+msgstr "amanhã"
 
 #: lib/presentation_strings.ex:161
 #, elixir-autogen, elixir-format
 msgid "track problem"
-msgstr ""
+msgstr "problema nos trilhos"
 
 #: lib/presentation_strings.ex:162
 #, elixir-autogen, elixir-format
 msgid "track work"
-msgstr ""
+msgstr "trabalho nos trilhos"
 
 #: lib/presentation_strings.ex:163
 #, elixir-autogen, elixir-format
 msgid "traffic"
-msgstr ""
+msgstr "tráfego"
 
 #: lib/presentation_strings.ex:16
 #, elixir-autogen, elixir-format
 msgid "train"
-msgstr ""
+msgstr "trem"
 
 #: lib/presentation_strings.ex:164
 #, elixir-autogen, elixir-format
 msgid "train traffic"
-msgstr ""
+msgstr "tráfego de trem"
 
 #: lib/presentation_strings.ex:17
 #, elixir-autogen, elixir-format
 msgid "trains"
-msgstr ""
+msgstr "trens"
 
 #: lib/presentation_strings.ex:165
 #, elixir-autogen, elixir-format
 msgid "unruly passenger"
-msgstr ""
+msgstr "passageiro problemático"
 
 #: lib/presentation_strings.ex:166
 #, elixir-autogen, elixir-format
 msgid "weather"
-msgstr ""
+msgstr "clima"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:388
 #, elixir-autogen, elixir-format
 msgid "will not stop at %{stop_list} %{day}"
-msgstr ""
+msgstr "não vai parar em %{stop_list} %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:411
 #, elixir-autogen, elixir-format
 msgid "will terminate at %{terminating_stop} %{day}"
-msgstr ""
+msgstr "será encerrado em %{terminating_stop} %{day}"
 
 #: lib/mobile_app_backend_web/components/core_components.ex:484
 #, elixir-autogen, elixir-format, import-optional

--- a/priv/gettext/pt-BR/LC_MESSAGES/errors.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/errors.po
@@ -1,0 +1,12 @@
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: pt-BR\n"
+"Plural-Forms: nplurals=3\n"

--- a/priv/gettext/vi/LC_MESSAGES/default.po
+++ b/priv/gettext/vi/LC_MESSAGES/default.po
@@ -1,176 +1,176 @@
-## This file is a PO Template file.
-##
-## "msgid"s here are often extracted from source code.
-## Add new messages manually only if they're dynamic
-## messages that can't be statically extracted.
-##
-## Run "mix gettext.extract" to bring this file up to
-## date. Leave "msgstr"s empty as changing them here has no
-## effect: edit them in PO (.po) files instead.
-#
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
 msgid ""
 msgstr ""
+"Language: vi\n"
+"Plural-Forms: nplurals=1\n"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:101
 #, elixir-autogen, elixir-format
 msgid " at **%{stop_name}**"
-msgstr ""
+msgstr " tại **%{stop_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:210
 #, elixir-autogen, elixir-format
 msgid " daily%{recurrence_text}"
-msgstr ""
+msgstr " hằng ngày%{recurrence_text}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:434
 #, elixir-autogen, elixir-format
 msgid " due to %{cause}"
-msgstr ""
+msgstr " bởi vì %{cause}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:173
 #, elixir-autogen, elixir-format
 msgid " from %{start_time} to %{end_time}"
-msgstr ""
+msgstr " từ %{start_time} đến %{end_time}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:95
 #, elixir-autogen, elixir-format
 msgid " from **%{direction_name}** stops to **%{end_stop_name}**"
-msgstr ""
+msgstr " từ các điểm dừng **%{direction_name}** đến **%{end_stop_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:110
 #, elixir-autogen, elixir-format
 msgid " from **%{start_stop}** to **%{end_stop}**"
-msgstr ""
+msgstr " từ **%{start_stop}** đến **%{end_stop}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:104
 #, elixir-autogen, elixir-format
 msgid " from **%{stop_name}** to **%{direction_name}** stops"
-msgstr ""
+msgstr " từ **%{stop_name}** đến các điểm dừng **%{direction_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:121
 #, elixir-autogen, elixir-format
 msgid " on **%{mode_label}**"
-msgstr ""
+msgstr " trên **%{mode_label}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:117
 #, elixir-autogen, elixir-format
 msgid " replacing **%{mode_label}**"
-msgstr ""
+msgstr " thay thế **%{mode_label}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:219
 #, elixir-autogen, elixir-format
 msgid " some days%{recurrence_text}"
-msgstr ""
+msgstr " một số ngày%{recurrence_text}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:168
 #, elixir-autogen, elixir-format
 msgid " starting **%{formatted_time}** today"
-msgstr ""
+msgstr " bắt đầu từ **%{formatted_time}** hôm nay"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:165
 #, elixir-autogen, elixir-format
 msgid " starting tomorrow"
-msgstr ""
+msgstr " bắt đầu từ ngày mai"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:138
 #, elixir-autogen, elixir-format
 msgid " through end of service"
-msgstr ""
+msgstr " đến cuối dịch vụ"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:141
 #, elixir-autogen, elixir-format
 msgid " through tomorrow"
-msgstr ""
+msgstr " đến ngày mai"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:135
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:233
 #, elixir-autogen, elixir-format
 msgid " until further notice"
-msgstr ""
+msgstr " cho đến khi có thông báo mới"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:236
 #, elixir-autogen, elixir-format
 msgid " until tomorrow"
-msgstr ""
+msgstr " cho đến ngày mai"
 
 #: lib/mobile_app_backend/notifications/notification_title.ex:63
 #, elixir-autogen, elixir-format
 msgid "%{label} %{mode_label}"
-msgstr ""
+msgstr "%{label} %{mode_label}"
 
 #: lib/presentation_strings.ex:22
 #, elixir-autogen, elixir-format
 msgid "%{name} bus"
-msgstr ""
+msgstr "%{name} xe buýt"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:398
 #, elixir-autogen, elixir-format
 msgid "%{stop} and %{other_stops}"
-msgstr ""
+msgstr "%{stop} và %{other_stops}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:57
 #, elixir-autogen, elixir-format
 msgid "%{trip_identity} %{trip_effect}%{cause}%{recurrence}"
-msgstr ""
+msgstr "%{trip_identity} %{trip_effect}%{cause}%{recurrence}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:290
 #, elixir-autogen, elixir-format
 msgid "%{trip_identity} is replaced by shuttle buses from **%{start_stop}** to **%{end_stop}**%{recurrence}"
-msgstr ""
+msgstr "Tuyến %{trip_identity} được thay thế bằng xe buýt đưa đón từ **%{start_stop}** đến **%{end_stop}**%{recurrence}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:47
 #, elixir-autogen, elixir-format
 msgid "**%{effect_sentence_case}**%{summary_location}%{summary_timeframe}%{summary_recurrence}"
-msgstr ""
+msgstr "**%{effect_sentence_case}**%{summary_location}%{summary_timeframe}%{summary_recurrence}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:313
 #, elixir-autogen, elixir-format
 msgid "**%{time}** %{vehicle} from **%{from_stop}**"
-msgstr ""
+msgstr "**%{time}** %{vehicle} từ **%{from_stop}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:268
 #, elixir-autogen, elixir-format
 msgid "**%{trip_time}** %{route_type} from **%{stop_name}**"
-msgstr ""
+msgstr "**%{trip_time}** %{route_type} từ **%{stop_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:275
 #, elixir-autogen, elixir-format
 msgid "**%{trip_time}** %{route_type} to **%{headsign}**"
-msgstr ""
+msgstr "**%{trip_time}** %{route_type} đến **%{headsign}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:28
 #, elixir-autogen, elixir-format
 msgid "**All clear:** Regular service%{location}"
-msgstr ""
+msgstr "**Đã thông thoáng:** Dịch vụ thường lệ%{location}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:39
 #, elixir-autogen, elixir-format
 msgid "**Update:** %{effect_sentence_case}%{summary_location}%{summary_timeframe}%{summary_recurrence}"
-msgstr ""
+msgstr "**Cập nhật:** %{effect_sentence_case}%{summary_location}%{summary_timeframe}%{summary_recurrence}"
 
 #: lib/presentation_strings.ex:71
 #, elixir-autogen, elixir-format
 msgid "Access Issue"
-msgstr ""
+msgstr "Vấn đề về tiếp cận"
 
 #: lib/presentation_strings.ex:31
 #, elixir-autogen, elixir-format
 msgid "Access issue"
-msgstr ""
+msgstr "Vấn đề về tiếp cận"
 
 #: lib/presentation_strings.ex:174
 #, elixir-autogen, elixir-format
 msgid "Accident"
-msgstr ""
+msgstr "Tai nạn"
 
 #: lib/presentation_strings.ex:72
 #, elixir-autogen, elixir-format
 msgid "Additional Service"
-msgstr ""
+msgstr "Dịch vụ bổ sung"
 
 #: lib/presentation_strings.ex:32
 #, elixir-autogen, elixir-format
 msgid "Additional service"
-msgstr ""
+msgstr "Dịch vụ bổ sung"
 
 #: lib/presentation_strings.ex:63
 #: lib/presentation_strings.ex:64
@@ -178,1014 +178,1014 @@ msgstr ""
 #: lib/presentation_strings.ex:104
 #, elixir-autogen, elixir-format
 msgid "Alert"
-msgstr ""
+msgstr "Báo động"
 
 #: lib/presentation_strings.ex:73
 #, elixir-autogen, elixir-format
 msgid "Amber Alert"
-msgstr ""
+msgstr "Cảnh báo Amber"
 
 #: lib/presentation_strings.ex:33
 #, elixir-autogen, elixir-format
 msgid "Amber alert"
-msgstr ""
+msgstr "Cảnh báo Amber"
 
 #: lib/presentation_strings.ex:112
 #: lib/presentation_strings.ex:175
 #, elixir-autogen, elixir-format
 msgid "Amtrak"
-msgstr ""
+msgstr "Amtrak"
 
 #: lib/presentation_strings.ex:176
 #, elixir-autogen, elixir-format
 msgid "Amtrak Train Traffic"
-msgstr ""
+msgstr "Giao thông đường sắt Amtrak"
 
 #: lib/presentation_strings.ex:113
 #, elixir-autogen, elixir-format
 msgid "Amtrak train traffic"
-msgstr ""
+msgstr "Giao thông đường sắt Amtrak"
 
 #: lib/presentation_strings.ex:177
 #, elixir-autogen, elixir-format
 msgid "An Earlier Mechanical Problem"
-msgstr ""
+msgstr "Một vấn đề về cơ khí trước đó"
 
 #: lib/presentation_strings.ex:178
 #, elixir-autogen, elixir-format
 msgid "An Earlier Signal Problem"
-msgstr ""
+msgstr "Một vấn đề về đèn tín hiệu trước đó"
 
 #: lib/presentation_strings.ex:179
 #, elixir-autogen, elixir-format
 msgid "Autos Impeding Service"
-msgstr ""
+msgstr "Xe hơi cản trở dịch vụ"
 
 #: lib/presentation_strings.ex:74
 #, elixir-autogen, elixir-format
 msgid "Bike Issue"
-msgstr ""
+msgstr "Vấn đề về xe đạp"
 
 #: lib/presentation_strings.ex:34
 #, elixir-autogen, elixir-format
 msgid "Bike issue"
-msgstr ""
+msgstr "Vấn đề về xe đạp"
 
 #: lib/presentation_strings.ex:75
 #, elixir-autogen, elixir-format
 msgid "Cancellation"
-msgstr ""
+msgstr "Hủy"
 
 #: lib/presentation_strings.ex:180
 #, elixir-autogen, elixir-format
 msgid "Coast Guard Restriction"
-msgstr ""
+msgstr "Hạn chế của cảnh sát biển"
 
 #: lib/presentation_strings.ex:117
 #, elixir-autogen, elixir-format
 msgid "Coast Guard restriction"
-msgstr ""
+msgstr "Hạn chế của Cảnh sát biển"
 
 #: lib/presentation_strings.ex:181
 #, elixir-autogen, elixir-format
 msgid "Congestion"
-msgstr ""
+msgstr "Tắc nghẽn"
 
 #: lib/presentation_strings.ex:182
 #, elixir-autogen, elixir-format
 msgid "Construction"
-msgstr ""
+msgstr "Thi công"
 
 #: lib/presentation_strings.ex:183
 #, elixir-autogen, elixir-format
 msgid "Crossing Issue"
-msgstr ""
+msgstr "Vấn đề tại điểm giao cắt"
 
 #: lib/presentation_strings.ex:184
 #, elixir-autogen, elixir-format
 msgid "Crossing Malfunction"
-msgstr ""
+msgstr "Sự cố giao cắt"
 
 #: lib/presentation_strings.ex:36
 #: lib/presentation_strings.ex:76
 #, elixir-autogen, elixir-format
 msgid "Delay"
-msgstr ""
+msgstr "Trễ"
 
 #: lib/presentation_strings.ex:185
 #, elixir-autogen, elixir-format
 msgid "Demonstration"
-msgstr ""
+msgstr "Biểu tình"
 
 #: lib/presentation_strings.ex:37
 #: lib/presentation_strings.ex:77
 #, elixir-autogen, elixir-format
 msgid "Detour"
-msgstr ""
+msgstr "Đường vòng"
 
 #: lib/presentation_strings.ex:186
 #, elixir-autogen, elixir-format
 msgid "Disabled Bus"
-msgstr ""
+msgstr "Xe buýt bị sự cố"
 
 #: lib/presentation_strings.ex:187
 #, elixir-autogen, elixir-format
 msgid "Disabled Train"
-msgstr ""
+msgstr "Tàu bị sự cố"
 
 #: lib/presentation_strings.ex:78
 #, elixir-autogen, elixir-format
 msgid "Dock Closure"
-msgstr ""
+msgstr "Đóng bến tàu"
 
 #: lib/presentation_strings.ex:79
 #, elixir-autogen, elixir-format
 msgid "Dock Issue"
-msgstr ""
+msgstr "Vấn đề về bến tàu"
 
 #: lib/presentation_strings.ex:38
 #, elixir-autogen, elixir-format
 msgid "Dock closed"
-msgstr ""
+msgstr "Bến tàu đóng cửa"
 
 #: lib/presentation_strings.ex:39
 #, elixir-autogen, elixir-format
 msgid "Dock issue"
-msgstr ""
+msgstr "Vấn đề về bến tàu"
 
 #: lib/presentation_strings.ex:188
 #, elixir-autogen, elixir-format
 msgid "Drawbridge Being Raised"
-msgstr ""
+msgstr "Cầu rút đang nâng"
 
 #: lib/presentation_strings.ex:189
 #, elixir-autogen, elixir-format
 msgid "Drawbridge Issue"
-msgstr ""
+msgstr "Vấn đề cầu kéo"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:8
 #, elixir-autogen, elixir-format
 msgid "Eastbound"
-msgstr ""
+msgstr "Về hướng đông"
 
 #: lib/presentation_strings.ex:190
 #, elixir-autogen, elixir-format
 msgid "Electrical Work"
-msgstr ""
+msgstr "Thi công điện"
 
 #: lib/presentation_strings.ex:80
 #, elixir-autogen, elixir-format
 msgid "Elevator Closure"
-msgstr ""
+msgstr "Đóng thang máy"
 
 #: lib/presentation_strings.ex:40
 #, elixir-autogen, elixir-format
 msgid "Elevator closed"
-msgstr ""
+msgstr "Thang máy đóng cửa"
 
 #: lib/presentation_strings.ex:81
 #, elixir-autogen, elixir-format
 msgid "Escalator Closure"
-msgstr ""
+msgstr "Thang cuốn đóng cửa"
 
 #: lib/presentation_strings.ex:41
 #, elixir-autogen, elixir-format
 msgid "Escalator closed"
-msgstr ""
+msgstr "Thang cuốn đóng cửa"
 
 #: lib/presentation_strings.ex:82
 #, elixir-autogen, elixir-format
 msgid "Extra Service"
-msgstr ""
+msgstr "Dịch vụ bổ sung"
 
 #: lib/presentation_strings.ex:42
 #, elixir-autogen, elixir-format
 msgid "Extra service"
-msgstr ""
+msgstr "Dịch vụ bổ sung"
 
 #: lib/presentation_strings.ex:83
 #, elixir-autogen, elixir-format
 msgid "Facility Issue"
-msgstr ""
+msgstr "Vấn đề về cơ sở vật chất"
 
 #: lib/presentation_strings.ex:43
 #, elixir-autogen, elixir-format
 msgid "Facility issue"
-msgstr ""
+msgstr "Vấn đề về cơ sở vật chất"
 
 #: lib/presentation_strings.ex:191
 #, elixir-autogen, elixir-format
 msgid "Fire"
-msgstr ""
+msgstr "Hỏa hoạn"
 
 #: lib/presentation_strings.ex:192
 #, elixir-autogen, elixir-format
 msgid "Fire Department Activity"
-msgstr ""
+msgstr "Hoạt động của Sở Cứu Hỏa"
 
 #: lib/presentation_strings.ex:193
 #, elixir-autogen, elixir-format
 msgid "Flooding"
-msgstr ""
+msgstr "Lũ lụt"
 
 #: lib/presentation_strings.ex:194
 #, elixir-autogen, elixir-format
 msgid "Fog"
-msgstr ""
+msgstr "Sương mù"
 
 #: lib/presentation_strings.ex:195
 #, elixir-autogen, elixir-format
 msgid "Freight Train Interference"
-msgstr ""
+msgstr "Bị tàu chở hàng chặn"
 
 #: lib/presentation_strings.ex:196
 #, elixir-autogen, elixir-format
 msgid "Hazmat Condition"
-msgstr ""
+msgstr "Tình trạng có vật liệu nguy hiểm"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:17
 #, elixir-autogen, elixir-format
 msgid "Heading"
-msgstr ""
+msgstr "Tiêu đề"
 
 #: lib/presentation_strings.ex:197
 #, elixir-autogen, elixir-format
 msgid "Heavy Ridership"
-msgstr ""
+msgstr "Có đông người đi xe"
 
 #: lib/presentation_strings.ex:198
 #, elixir-autogen, elixir-format
 msgid "High Winds"
-msgstr ""
+msgstr "Gió mạnh"
 
 #: lib/presentation_strings.ex:199
 #, elixir-autogen, elixir-format
 msgid "Holiday"
-msgstr ""
+msgstr "Ngày lễ"
 
 #: lib/presentation_strings.ex:200
 #, elixir-autogen, elixir-format
 msgid "Hurricane"
-msgstr ""
+msgstr "Bão"
 
 #: lib/presentation_strings.ex:201
 #, elixir-autogen, elixir-format
 msgid "Ice In Harbor"
-msgstr ""
+msgstr "Băng ở cảng"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:10
 #, elixir-autogen, elixir-format
 msgid "Inbound"
-msgstr ""
+msgstr "Đến"
 
 #: lib/presentation_strings.ex:202
 #, elixir-autogen, elixir-format
 msgid "Maintenance"
-msgstr ""
+msgstr "Bảo trì"
 
 #: lib/presentation_strings.ex:203
 #, elixir-autogen, elixir-format
 msgid "Mechanical Issue"
-msgstr ""
+msgstr "Vấn đề cơ khí"
 
 #: lib/presentation_strings.ex:204
 #, elixir-autogen, elixir-format
 msgid "Mechanical Problem"
-msgstr ""
+msgstr "Vấn đề cơ khí"
 
 #: lib/presentation_strings.ex:205
 #, elixir-autogen, elixir-format
 msgid "Medical Emergency"
-msgstr ""
+msgstr "Cấp cứu y tế"
 
 #: lib/presentation_strings.ex:84
 #, elixir-autogen, elixir-format
 msgid "Modified Service"
-msgstr ""
+msgstr "Dịch vụ đã sửa đổi"
 
 #: lib/presentation_strings.ex:44
 #, elixir-autogen, elixir-format
 msgid "Modified service"
-msgstr ""
+msgstr "Dịch vụ đã sửa đổi"
 
 #: lib/mobile_app_backend/notifications/notification_title.ex:69
 #, elixir-autogen, elixir-format
 msgid "Multiple routes"
-msgstr ""
+msgstr "Nhiều tuyến đường"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:282
 #, elixir-autogen, elixir-format
 msgid "Multiple trips"
-msgstr ""
+msgstr "Nhiều chuyến đi"
 
 #: lib/presentation_strings.ex:85
 #, elixir-autogen, elixir-format
 msgid "No Service"
-msgstr ""
+msgstr "Không có dịch vụ"
 
 #: lib/presentation_strings.ex:45
 #, elixir-autogen, elixir-format
 msgid "No service"
-msgstr ""
+msgstr "Không có dịch vụ"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:6
 #, elixir-autogen, elixir-format
 msgid "Northbound"
-msgstr ""
+msgstr "Về hướng bắc"
 
 #: lib/presentation_strings.ex:46
 #: lib/presentation_strings.ex:86
 #, elixir-autogen, elixir-format
 msgid "Notice"
-msgstr ""
+msgstr "Để ý"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:11
 #, elixir-autogen, elixir-format
 msgid "Outbound"
-msgstr ""
+msgstr "Đi"
 
 #: lib/presentation_strings.ex:206
 #, elixir-autogen, elixir-format
 msgid "Parade"
-msgstr ""
+msgstr "Cuộc diễu hành"
 
 #: lib/presentation_strings.ex:87
 #, elixir-autogen, elixir-format
 msgid "Parking Closure"
-msgstr ""
+msgstr "Bãi đậu xe đóng cửa"
 
 #: lib/presentation_strings.ex:88
 #, elixir-autogen, elixir-format
 msgid "Parking Issue"
-msgstr ""
+msgstr "Vấn đề về đậu xe"
 
 #: lib/presentation_strings.ex:47
 #, elixir-autogen, elixir-format
 msgid "Parking closed"
-msgstr ""
+msgstr "Bãi đậu xe đóng"
 
 #: lib/presentation_strings.ex:48
 #, elixir-autogen, elixir-format
 msgid "Parking issue"
-msgstr ""
+msgstr "Vấn đề về đậu xe"
 
 #: lib/presentation_strings.ex:207
 #, elixir-autogen, elixir-format
 msgid "Police Action"
-msgstr ""
+msgstr "Hành động của cảnh sát"
 
 #: lib/presentation_strings.ex:208
 #, elixir-autogen, elixir-format
 msgid "Police Activity"
-msgstr ""
+msgstr "Hoạt động của cảnh sát"
 
 #: lib/presentation_strings.ex:89
 #, elixir-autogen, elixir-format
 msgid "Policy Change"
-msgstr ""
+msgstr "Thay đổi chính sách"
 
 #: lib/presentation_strings.ex:49
 #, elixir-autogen, elixir-format
 msgid "Policy change"
-msgstr ""
+msgstr "Thay đổi chính sách"
 
 #: lib/presentation_strings.ex:209
 #, elixir-autogen, elixir-format
 msgid "Power Problem"
-msgstr ""
+msgstr "Vấn đề về điện"
 
 #: lib/presentation_strings.ex:210
 #, elixir-autogen, elixir-format
 msgid "Rail Defect"
-msgstr ""
+msgstr "Lỗi đường sắt"
 
 #: lib/presentation_strings.ex:90
 #, elixir-autogen, elixir-format
 msgid "Schedule Change"
-msgstr ""
+msgstr "Thay đổi lịch trình"
 
 #: lib/presentation_strings.ex:50
 #, elixir-autogen, elixir-format
 msgid "Schedule change"
-msgstr ""
+msgstr "Thay đổi lịch trình"
 
 #: lib/presentation_strings.ex:91
 #, elixir-autogen, elixir-format
 msgid "Service Change"
-msgstr ""
+msgstr "Thay đổi dịch vụ"
 
 #: lib/presentation_strings.ex:51
 #, elixir-autogen, elixir-format
 msgid "Service change"
-msgstr ""
+msgstr "Thay đổi dịch vụ"
 
 #: lib/presentation_strings.ex:61
 #, elixir-autogen, elixir-format
 msgid "Service suspended"
-msgstr ""
+msgstr "Dịch vụ bị đình chỉ"
 
 #: lib/presentation_strings.ex:211
 #, elixir-autogen, elixir-format
 msgid "Severe Weather"
-msgstr ""
+msgstr "Thời tiết khắc nghiệt"
 
 #: lib/presentation_strings.ex:92
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
-msgstr ""
+msgstr "Xe đưa đón"
 
 #: lib/presentation_strings.ex:52
 #, elixir-autogen, elixir-format
 msgid "Shuttle buses"
-msgstr ""
+msgstr "Xe buýt đưa đón"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:298
 #, elixir-autogen, elixir-format
 msgid "Shuttle buses replace %{trip_identity} from **%{start_stop}** to **%{end_stop}**%{recurrence}"
-msgstr ""
+msgstr "Xe buýt đưa đón thay thế %{trip_identity} từ **%{start_stop}** đến **%{end_stop}**%{recurrence}"
 
 #: lib/presentation_strings.ex:212
 #, elixir-autogen, elixir-format
 msgid "Signal Issue"
-msgstr ""
+msgstr "Vấn đề đèn tín hiệu"
 
 #: lib/presentation_strings.ex:213
 #, elixir-autogen, elixir-format
 msgid "Signal Problem"
-msgstr ""
+msgstr "Vấn đề đèn tín hiệu"
 
 #: lib/presentation_strings.ex:214
 #, elixir-autogen, elixir-format
 msgid "Single Tracking"
-msgstr ""
+msgstr "Đường ray đơn"
 
 #: lib/presentation_strings.ex:215
 #, elixir-autogen, elixir-format
 msgid "Slippery Rail"
-msgstr ""
+msgstr "Đường ray trơn trượt"
 
 #: lib/presentation_strings.ex:216
 #, elixir-autogen, elixir-format
 msgid "Snow"
-msgstr ""
+msgstr "Tuyết"
 
 #: lib/presentation_strings.ex:93
 #, elixir-autogen, elixir-format
 msgid "Snow Route"
-msgstr ""
+msgstr "Tuyến đường có tuyết"
 
 #: lib/presentation_strings.ex:53
 #, elixir-autogen, elixir-format
 msgid "Snow route"
-msgstr ""
+msgstr "Tuyến đường tuyết"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:7
 #, elixir-autogen, elixir-format
 msgid "Southbound"
-msgstr ""
+msgstr "Về hướng nam"
 
 #: lib/presentation_strings.ex:217
 #, elixir-autogen, elixir-format
 msgid "Special Event"
-msgstr ""
+msgstr "Sự kiện đặc biệt"
 
 #: lib/presentation_strings.ex:218
 #, elixir-autogen, elixir-format
 msgid "Speed Restriction"
-msgstr ""
+msgstr "Giới hạn tốc độ"
 
 #: lib/presentation_strings.ex:94
 #, elixir-autogen, elixir-format
 msgid "Station Closure"
-msgstr ""
+msgstr "Đóng ga"
 
 #: lib/presentation_strings.ex:95
 #, elixir-autogen, elixir-format
 msgid "Station Issue"
-msgstr ""
+msgstr "Vấn đề về nhà ga/trạm dừng"
 
 #: lib/presentation_strings.ex:54
 #, elixir-autogen, elixir-format
 msgid "Station closed"
-msgstr ""
+msgstr "Nhà ga/trạm dừng đóng cửa"
 
 #: lib/presentation_strings.ex:55
 #, elixir-autogen, elixir-format
 msgid "Station issue"
-msgstr ""
+msgstr "Vấn đề về nhà ga/trạm dừng"
 
 #: lib/presentation_strings.ex:96
 #, elixir-autogen, elixir-format
 msgid "Stop Closure"
-msgstr ""
+msgstr "Đóng điểm dừng"
 
 #: lib/presentation_strings.ex:97
 #: lib/presentation_strings.ex:98
 #, elixir-autogen, elixir-format
 msgid "Stop Moved"
-msgstr ""
+msgstr "Điểm dừng đã di chuyển"
 
 #: lib/presentation_strings.ex:99
 #, elixir-autogen, elixir-format
 msgid "Stop Shoveling"
-msgstr ""
+msgstr "Dừng việc xúc tuyết"
 
 #: lib/presentation_strings.ex:56
 #, elixir-autogen, elixir-format
 msgid "Stop closed"
-msgstr ""
+msgstr "Điểm dừng bị đóng"
 
 #: lib/presentation_strings.ex:57
 #: lib/presentation_strings.ex:58
 #, elixir-autogen, elixir-format
 msgid "Stop moved"
-msgstr ""
+msgstr "Điểm dừng đã di chuyển"
 
 #: lib/presentation_strings.ex:59
 #, elixir-autogen, elixir-format
 msgid "Stop shoveling"
-msgstr ""
+msgstr "Dừng việc xúc tuyết"
 
 #: lib/presentation_strings.ex:219
 #, elixir-autogen, elixir-format
 msgid "Strike"
-msgstr ""
+msgstr "Biểu tình"
 
 #: lib/presentation_strings.ex:60
 #: lib/presentation_strings.ex:100
 #, elixir-autogen, elixir-format
 msgid "Summary"
-msgstr ""
+msgstr "Bản tóm tắt"
 
 #: lib/presentation_strings.ex:101
 #, elixir-autogen, elixir-format
 msgid "Suspension"
-msgstr ""
+msgstr "Đình chỉ"
 
 #: lib/presentation_strings.ex:220
 #, elixir-autogen, elixir-format
 msgid "Switch Issue"
-msgstr ""
+msgstr "Vấn đề chuyển đổi"
 
 #: lib/presentation_strings.ex:221
 #, elixir-autogen, elixir-format
 msgid "Switch Problem"
-msgstr ""
+msgstr "Vấn đề chuyển đổi"
 
 #: lib/presentation_strings.ex:222
 #, elixir-autogen, elixir-format
 msgid "Technical Problem"
-msgstr ""
+msgstr "Vấn đề kỹ thuật"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:263
 #, elixir-autogen, elixir-format
 msgid "This %{route_type}"
-msgstr ""
+msgstr "Cái này %{route_type}"
 
 #: lib/presentation_strings.ex:223
 #, elixir-autogen, elixir-format
 msgid "Tie Replacement"
-msgstr ""
+msgstr "Thay tà vẹt"
 
 #: lib/presentation_strings.ex:102
 #, elixir-autogen, elixir-format
 msgid "Track Change"
-msgstr ""
+msgstr "Thay đổi đường ray"
 
 #: lib/presentation_strings.ex:224
 #, elixir-autogen, elixir-format
 msgid "Track Problem"
-msgstr ""
+msgstr "Vấn đề về đường ray"
 
 #: lib/presentation_strings.ex:225
 #, elixir-autogen, elixir-format
 msgid "Track Work"
-msgstr ""
+msgstr "Thi công đường ray"
 
 #: lib/presentation_strings.ex:62
 #, elixir-autogen, elixir-format
 msgid "Track change"
-msgstr ""
+msgstr "Thay đổi đường ray"
 
 #: lib/presentation_strings.ex:226
 #, elixir-autogen, elixir-format
 msgid "Traffic"
-msgstr ""
+msgstr "Giao thông"
 
 #: lib/presentation_strings.ex:227
 #, elixir-autogen, elixir-format
 msgid "Train Traffic"
-msgstr ""
+msgstr "Giao thông đường sắt"
 
 #: lib/presentation_strings.ex:35
 #, elixir-autogen, elixir-format
 msgid "Trip cancelled"
-msgstr ""
+msgstr "Chuyến đi đã bị hủy"
 
 #: lib/presentation_strings.ex:228
 #, elixir-autogen, elixir-format
 msgid "Unruly Passenger"
-msgstr ""
+msgstr "Hành khách ngỗ ngược"
 
 #: lib/presentation_strings.ex:229
 #, elixir-autogen, elixir-format
 msgid "Weather"
-msgstr ""
+msgstr "Thời tiết"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:9
 #, elixir-autogen, elixir-format
 msgid "Westbound"
-msgstr ""
+msgstr "Về hướng tây"
 
 #: lib/presentation_strings.ex:111
 #, elixir-autogen, elixir-format
 msgid "accident"
-msgstr ""
+msgstr "tai nạn"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:424
 #, elixir-autogen, elixir-format
 msgid "affected by %{effect} %{day}"
-msgstr ""
+msgstr "bị ảnh hưởng bởi %{effect} %{day}"
 
 #: lib/presentation_strings.ex:114
 #, elixir-autogen, elixir-format
 msgid "an earlier mechanical problem"
-msgstr ""
+msgstr "một vấn đề cơ khí trước đó"
 
 #: lib/presentation_strings.ex:115
 #, elixir-autogen, elixir-format
 msgid "an earlier signal problem"
-msgstr ""
+msgstr "vấn đề về đèn tín hiệu trước đó"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:382
 #, elixir-autogen, elixir-format
 msgid "are cancelled %{day}"
-msgstr ""
+msgstr "bị hủy bỏ %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:417
 #, elixir-autogen, elixir-format
 msgid "are suspended %{day}"
-msgstr ""
+msgstr "bị đình chỉ %{day}"
 
 #: lib/presentation_strings.ex:116
 #, elixir-autogen, elixir-format
 msgid "autos impeding service"
-msgstr ""
+msgstr "xe hơi cản trở dịch vụ"
 
 #: lib/presentation_strings.ex:12
 #, elixir-autogen, elixir-format
 msgid "bus"
-msgstr ""
+msgstr "xe buýt"
 
 #: lib/presentation_strings.ex:13
 #, elixir-autogen, elixir-format
 msgid "buses"
-msgstr ""
+msgstr "xe buýt"
 
 #: lib/presentation_strings.ex:118
 #, elixir-autogen, elixir-format
 msgid "congestion"
-msgstr ""
+msgstr "sự cố tắc nghẽn"
 
 #: lib/presentation_strings.ex:119
 #, elixir-autogen, elixir-format
 msgid "construction"
-msgstr ""
+msgstr "hạt động thi công"
 
 #: lib/presentation_strings.ex:120
 #, elixir-autogen, elixir-format
 msgid "crossing issue"
-msgstr ""
+msgstr "vấn đề tại điểm giao cắt"
 
 #: lib/presentation_strings.ex:121
 #, elixir-autogen, elixir-format
 msgid "crossing malfunction"
-msgstr ""
+msgstr "sự cố tại điểm giao cắt"
 
 #: lib/presentation_strings.ex:122
 #, elixir-autogen, elixir-format
 msgid "demonstration"
-msgstr ""
+msgstr "cuộc biểu tình"
 
 #: lib/presentation_strings.ex:123
 #, elixir-autogen, elixir-format
 msgid "disabled bus"
-msgstr ""
+msgstr "sự cố xe buýt"
 
 #: lib/presentation_strings.ex:124
 #, elixir-autogen, elixir-format
 msgid "disabled train"
-msgstr ""
+msgstr "sự cố tàu"
 
 #: lib/presentation_strings.ex:125
 #, elixir-autogen, elixir-format
 msgid "drawbridge being raised"
-msgstr ""
+msgstr "cầu kéo đang được nâng lên"
 
 #: lib/presentation_strings.ex:126
 #, elixir-autogen, elixir-format
 msgid "drawbridge issue"
-msgstr ""
+msgstr "vấn đề cầu kéo"
 
 #: lib/presentation_strings.ex:127
 #, elixir-autogen, elixir-format
 msgid "electrical work"
-msgstr ""
+msgstr "công việc về điện"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:193
 #, elixir-autogen, elixir-format
 msgid "end of service"
-msgstr ""
+msgstr "kết thúc dịch vụ"
 
 #: lib/presentation_strings.ex:15
 #, elixir-autogen, elixir-format
 msgid "ferries"
-msgstr ""
+msgstr "phà"
 
 #: lib/presentation_strings.ex:14
 #, elixir-autogen, elixir-format
 msgid "ferry"
-msgstr ""
+msgstr "phà"
 
 #: lib/presentation_strings.ex:128
 #, elixir-autogen, elixir-format
 msgid "fire"
-msgstr ""
+msgstr "cháy"
 
 #: lib/presentation_strings.ex:129
 #, elixir-autogen, elixir-format
 msgid "fire department activity"
-msgstr ""
+msgstr "hoạt động cứu hỏa"
 
 #: lib/presentation_strings.ex:130
 #, elixir-autogen, elixir-format
 msgid "flooding"
-msgstr ""
+msgstr "lũ lụt"
 
 #: lib/presentation_strings.ex:131
 #, elixir-autogen, elixir-format
 msgid "fog"
-msgstr ""
+msgstr "sương mù"
 
 #: lib/presentation_strings.ex:132
 #, elixir-autogen, elixir-format
 msgid "freight train interference"
-msgstr ""
+msgstr "ảnh hưởng của tàu hàng"
 
 #: lib/presentation_strings.ex:133
 #, elixir-autogen, elixir-format
 msgid "hazmat condition"
-msgstr ""
+msgstr "tình trạng nguy hiểm"
 
 #: lib/presentation_strings.ex:134
 #, elixir-autogen, elixir-format
 msgid "heavy ridership"
-msgstr ""
+msgstr "có đông người đi xe"
 
 #: lib/presentation_strings.ex:135
 #, elixir-autogen, elixir-format
 msgid "high winds"
-msgstr ""
+msgstr "gió lớn"
 
 #: lib/presentation_strings.ex:136
 #, elixir-autogen, elixir-format
 msgid "holiday"
-msgstr ""
+msgstr "ngày lễ"
 
 #: lib/presentation_strings.ex:137
 #, elixir-autogen, elixir-format
 msgid "hurricane"
-msgstr ""
+msgstr "cơn bão"
 
 #: lib/presentation_strings.ex:138
 #, elixir-autogen, elixir-format
 msgid "ice in harbor"
-msgstr ""
+msgstr "băng ở bến cảng"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:385
 #, elixir-autogen, elixir-format
 msgid "is cancelled %{day}"
-msgstr ""
+msgstr "đã bị hủy %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:420
 #, elixir-autogen, elixir-format
 msgid "is suspended %{day}"
-msgstr ""
+msgstr "bị đình chỉ %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:239
-#, elixir-autogen, elixir-format
+#, elixir-autogen, elixir-format, fuzzy
 msgid "key/alert_summary_recurrence_end_day_later_date"
-msgstr ""
+msgstr " cho đến khi %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:247
-#, elixir-autogen, elixir-format
+#, elixir-autogen, elixir-format, fuzzy
 msgid "key/alert_summary_recurrence_end_day_this_week"
-msgstr ""
+msgstr " cho đến khi %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:144
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_timeframe_later_date"
-msgstr ""
+msgstr " đến %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:152
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_timeframe_this_week"
-msgstr ""
+msgstr " đến %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:160
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_timeframe_time"
-msgstr ""
+msgstr " đến %{1}"
 
 #: lib/presentation_strings.ex:139
 #, elixir-autogen, elixir-format
 msgid "maintenance"
-msgstr ""
+msgstr "bảo trì"
 
 #: lib/presentation_strings.ex:140
 #, elixir-autogen, elixir-format
 msgid "mechanical issue"
-msgstr ""
+msgstr "vấn đề cơ khí"
 
 #: lib/presentation_strings.ex:141
 #, elixir-autogen, elixir-format
 msgid "mechanical problem"
-msgstr ""
+msgstr "vấn đề cơ khí"
 
 #: lib/presentation_strings.ex:142
 #, elixir-autogen, elixir-format
 msgid "medical emergency"
-msgstr ""
+msgstr "cấp cứu y tế"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:333
 #, elixir-autogen, elixir-format
 msgid "multiple trips"
-msgstr ""
+msgstr "nhiều chuyến đi"
 
 #: lib/presentation_strings.ex:143
 #, elixir-autogen, elixir-format
 msgid "parade"
-msgstr ""
+msgstr "cuộc diễu hành"
 
 #: lib/presentation_strings.ex:144
 #, elixir-autogen, elixir-format
 msgid "police action"
-msgstr ""
+msgstr "hành động của cảnh sát"
 
 #: lib/presentation_strings.ex:145
 #, elixir-autogen, elixir-format
 msgid "police activity"
-msgstr ""
+msgstr "hoạt động của cảnh sát"
 
 #: lib/presentation_strings.ex:146
 #, elixir-autogen, elixir-format
 msgid "power problem"
-msgstr ""
+msgstr "vấn đề về điện"
 
 #: lib/presentation_strings.ex:147
 #, elixir-autogen, elixir-format
 msgid "rail defect"
-msgstr ""
+msgstr "lỗi đường sắt"
 
 #: lib/presentation_strings.ex:148
 #, elixir-autogen, elixir-format
 msgid "severe weather"
-msgstr ""
+msgstr "thời tiết khắc nghiệt"
 
 #: lib/presentation_strings.ex:149
 #, elixir-autogen, elixir-format
 msgid "signal issue"
-msgstr ""
+msgstr "vấn đề đèn tín hiệu"
 
 #: lib/presentation_strings.ex:150
 #, elixir-autogen, elixir-format
 msgid "signal problem"
-msgstr ""
+msgstr "vấn đề đèn tín hiệu"
 
 #: lib/presentation_strings.ex:151
 #, elixir-autogen, elixir-format
 msgid "single tracking"
-msgstr ""
+msgstr "đường ray đơn"
 
 #: lib/presentation_strings.ex:152
 #, elixir-autogen, elixir-format
 msgid "slippery rail"
-msgstr ""
+msgstr "đường ray trơn trượt"
 
 #: lib/presentation_strings.ex:153
 #, elixir-autogen, elixir-format
 msgid "snow"
-msgstr ""
+msgstr "tuyết"
 
 #: lib/presentation_strings.ex:154
 #, elixir-autogen, elixir-format
 msgid "special event"
-msgstr ""
+msgstr "sự kiện đặc biệt"
 
 #: lib/presentation_strings.ex:155
 #, elixir-autogen, elixir-format
 msgid "speed restriction"
-msgstr ""
+msgstr "hạn chế tốc độ"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:190
 #, elixir-autogen, elixir-format
 msgid "start of service"
-msgstr ""
+msgstr "bắt đầu dịch vụ"
 
 #: lib/presentation_strings.ex:156
 #, elixir-autogen, elixir-format
 msgid "strike"
-msgstr ""
+msgstr "biểu tình"
 
 #: lib/presentation_strings.ex:157
 #, elixir-autogen, elixir-format
 msgid "switch issue"
-msgstr ""
+msgstr "vấn đề chuyển đổi"
 
 #: lib/presentation_strings.ex:158
 #, elixir-autogen, elixir-format
 msgid "switch problem"
-msgstr ""
+msgstr "vấn đề chuyển đổi"
 
 #: lib/presentation_strings.ex:159
 #, elixir-autogen, elixir-format
 msgid "technical problem"
-msgstr ""
+msgstr "vấn đề kỹ thuật"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:320
 #, elixir-autogen, elixir-format
 msgid "the **%{time}** %{vehicle}"
-msgstr ""
+msgstr "cái **%{time}** %{vehicle}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:328
 #, elixir-autogen, elixir-format
 msgid "this %{vehicle}"
-msgstr ""
+msgstr "cái này %{vehicle}"
 
 #: lib/presentation_strings.ex:160
 #, elixir-autogen, elixir-format
 msgid "tie replacement"
-msgstr ""
+msgstr "thay tà vẹt"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:377
 #, elixir-autogen, elixir-format
 msgid "today"
-msgstr ""
+msgstr "Hôm nay"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:377
 #, elixir-autogen, elixir-format
 msgid "tomorrow"
-msgstr ""
+msgstr "Ngày mai"
 
 #: lib/presentation_strings.ex:161
 #, elixir-autogen, elixir-format
 msgid "track problem"
-msgstr ""
+msgstr "vấn đề về đường ray"
 
 #: lib/presentation_strings.ex:162
 #, elixir-autogen, elixir-format
 msgid "track work"
-msgstr ""
+msgstr "thi công đường ray"
 
 #: lib/presentation_strings.ex:163
 #, elixir-autogen, elixir-format
 msgid "traffic"
-msgstr ""
+msgstr "giao thông"
 
 #: lib/presentation_strings.ex:16
 #, elixir-autogen, elixir-format
 msgid "train"
-msgstr ""
+msgstr "tàu"
 
 #: lib/presentation_strings.ex:164
 #, elixir-autogen, elixir-format
 msgid "train traffic"
-msgstr ""
+msgstr "giao thông đường sắt"
 
 #: lib/presentation_strings.ex:17
 #, elixir-autogen, elixir-format
 msgid "trains"
-msgstr ""
+msgstr "tàu"
 
 #: lib/presentation_strings.ex:165
 #, elixir-autogen, elixir-format
 msgid "unruly passenger"
-msgstr ""
+msgstr "hành khách ngỗ ngược"
 
 #: lib/presentation_strings.ex:166
 #, elixir-autogen, elixir-format
 msgid "weather"
-msgstr ""
+msgstr "thời tiết"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:388
 #, elixir-autogen, elixir-format
 msgid "will not stop at %{stop_list} %{day}"
-msgstr ""
+msgstr "sẽ không dừng lại ở %{stop_list} %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:411
 #, elixir-autogen, elixir-format
 msgid "will terminate at %{terminating_stop} %{day}"
-msgstr ""
+msgstr "sẽ kết thúc tại %{terminating_stop} %{day}"
 
 #: lib/mobile_app_backend_web/components/core_components.ex:484
 #, elixir-autogen, elixir-format, import-optional

--- a/priv/gettext/vi/LC_MESSAGES/errors.po
+++ b/priv/gettext/vi/LC_MESSAGES/errors.po
@@ -1,0 +1,12 @@
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: vi\n"
+"Plural-Forms: nplurals=1\n"

--- a/priv/gettext/zh-Hans-CN/LC_MESSAGES/default.po
+++ b/priv/gettext/zh-Hans-CN/LC_MESSAGES/default.po
@@ -1,176 +1,176 @@
-## This file is a PO Template file.
-##
-## "msgid"s here are often extracted from source code.
-## Add new messages manually only if they're dynamic
-## messages that can't be statically extracted.
-##
-## Run "mix gettext.extract" to bring this file up to
-## date. Leave "msgstr"s empty as changing them here has no
-## effect: edit them in PO (.po) files instead.
-#
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
 msgid ""
 msgstr ""
+"Language: zh-Hans-CN\n"
+"Plural-Forms: nplurals=1\n"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:101
 #, elixir-autogen, elixir-format
 msgid " at **%{stop_name}**"
-msgstr ""
+msgstr " 在**%{stop_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:210
 #, elixir-autogen, elixir-format
 msgid " daily%{recurrence_text}"
-msgstr ""
+msgstr " 日常的%{recurrence_text}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:434
 #, elixir-autogen, elixir-format
 msgid " due to %{cause}"
-msgstr ""
+msgstr " 由于 %{cause}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:173
 #, elixir-autogen, elixir-format
 msgid " from %{start_time} to %{end_time}"
-msgstr ""
+msgstr " 从 %{start_time} 到 %{end_time}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:95
 #, elixir-autogen, elixir-format
 msgid " from **%{direction_name}** stops to **%{end_stop_name}**"
-msgstr ""
+msgstr " 从**%{direction_name}**站到**%{end_stop_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:110
 #, elixir-autogen, elixir-format
 msgid " from **%{start_stop}** to **%{end_stop}**"
-msgstr ""
+msgstr " 从**%{start_stop}**到**%{end_stop}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:104
 #, elixir-autogen, elixir-format
 msgid " from **%{stop_name}** to **%{direction_name}** stops"
-msgstr ""
+msgstr " 从**%{stop_name}**到**%{direction_name}**站"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:121
 #, elixir-autogen, elixir-format
 msgid " on **%{mode_label}**"
-msgstr ""
+msgstr " 在 **%{mode_label}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:117
 #, elixir-autogen, elixir-format
 msgid " replacing **%{mode_label}**"
-msgstr ""
+msgstr " 替换 **%{mode_label}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:219
 #, elixir-autogen, elixir-format
 msgid " some days%{recurrence_text}"
-msgstr ""
+msgstr "%{recurrence_text}有些日子"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:168
 #, elixir-autogen, elixir-format
 msgid " starting **%{formatted_time}** today"
-msgstr ""
+msgstr " 从今天**%{formatted_time}**开始"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:165
 #, elixir-autogen, elixir-format
 msgid " starting tomorrow"
-msgstr ""
+msgstr " 从明天开始"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:138
 #, elixir-autogen, elixir-format
 msgid " through end of service"
-msgstr ""
+msgstr " 直至服务结束"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:141
 #, elixir-autogen, elixir-format
 msgid " through tomorrow"
-msgstr ""
+msgstr " 直至明天"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:135
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:233
 #, elixir-autogen, elixir-format
 msgid " until further notice"
-msgstr ""
+msgstr " 等待进一步通知"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:236
 #, elixir-autogen, elixir-format
 msgid " until tomorrow"
-msgstr ""
+msgstr " 直到明天"
 
 #: lib/mobile_app_backend/notifications/notification_title.ex:63
 #, elixir-autogen, elixir-format
 msgid "%{label} %{mode_label}"
-msgstr ""
+msgstr "%{label} %{mode_label}"
 
 #: lib/presentation_strings.ex:22
 #, elixir-autogen, elixir-format
 msgid "%{name} bus"
-msgstr ""
+msgstr "%{name}巴士"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:398
 #, elixir-autogen, elixir-format
 msgid "%{stop} and %{other_stops}"
-msgstr ""
+msgstr "%{stop} 和 %{other_stops}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:57
 #, elixir-autogen, elixir-format
 msgid "%{trip_identity} %{trip_effect}%{cause}%{recurrence}"
-msgstr ""
+msgstr "%{trip_identity} %{trip_effect}%{cause}%{recurrence}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:290
 #, elixir-autogen, elixir-format
 msgid "%{trip_identity} is replaced by shuttle buses from **%{start_stop}** to **%{end_stop}**%{recurrence}"
-msgstr ""
+msgstr "%{trip_identity} 由 **%{start_stop}** 到 **%{end_stop}**%{recurrence} 的接驳巴士替代"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:47
 #, elixir-autogen, elixir-format
 msgid "**%{effect_sentence_case}**%{summary_location}%{summary_timeframe}%{summary_recurrence}"
-msgstr ""
+msgstr "**%{effect_sentence_case}**%{summary_location}%{summary_timeframe}%{summary_recurrence}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:313
 #, elixir-autogen, elixir-format
 msgid "**%{time}** %{vehicle} from **%{from_stop}**"
-msgstr ""
+msgstr "**%{time}** %{vehicle} 来自 **%{from_stop}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:268
 #, elixir-autogen, elixir-format
 msgid "**%{trip_time}** %{route_type} from **%{stop_name}**"
-msgstr ""
+msgstr "**%{trip_time}** %{route_type} 来自 **%{stop_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:275
 #, elixir-autogen, elixir-format
 msgid "**%{trip_time}** %{route_type} to **%{headsign}**"
-msgstr ""
+msgstr "**%{trip_time}** %{route_type} 至 **%{headsign}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:28
 #, elixir-autogen, elixir-format
 msgid "**All clear:** Regular service%{location}"
-msgstr ""
+msgstr "一切正常：服务正常%{location}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:39
 #, elixir-autogen, elixir-format
 msgid "**Update:** %{effect_sentence_case}%{summary_location}%{summary_timeframe}%{summary_recurrence}"
-msgstr ""
+msgstr "**更新：** %{effect_sentence_case}%{summary_location}%{summary_timeframe}%{summary_recurrence}"
 
 #: lib/presentation_strings.ex:71
 #, elixir-autogen, elixir-format
 msgid "Access Issue"
-msgstr ""
+msgstr "无障碍问题"
 
 #: lib/presentation_strings.ex:31
 #, elixir-autogen, elixir-format
 msgid "Access issue"
-msgstr ""
+msgstr "无障碍问题"
 
 #: lib/presentation_strings.ex:174
 #, elixir-autogen, elixir-format
 msgid "Accident"
-msgstr ""
+msgstr "事件"
 
 #: lib/presentation_strings.ex:72
 #, elixir-autogen, elixir-format
 msgid "Additional Service"
-msgstr ""
+msgstr "附加服务"
 
 #: lib/presentation_strings.ex:32
 #, elixir-autogen, elixir-format
 msgid "Additional service"
-msgstr ""
+msgstr "附加服务"
 
 #: lib/presentation_strings.ex:63
 #: lib/presentation_strings.ex:64
@@ -178,1014 +178,1014 @@ msgstr ""
 #: lib/presentation_strings.ex:104
 #, elixir-autogen, elixir-format
 msgid "Alert"
-msgstr ""
+msgstr "警报"
 
 #: lib/presentation_strings.ex:73
 #, elixir-autogen, elixir-format
 msgid "Amber Alert"
-msgstr ""
+msgstr "安珀警报"
 
 #: lib/presentation_strings.ex:33
 #, elixir-autogen, elixir-format
 msgid "Amber alert"
-msgstr ""
+msgstr "安珀警报"
 
 #: lib/presentation_strings.ex:112
 #: lib/presentation_strings.ex:175
 #, elixir-autogen, elixir-format
 msgid "Amtrak"
-msgstr ""
+msgstr "Amtrak"
 
 #: lib/presentation_strings.ex:176
 #, elixir-autogen, elixir-format
 msgid "Amtrak Train Traffic"
-msgstr ""
+msgstr "Amtrak火车交通"
 
 #: lib/presentation_strings.ex:113
 #, elixir-autogen, elixir-format
 msgid "Amtrak train traffic"
-msgstr ""
+msgstr "Amtrak火车交通"
 
 #: lib/presentation_strings.ex:177
 #, elixir-autogen, elixir-format
 msgid "An Earlier Mechanical Problem"
-msgstr ""
+msgstr "早前的机械故障"
 
 #: lib/presentation_strings.ex:178
 #, elixir-autogen, elixir-format
 msgid "An Earlier Signal Problem"
-msgstr ""
+msgstr "早前的信号问题"
 
 #: lib/presentation_strings.ex:179
 #, elixir-autogen, elixir-format
 msgid "Autos Impeding Service"
-msgstr ""
+msgstr "交通事故"
 
 #: lib/presentation_strings.ex:74
 #, elixir-autogen, elixir-format
 msgid "Bike Issue"
-msgstr ""
+msgstr "自行车问题"
 
 #: lib/presentation_strings.ex:34
 #, elixir-autogen, elixir-format
 msgid "Bike issue"
-msgstr ""
+msgstr "自行车问题"
 
 #: lib/presentation_strings.ex:75
 #, elixir-autogen, elixir-format
 msgid "Cancellation"
-msgstr ""
+msgstr "取消"
 
 #: lib/presentation_strings.ex:180
 #, elixir-autogen, elixir-format
 msgid "Coast Guard Restriction"
-msgstr ""
+msgstr "海岸警卫队警戒"
 
 #: lib/presentation_strings.ex:117
 #, elixir-autogen, elixir-format
 msgid "Coast Guard restriction"
-msgstr ""
+msgstr "海岸警卫队警戒"
 
 #: lib/presentation_strings.ex:181
 #, elixir-autogen, elixir-format
 msgid "Congestion"
-msgstr ""
+msgstr "交通拥堵"
 
 #: lib/presentation_strings.ex:182
 #, elixir-autogen, elixir-format
 msgid "Construction"
-msgstr ""
+msgstr "建筑施工"
 
 #: lib/presentation_strings.ex:183
 #, elixir-autogen, elixir-format
 msgid "Crossing Issue"
-msgstr ""
+msgstr "交通信号灯问题"
 
 #: lib/presentation_strings.ex:184
 #, elixir-autogen, elixir-format
 msgid "Crossing Malfunction"
-msgstr ""
+msgstr "交通信号灯故障"
 
 #: lib/presentation_strings.ex:36
 #: lib/presentation_strings.ex:76
 #, elixir-autogen, elixir-format
 msgid "Delay"
-msgstr ""
+msgstr "延误"
 
 #: lib/presentation_strings.ex:185
 #, elixir-autogen, elixir-format
 msgid "Demonstration"
-msgstr ""
+msgstr "示威"
 
 #: lib/presentation_strings.ex:37
 #: lib/presentation_strings.ex:77
 #, elixir-autogen, elixir-format
 msgid "Detour"
-msgstr ""
+msgstr "交通改道"
 
 #: lib/presentation_strings.ex:186
 #, elixir-autogen, elixir-format
 msgid "Disabled Bus"
-msgstr ""
+msgstr "巴士抛锚"
 
 #: lib/presentation_strings.ex:187
 #, elixir-autogen, elixir-format
 msgid "Disabled Train"
-msgstr ""
+msgstr "列车停运"
 
 #: lib/presentation_strings.ex:78
 #, elixir-autogen, elixir-format
 msgid "Dock Closure"
-msgstr ""
+msgstr "码头关闭"
 
 #: lib/presentation_strings.ex:79
 #, elixir-autogen, elixir-format
 msgid "Dock Issue"
-msgstr ""
+msgstr "停靠区域问题"
 
 #: lib/presentation_strings.ex:38
 #, elixir-autogen, elixir-format
 msgid "Dock closed"
-msgstr ""
+msgstr "停靠区域已关闭"
 
 #: lib/presentation_strings.ex:39
 #, elixir-autogen, elixir-format
 msgid "Dock issue"
-msgstr ""
+msgstr "停靠区域问题"
 
 #: lib/presentation_strings.ex:188
 #, elixir-autogen, elixir-format
 msgid "Drawbridge Being Raised"
-msgstr ""
+msgstr "吊桥升起"
 
 #: lib/presentation_strings.ex:189
 #, elixir-autogen, elixir-format
 msgid "Drawbridge Issue"
-msgstr ""
+msgstr "吊桥问题"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:8
 #, elixir-autogen, elixir-format
 msgid "Eastbound"
-msgstr ""
+msgstr "东行"
 
 #: lib/presentation_strings.ex:190
 #, elixir-autogen, elixir-format
 msgid "Electrical Work"
-msgstr ""
+msgstr "电力作业"
 
 #: lib/presentation_strings.ex:80
 #, elixir-autogen, elixir-format
 msgid "Elevator Closure"
-msgstr ""
+msgstr "电梯关停"
 
 #: lib/presentation_strings.ex:40
 #, elixir-autogen, elixir-format
 msgid "Elevator closed"
-msgstr ""
+msgstr "直梯已关闭"
 
 #: lib/presentation_strings.ex:81
 #, elixir-autogen, elixir-format
 msgid "Escalator Closure"
-msgstr ""
+msgstr "自动扶梯关闭"
 
 #: lib/presentation_strings.ex:41
 #, elixir-autogen, elixir-format
 msgid "Escalator closed"
-msgstr ""
+msgstr "自动扶梯已关闭"
 
 #: lib/presentation_strings.ex:82
 #, elixir-autogen, elixir-format
 msgid "Extra Service"
-msgstr ""
+msgstr "额外服务"
 
 #: lib/presentation_strings.ex:42
 #, elixir-autogen, elixir-format
 msgid "Extra service"
-msgstr ""
+msgstr "额外服务"
 
 #: lib/presentation_strings.ex:83
 #, elixir-autogen, elixir-format
 msgid "Facility Issue"
-msgstr ""
+msgstr "设施问题"
 
 #: lib/presentation_strings.ex:43
 #, elixir-autogen, elixir-format
 msgid "Facility issue"
-msgstr ""
+msgstr "设施问题"
 
 #: lib/presentation_strings.ex:191
 #, elixir-autogen, elixir-format
 msgid "Fire"
-msgstr ""
+msgstr "火灾"
 
 #: lib/presentation_strings.ex:192
 #, elixir-autogen, elixir-format
 msgid "Fire Department Activity"
-msgstr ""
+msgstr "消防局活动"
 
 #: lib/presentation_strings.ex:193
 #, elixir-autogen, elixir-format
 msgid "Flooding"
-msgstr ""
+msgstr "洪水"
 
 #: lib/presentation_strings.ex:194
 #, elixir-autogen, elixir-format
 msgid "Fog"
-msgstr ""
+msgstr "大雾"
 
 #: lib/presentation_strings.ex:195
 #, elixir-autogen, elixir-format
 msgid "Freight Train Interference"
-msgstr ""
+msgstr "货运列车干扰"
 
 #: lib/presentation_strings.ex:196
 #, elixir-autogen, elixir-format
 msgid "Hazmat Condition"
-msgstr ""
+msgstr "危险物质"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:17
 #, elixir-autogen, elixir-format
 msgid "Heading"
-msgstr ""
+msgstr "方向"
 
 #: lib/presentation_strings.ex:197
 #, elixir-autogen, elixir-format
 msgid "Heavy Ridership"
-msgstr ""
+msgstr "客流过大"
 
 #: lib/presentation_strings.ex:198
 #, elixir-autogen, elixir-format
 msgid "High Winds"
-msgstr ""
+msgstr "强风"
 
 #: lib/presentation_strings.ex:199
 #, elixir-autogen, elixir-format
 msgid "Holiday"
-msgstr ""
+msgstr "节假日"
 
 #: lib/presentation_strings.ex:200
 #, elixir-autogen, elixir-format
 msgid "Hurricane"
-msgstr ""
+msgstr "飓风"
 
 #: lib/presentation_strings.ex:201
 #, elixir-autogen, elixir-format
 msgid "Ice In Harbor"
-msgstr ""
+msgstr "港口结冰"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:10
 #, elixir-autogen, elixir-format
 msgid "Inbound"
-msgstr ""
+msgstr "进站"
 
 #: lib/presentation_strings.ex:202
 #, elixir-autogen, elixir-format
 msgid "Maintenance"
-msgstr ""
+msgstr "维护"
 
 #: lib/presentation_strings.ex:203
 #, elixir-autogen, elixir-format
 msgid "Mechanical Issue"
-msgstr ""
+msgstr "机械问题"
 
 #: lib/presentation_strings.ex:204
 #, elixir-autogen, elixir-format
 msgid "Mechanical Problem"
-msgstr ""
+msgstr "机械故障"
 
 #: lib/presentation_strings.ex:205
 #, elixir-autogen, elixir-format
 msgid "Medical Emergency"
-msgstr ""
+msgstr "医疗急救"
 
 #: lib/presentation_strings.ex:84
 #, elixir-autogen, elixir-format
 msgid "Modified Service"
-msgstr ""
+msgstr "调整后的服务"
 
 #: lib/presentation_strings.ex:44
 #, elixir-autogen, elixir-format
 msgid "Modified service"
-msgstr ""
+msgstr "调整后的服务"
 
 #: lib/mobile_app_backend/notifications/notification_title.ex:69
 #, elixir-autogen, elixir-format
 msgid "Multiple routes"
-msgstr ""
+msgstr "多条路线"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:282
 #, elixir-autogen, elixir-format
 msgid "Multiple trips"
-msgstr ""
+msgstr "多次旅行"
 
 #: lib/presentation_strings.ex:85
 #, elixir-autogen, elixir-format
 msgid "No Service"
-msgstr ""
+msgstr "无服务"
 
 #: lib/presentation_strings.ex:45
 #, elixir-autogen, elixir-format
 msgid "No service"
-msgstr ""
+msgstr "无服务"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:6
 #, elixir-autogen, elixir-format
 msgid "Northbound"
-msgstr ""
+msgstr "北行"
 
 #: lib/presentation_strings.ex:46
 #: lib/presentation_strings.ex:86
 #, elixir-autogen, elixir-format
 msgid "Notice"
-msgstr ""
+msgstr "注意"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:11
 #, elixir-autogen, elixir-format
 msgid "Outbound"
-msgstr ""
+msgstr "出站"
 
 #: lib/presentation_strings.ex:206
 #, elixir-autogen, elixir-format
 msgid "Parade"
-msgstr ""
+msgstr "游行"
 
 #: lib/presentation_strings.ex:87
 #, elixir-autogen, elixir-format
 msgid "Parking Closure"
-msgstr ""
+msgstr "停车关闭"
 
 #: lib/presentation_strings.ex:88
 #, elixir-autogen, elixir-format
 msgid "Parking Issue"
-msgstr ""
+msgstr "停车问题"
 
 #: lib/presentation_strings.ex:47
 #, elixir-autogen, elixir-format
 msgid "Parking closed"
-msgstr ""
+msgstr "停车已关闭"
 
 #: lib/presentation_strings.ex:48
 #, elixir-autogen, elixir-format
 msgid "Parking issue"
-msgstr ""
+msgstr "停车问题"
 
 #: lib/presentation_strings.ex:207
 #, elixir-autogen, elixir-format
 msgid "Police Action"
-msgstr ""
+msgstr "警方行动"
 
 #: lib/presentation_strings.ex:208
 #, elixir-autogen, elixir-format
 msgid "Police Activity"
-msgstr ""
+msgstr "警方活动"
 
 #: lib/presentation_strings.ex:89
 #, elixir-autogen, elixir-format
 msgid "Policy Change"
-msgstr ""
+msgstr "政策变化"
 
 #: lib/presentation_strings.ex:49
 #, elixir-autogen, elixir-format
 msgid "Policy change"
-msgstr ""
+msgstr "政策变化"
 
 #: lib/presentation_strings.ex:209
 #, elixir-autogen, elixir-format
 msgid "Power Problem"
-msgstr ""
+msgstr "电力故障"
 
 #: lib/presentation_strings.ex:210
 #, elixir-autogen, elixir-format
 msgid "Rail Defect"
-msgstr ""
+msgstr "轨道缺陷"
 
 #: lib/presentation_strings.ex:90
 #, elixir-autogen, elixir-format
 msgid "Schedule Change"
-msgstr ""
+msgstr "时刻表变更"
 
 #: lib/presentation_strings.ex:50
 #, elixir-autogen, elixir-format
 msgid "Schedule change"
-msgstr ""
+msgstr "时刻表变更"
 
 #: lib/presentation_strings.ex:91
 #, elixir-autogen, elixir-format
 msgid "Service Change"
-msgstr ""
+msgstr "服务变更"
 
 #: lib/presentation_strings.ex:51
 #, elixir-autogen, elixir-format
 msgid "Service change"
-msgstr ""
+msgstr "服务变更"
 
 #: lib/presentation_strings.ex:61
 #, elixir-autogen, elixir-format
 msgid "Service suspended"
-msgstr ""
+msgstr "服务暂停"
 
 #: lib/presentation_strings.ex:211
 #, elixir-autogen, elixir-format
 msgid "Severe Weather"
-msgstr ""
+msgstr "恶劣天气"
 
 #: lib/presentation_strings.ex:92
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
-msgstr ""
+msgstr "摆渡巴士"
 
 #: lib/presentation_strings.ex:52
 #, elixir-autogen, elixir-format
 msgid "Shuttle buses"
-msgstr ""
+msgstr "摆渡巴士"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:298
 #, elixir-autogen, elixir-format
 msgid "Shuttle buses replace %{trip_identity} from **%{start_stop}** to **%{end_stop}**%{recurrence}"
-msgstr ""
+msgstr "接驳巴士取代了从 **%{start_stop}** 到 **%{end_stop}**%{recurrence} 的 %{trip_identity}"
 
 #: lib/presentation_strings.ex:212
 #, elixir-autogen, elixir-format
 msgid "Signal Issue"
-msgstr ""
+msgstr "信号问题"
 
 #: lib/presentation_strings.ex:213
 #, elixir-autogen, elixir-format
 msgid "Signal Problem"
-msgstr ""
+msgstr "信号故障"
 
 #: lib/presentation_strings.ex:214
 #, elixir-autogen, elixir-format
 msgid "Single Tracking"
-msgstr ""
+msgstr "单轨道"
 
 #: lib/presentation_strings.ex:215
 #, elixir-autogen, elixir-format
 msgid "Slippery Rail"
-msgstr ""
+msgstr "轨道湿滑"
 
 #: lib/presentation_strings.ex:216
 #, elixir-autogen, elixir-format
 msgid "Snow"
-msgstr ""
+msgstr "降雪"
 
 #: lib/presentation_strings.ex:93
 #, elixir-autogen, elixir-format
 msgid "Snow Route"
-msgstr ""
+msgstr "雪地线路"
 
 #: lib/presentation_strings.ex:53
 #, elixir-autogen, elixir-format
 msgid "Snow route"
-msgstr ""
+msgstr "路线积雪"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:7
 #, elixir-autogen, elixir-format
 msgid "Southbound"
-msgstr ""
+msgstr "南行"
 
 #: lib/presentation_strings.ex:217
 #, elixir-autogen, elixir-format
 msgid "Special Event"
-msgstr ""
+msgstr "特殊事件"
 
 #: lib/presentation_strings.ex:218
 #, elixir-autogen, elixir-format
 msgid "Speed Restriction"
-msgstr ""
+msgstr "速度限制"
 
 #: lib/presentation_strings.ex:94
 #, elixir-autogen, elixir-format
 msgid "Station Closure"
-msgstr ""
+msgstr "车站关闭"
 
 #: lib/presentation_strings.ex:95
 #, elixir-autogen, elixir-format
 msgid "Station Issue"
-msgstr ""
+msgstr "车站问题"
 
 #: lib/presentation_strings.ex:54
 #, elixir-autogen, elixir-format
 msgid "Station closed"
-msgstr ""
+msgstr "车站已关闭"
 
 #: lib/presentation_strings.ex:55
 #, elixir-autogen, elixir-format
 msgid "Station issue"
-msgstr ""
+msgstr "车站问题"
 
 #: lib/presentation_strings.ex:96
 #, elixir-autogen, elixir-format
 msgid "Stop Closure"
-msgstr ""
+msgstr "站点关闭"
 
 #: lib/presentation_strings.ex:97
 #: lib/presentation_strings.ex:98
 #, elixir-autogen, elixir-format
 msgid "Stop Moved"
-msgstr ""
+msgstr "站点已移动"
 
 #: lib/presentation_strings.ex:99
 #, elixir-autogen, elixir-format
 msgid "Stop Shoveling"
-msgstr ""
+msgstr "站点铲雪中"
 
 #: lib/presentation_strings.ex:56
 #, elixir-autogen, elixir-format
 msgid "Stop closed"
-msgstr ""
+msgstr "站点已关闭"
 
 #: lib/presentation_strings.ex:57
 #: lib/presentation_strings.ex:58
 #, elixir-autogen, elixir-format
 msgid "Stop moved"
-msgstr ""
+msgstr "站点已移动"
 
 #: lib/presentation_strings.ex:59
 #, elixir-autogen, elixir-format
 msgid "Stop shoveling"
-msgstr ""
+msgstr "站点铲雪中"
 
 #: lib/presentation_strings.ex:219
 #, elixir-autogen, elixir-format
 msgid "Strike"
-msgstr ""
+msgstr "罢工"
 
 #: lib/presentation_strings.ex:60
 #: lib/presentation_strings.ex:100
 #, elixir-autogen, elixir-format
 msgid "Summary"
-msgstr ""
+msgstr "概要"
 
 #: lib/presentation_strings.ex:101
 #, elixir-autogen, elixir-format
 msgid "Suspension"
-msgstr ""
+msgstr "暂停"
 
 #: lib/presentation_strings.ex:220
 #, elixir-autogen, elixir-format
 msgid "Switch Issue"
-msgstr ""
+msgstr "道岔问题"
 
 #: lib/presentation_strings.ex:221
 #, elixir-autogen, elixir-format
 msgid "Switch Problem"
-msgstr ""
+msgstr "道岔故障"
 
 #: lib/presentation_strings.ex:222
 #, elixir-autogen, elixir-format
 msgid "Technical Problem"
-msgstr ""
+msgstr "技术故障"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:263
 #, elixir-autogen, elixir-format
 msgid "This %{route_type}"
-msgstr ""
+msgstr "这 %{route_type}"
 
 #: lib/presentation_strings.ex:223
 #, elixir-autogen, elixir-format
 msgid "Tie Replacement"
-msgstr ""
+msgstr "更换轨枕"
 
 #: lib/presentation_strings.ex:102
 #, elixir-autogen, elixir-format
 msgid "Track Change"
-msgstr ""
+msgstr "轨道变更"
 
 #: lib/presentation_strings.ex:224
 #, elixir-autogen, elixir-format
 msgid "Track Problem"
-msgstr ""
+msgstr "轨道故障"
 
 #: lib/presentation_strings.ex:225
 #, elixir-autogen, elixir-format
 msgid "Track Work"
-msgstr ""
+msgstr "轨道作业"
 
 #: lib/presentation_strings.ex:62
 #, elixir-autogen, elixir-format
 msgid "Track change"
-msgstr ""
+msgstr "轨道变更"
 
 #: lib/presentation_strings.ex:226
 #, elixir-autogen, elixir-format
 msgid "Traffic"
-msgstr ""
+msgstr "交通"
 
 #: lib/presentation_strings.ex:227
 #, elixir-autogen, elixir-format
 msgid "Train Traffic"
-msgstr ""
+msgstr "火车交通"
 
 #: lib/presentation_strings.ex:35
 #, elixir-autogen, elixir-format
 msgid "Trip cancelled"
-msgstr ""
+msgstr "行程已取消"
 
 #: lib/presentation_strings.ex:228
 #, elixir-autogen, elixir-format
 msgid "Unruly Passenger"
-msgstr ""
+msgstr "乘客干扰"
 
 #: lib/presentation_strings.ex:229
 #, elixir-autogen, elixir-format
 msgid "Weather"
-msgstr ""
+msgstr "天气"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:9
 #, elixir-autogen, elixir-format
 msgid "Westbound"
-msgstr ""
+msgstr "西行"
 
 #: lib/presentation_strings.ex:111
 #, elixir-autogen, elixir-format
 msgid "accident"
-msgstr ""
+msgstr "事故"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:424
 #, elixir-autogen, elixir-format
 msgid "affected by %{effect} %{day}"
-msgstr ""
+msgstr "受 %{effect} %{day} 影响"
 
 #: lib/presentation_strings.ex:114
 #, elixir-autogen, elixir-format
 msgid "an earlier mechanical problem"
-msgstr ""
+msgstr "早前的机械故障"
 
 #: lib/presentation_strings.ex:115
 #, elixir-autogen, elixir-format
 msgid "an earlier signal problem"
-msgstr ""
+msgstr "早前的信号问题"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:382
 #, elixir-autogen, elixir-format
 msgid "are cancelled %{day}"
-msgstr ""
+msgstr "已取消 %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:417
 #, elixir-autogen, elixir-format
 msgid "are suspended %{day}"
-msgstr ""
+msgstr "已暂停 %{day}"
 
 #: lib/presentation_strings.ex:116
 #, elixir-autogen, elixir-format
 msgid "autos impeding service"
-msgstr ""
+msgstr "交通事故"
 
 #: lib/presentation_strings.ex:12
 #, elixir-autogen, elixir-format
 msgid "bus"
-msgstr ""
+msgstr "巴士"
 
 #: lib/presentation_strings.ex:13
 #, elixir-autogen, elixir-format
 msgid "buses"
-msgstr ""
+msgstr "巴士"
 
 #: lib/presentation_strings.ex:118
 #, elixir-autogen, elixir-format
 msgid "congestion"
-msgstr ""
+msgstr "交通拥堵"
 
 #: lib/presentation_strings.ex:119
 #, elixir-autogen, elixir-format
 msgid "construction"
-msgstr ""
+msgstr "建筑施工"
 
 #: lib/presentation_strings.ex:120
 #, elixir-autogen, elixir-format
 msgid "crossing issue"
-msgstr ""
+msgstr "交通信号灯问题"
 
 #: lib/presentation_strings.ex:121
 #, elixir-autogen, elixir-format
 msgid "crossing malfunction"
-msgstr ""
+msgstr "交通信号灯故障"
 
 #: lib/presentation_strings.ex:122
 #, elixir-autogen, elixir-format
 msgid "demonstration"
-msgstr ""
+msgstr "示威"
 
 #: lib/presentation_strings.ex:123
 #, elixir-autogen, elixir-format
 msgid "disabled bus"
-msgstr ""
+msgstr "巴士抛锚"
 
 #: lib/presentation_strings.ex:124
 #, elixir-autogen, elixir-format
 msgid "disabled train"
-msgstr ""
+msgstr "列车停运"
 
 #: lib/presentation_strings.ex:125
 #, elixir-autogen, elixir-format
 msgid "drawbridge being raised"
-msgstr ""
+msgstr "吊桥升起"
 
 #: lib/presentation_strings.ex:126
 #, elixir-autogen, elixir-format
 msgid "drawbridge issue"
-msgstr ""
+msgstr "吊桥问题"
 
 #: lib/presentation_strings.ex:127
 #, elixir-autogen, elixir-format
 msgid "electrical work"
-msgstr ""
+msgstr "电力作业"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:193
 #, elixir-autogen, elixir-format
 msgid "end of service"
-msgstr ""
+msgstr "服务结束"
 
 #: lib/presentation_strings.ex:15
 #, elixir-autogen, elixir-format
 msgid "ferries"
-msgstr ""
+msgstr "轮渡"
 
 #: lib/presentation_strings.ex:14
 #, elixir-autogen, elixir-format
 msgid "ferry"
-msgstr ""
+msgstr "轮渡"
 
 #: lib/presentation_strings.ex:128
 #, elixir-autogen, elixir-format
 msgid "fire"
-msgstr ""
+msgstr "火灾"
 
 #: lib/presentation_strings.ex:129
 #, elixir-autogen, elixir-format
 msgid "fire department activity"
-msgstr ""
+msgstr "消防局活动"
 
 #: lib/presentation_strings.ex:130
 #, elixir-autogen, elixir-format
 msgid "flooding"
-msgstr ""
+msgstr "洪水"
 
 #: lib/presentation_strings.ex:131
 #, elixir-autogen, elixir-format
 msgid "fog"
-msgstr ""
+msgstr "大雾"
 
 #: lib/presentation_strings.ex:132
 #, elixir-autogen, elixir-format
 msgid "freight train interference"
-msgstr ""
+msgstr "货运列车干扰"
 
 #: lib/presentation_strings.ex:133
 #, elixir-autogen, elixir-format
 msgid "hazmat condition"
-msgstr ""
+msgstr "危险物质"
 
 #: lib/presentation_strings.ex:134
 #, elixir-autogen, elixir-format
 msgid "heavy ridership"
-msgstr ""
+msgstr "客流过大"
 
 #: lib/presentation_strings.ex:135
 #, elixir-autogen, elixir-format
 msgid "high winds"
-msgstr ""
+msgstr "强风"
 
 #: lib/presentation_strings.ex:136
 #, elixir-autogen, elixir-format
 msgid "holiday"
-msgstr ""
+msgstr "节假日"
 
 #: lib/presentation_strings.ex:137
 #, elixir-autogen, elixir-format
 msgid "hurricane"
-msgstr ""
+msgstr "飓风"
 
 #: lib/presentation_strings.ex:138
 #, elixir-autogen, elixir-format
 msgid "ice in harbor"
-msgstr ""
+msgstr "港口结冰"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:385
 #, elixir-autogen, elixir-format
 msgid "is cancelled %{day}"
-msgstr ""
+msgstr "已取消 %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:420
 #, elixir-autogen, elixir-format
 msgid "is suspended %{day}"
-msgstr ""
+msgstr "已暂停 %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:239
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_recurrence_end_day_later_date"
-msgstr ""
+msgstr " 直到 %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:247
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_recurrence_end_day_this_week"
-msgstr ""
+msgstr " 直到 %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:144
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_timeframe_later_date"
-msgstr ""
+msgstr " 至%{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:152
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_timeframe_this_week"
-msgstr ""
+msgstr " 至%{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:160
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_timeframe_time"
-msgstr ""
+msgstr " 至%{1}"
 
 #: lib/presentation_strings.ex:139
 #, elixir-autogen, elixir-format
 msgid "maintenance"
-msgstr ""
+msgstr "维护"
 
 #: lib/presentation_strings.ex:140
 #, elixir-autogen, elixir-format
 msgid "mechanical issue"
-msgstr ""
+msgstr "机械问题"
 
 #: lib/presentation_strings.ex:141
 #, elixir-autogen, elixir-format
 msgid "mechanical problem"
-msgstr ""
+msgstr "机械故障"
 
 #: lib/presentation_strings.ex:142
 #, elixir-autogen, elixir-format
 msgid "medical emergency"
-msgstr ""
+msgstr "医疗急救"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:333
 #, elixir-autogen, elixir-format
 msgid "multiple trips"
-msgstr ""
+msgstr "多次旅行"
 
 #: lib/presentation_strings.ex:143
 #, elixir-autogen, elixir-format
 msgid "parade"
-msgstr ""
+msgstr "游行"
 
 #: lib/presentation_strings.ex:144
 #, elixir-autogen, elixir-format
 msgid "police action"
-msgstr ""
+msgstr "警方行动"
 
 #: lib/presentation_strings.ex:145
 #, elixir-autogen, elixir-format
 msgid "police activity"
-msgstr ""
+msgstr "警方活动"
 
 #: lib/presentation_strings.ex:146
 #, elixir-autogen, elixir-format
 msgid "power problem"
-msgstr ""
+msgstr "电力故障"
 
 #: lib/presentation_strings.ex:147
 #, elixir-autogen, elixir-format
 msgid "rail defect"
-msgstr ""
+msgstr "轨道缺陷"
 
 #: lib/presentation_strings.ex:148
 #, elixir-autogen, elixir-format
 msgid "severe weather"
-msgstr ""
+msgstr "恶劣天气"
 
 #: lib/presentation_strings.ex:149
 #, elixir-autogen, elixir-format
 msgid "signal issue"
-msgstr ""
+msgstr "信号问题"
 
 #: lib/presentation_strings.ex:150
 #, elixir-autogen, elixir-format
 msgid "signal problem"
-msgstr ""
+msgstr "信号故障"
 
 #: lib/presentation_strings.ex:151
 #, elixir-autogen, elixir-format
 msgid "single tracking"
-msgstr ""
+msgstr "单轨道"
 
 #: lib/presentation_strings.ex:152
 #, elixir-autogen, elixir-format
 msgid "slippery rail"
-msgstr ""
+msgstr "轨道湿滑"
 
 #: lib/presentation_strings.ex:153
 #, elixir-autogen, elixir-format
 msgid "snow"
-msgstr ""
+msgstr "降雪"
 
 #: lib/presentation_strings.ex:154
 #, elixir-autogen, elixir-format
 msgid "special event"
-msgstr ""
+msgstr "特殊事件"
 
 #: lib/presentation_strings.ex:155
 #, elixir-autogen, elixir-format
 msgid "speed restriction"
-msgstr ""
+msgstr "速度限制"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:190
 #, elixir-autogen, elixir-format
 msgid "start of service"
-msgstr ""
+msgstr "服务开始"
 
 #: lib/presentation_strings.ex:156
 #, elixir-autogen, elixir-format
 msgid "strike"
-msgstr ""
+msgstr "罢工"
 
 #: lib/presentation_strings.ex:157
 #, elixir-autogen, elixir-format
 msgid "switch issue"
-msgstr ""
+msgstr "道岔问题"
 
 #: lib/presentation_strings.ex:158
 #, elixir-autogen, elixir-format
 msgid "switch problem"
-msgstr ""
+msgstr "道岔故障"
 
 #: lib/presentation_strings.ex:159
 #, elixir-autogen, elixir-format
 msgid "technical problem"
-msgstr ""
+msgstr "技术故障"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:320
 #, elixir-autogen, elixir-format
 msgid "the **%{time}** %{vehicle}"
-msgstr ""
+msgstr "**%{time}** %{vehicle}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:328
 #, elixir-autogen, elixir-format
 msgid "this %{vehicle}"
-msgstr ""
+msgstr "这 %{vehicle}"
 
 #: lib/presentation_strings.ex:160
 #, elixir-autogen, elixir-format
 msgid "tie replacement"
-msgstr ""
+msgstr "更换轨枕"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:377
 #, elixir-autogen, elixir-format
 msgid "today"
-msgstr ""
+msgstr "今天"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:377
 #, elixir-autogen, elixir-format
 msgid "tomorrow"
-msgstr ""
+msgstr "明天"
 
 #: lib/presentation_strings.ex:161
 #, elixir-autogen, elixir-format
 msgid "track problem"
-msgstr ""
+msgstr "轨道故障"
 
 #: lib/presentation_strings.ex:162
 #, elixir-autogen, elixir-format
 msgid "track work"
-msgstr ""
+msgstr "轨道作业"
 
 #: lib/presentation_strings.ex:163
 #, elixir-autogen, elixir-format
 msgid "traffic"
-msgstr ""
+msgstr "交通"
 
 #: lib/presentation_strings.ex:16
 #, elixir-autogen, elixir-format
 msgid "train"
-msgstr ""
+msgstr "列车"
 
 #: lib/presentation_strings.ex:164
 #, elixir-autogen, elixir-format
 msgid "train traffic"
-msgstr ""
+msgstr "火车交通"
 
 #: lib/presentation_strings.ex:17
 #, elixir-autogen, elixir-format
 msgid "trains"
-msgstr ""
+msgstr "列车"
 
 #: lib/presentation_strings.ex:165
 #, elixir-autogen, elixir-format
 msgid "unruly passenger"
-msgstr ""
+msgstr "乘客干扰"
 
 #: lib/presentation_strings.ex:166
 #, elixir-autogen, elixir-format
 msgid "weather"
-msgstr ""
+msgstr "天气"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:388
 #, elixir-autogen, elixir-format
 msgid "will not stop at %{stop_list} %{day}"
-msgstr ""
+msgstr "不会止步于 %{stop_list} %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:411
 #, elixir-autogen, elixir-format
 msgid "will terminate at %{terminating_stop} %{day}"
-msgstr ""
+msgstr "将在 %{terminating_stop} %{day} 处终止"
 
 #: lib/mobile_app_backend_web/components/core_components.ex:484
 #, elixir-autogen, elixir-format, import-optional

--- a/priv/gettext/zh-Hans-CN/LC_MESSAGES/errors.po
+++ b/priv/gettext/zh-Hans-CN/LC_MESSAGES/errors.po
@@ -1,0 +1,12 @@
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: zh-Hans-CN\n"
+"Plural-Forms: nplurals=1\n"

--- a/priv/gettext/zh-Hant-TW/LC_MESSAGES/default.po
+++ b/priv/gettext/zh-Hant-TW/LC_MESSAGES/default.po
@@ -1,176 +1,176 @@
-## This file is a PO Template file.
-##
-## "msgid"s here are often extracted from source code.
-## Add new messages manually only if they're dynamic
-## messages that can't be statically extracted.
-##
-## Run "mix gettext.extract" to bring this file up to
-## date. Leave "msgstr"s empty as changing them here has no
-## effect: edit them in PO (.po) files instead.
-#
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
 msgid ""
 msgstr ""
+"Language: zh-Hant-TW\n"
+"Plural-Forms: nplurals=1\n"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:101
 #, elixir-autogen, elixir-format
 msgid " at **%{stop_name}**"
-msgstr ""
+msgstr " 在**%{stop_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:210
 #, elixir-autogen, elixir-format
 msgid " daily%{recurrence_text}"
-msgstr ""
+msgstr " 日常的%{recurrence_text}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:434
 #, elixir-autogen, elixir-format
 msgid " due to %{cause}"
-msgstr ""
+msgstr " 由於 %{cause}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:173
 #, elixir-autogen, elixir-format
 msgid " from %{start_time} to %{end_time}"
-msgstr ""
+msgstr " 從 %{start_time} 到 %{end_time}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:95
 #, elixir-autogen, elixir-format
 msgid " from **%{direction_name}** stops to **%{end_stop_name}**"
-msgstr ""
+msgstr " 從**%{direction_name}**站到**%{end_stop_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:110
 #, elixir-autogen, elixir-format
 msgid " from **%{start_stop}** to **%{end_stop}**"
-msgstr ""
+msgstr " 從**%{start_stop}**到**%{end_stop}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:104
 #, elixir-autogen, elixir-format
 msgid " from **%{stop_name}** to **%{direction_name}** stops"
-msgstr ""
+msgstr " 從**%{stop_name}**到**%{direction_name}**站"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:121
 #, elixir-autogen, elixir-format
 msgid " on **%{mode_label}**"
-msgstr ""
+msgstr " 在 **%{mode_label}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:117
 #, elixir-autogen, elixir-format
 msgid " replacing **%{mode_label}**"
-msgstr ""
+msgstr " 替換 **%{mode_label}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:219
 #, elixir-autogen, elixir-format
 msgid " some days%{recurrence_text}"
-msgstr ""
+msgstr "%{recurrence_text}有些日子"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:168
 #, elixir-autogen, elixir-format
 msgid " starting **%{formatted_time}** today"
-msgstr ""
+msgstr " 從今天**%{formatted_time}**開始"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:165
 #, elixir-autogen, elixir-format
 msgid " starting tomorrow"
-msgstr ""
+msgstr " 從明天開始"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:138
 #, elixir-autogen, elixir-format
 msgid " through end of service"
-msgstr ""
+msgstr " 直至服務結束"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:141
 #, elixir-autogen, elixir-format
 msgid " through tomorrow"
-msgstr ""
+msgstr " 直至明天"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:135
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:233
 #, elixir-autogen, elixir-format
 msgid " until further notice"
-msgstr ""
+msgstr " 等待進一步通知"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:236
 #, elixir-autogen, elixir-format
 msgid " until tomorrow"
-msgstr ""
+msgstr " 直到明天"
 
 #: lib/mobile_app_backend/notifications/notification_title.ex:63
 #, elixir-autogen, elixir-format
 msgid "%{label} %{mode_label}"
-msgstr ""
+msgstr "%{label} %{mode_label}"
 
 #: lib/presentation_strings.ex:22
 #, elixir-autogen, elixir-format
 msgid "%{name} bus"
-msgstr ""
+msgstr "%{name}巴士"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:398
 #, elixir-autogen, elixir-format
 msgid "%{stop} and %{other_stops}"
-msgstr ""
+msgstr "%{stop} 和 %{other_stops}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:57
 #, elixir-autogen, elixir-format
 msgid "%{trip_identity} %{trip_effect}%{cause}%{recurrence}"
-msgstr ""
+msgstr "%{trip_identity} %{trip_effect}%{cause}%{recurrence}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:290
 #, elixir-autogen, elixir-format
 msgid "%{trip_identity} is replaced by shuttle buses from **%{start_stop}** to **%{end_stop}**%{recurrence}"
-msgstr ""
+msgstr "%{trip_identity} 由 **%{start_stop}** 至 **%{end_stop}**%{recurrence} 的接駁巴士取代"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:47
 #, elixir-autogen, elixir-format
 msgid "**%{effect_sentence_case}**%{summary_location}%{summary_timeframe}%{summary_recurrence}"
-msgstr ""
+msgstr "**%{effect_sentence_case}**%{summary_location}%{summary_timeframe}%{summary_recurrence}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:313
 #, elixir-autogen, elixir-format
 msgid "**%{time}** %{vehicle} from **%{from_stop}**"
-msgstr ""
+msgstr "**%{time}** %{vehicle} 來自 **%{from_stop}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:268
 #, elixir-autogen, elixir-format
 msgid "**%{trip_time}** %{route_type} from **%{stop_name}**"
-msgstr ""
+msgstr "**%{trip_time}** %{route_type} 來自 **%{stop_name}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:275
 #, elixir-autogen, elixir-format
 msgid "**%{trip_time}** %{route_type} to **%{headsign}**"
-msgstr ""
+msgstr "**%{trip_time}** %{route_type} 至 **%{headsign}**"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:28
 #, elixir-autogen, elixir-format
 msgid "**All clear:** Regular service%{location}"
-msgstr ""
+msgstr "一切正常：服務正常%{location}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:39
 #, elixir-autogen, elixir-format
 msgid "**Update:** %{effect_sentence_case}%{summary_location}%{summary_timeframe}%{summary_recurrence}"
-msgstr ""
+msgstr "**更新：** %{effect_sentence_case}%{summary_location}%{summary_timeframe}%{summary_recurrence}"
 
 #: lib/presentation_strings.ex:71
 #, elixir-autogen, elixir-format
 msgid "Access Issue"
-msgstr ""
+msgstr "無障礙問題"
 
 #: lib/presentation_strings.ex:31
 #, elixir-autogen, elixir-format
 msgid "Access issue"
-msgstr ""
+msgstr "無障礙問題"
 
 #: lib/presentation_strings.ex:174
 #, elixir-autogen, elixir-format
 msgid "Accident"
-msgstr ""
+msgstr "事件"
 
 #: lib/presentation_strings.ex:72
 #, elixir-autogen, elixir-format
 msgid "Additional Service"
-msgstr ""
+msgstr "附加服務"
 
 #: lib/presentation_strings.ex:32
 #, elixir-autogen, elixir-format
 msgid "Additional service"
-msgstr ""
+msgstr "附加服務"
 
 #: lib/presentation_strings.ex:63
 #: lib/presentation_strings.ex:64
@@ -178,1014 +178,1014 @@ msgstr ""
 #: lib/presentation_strings.ex:104
 #, elixir-autogen, elixir-format
 msgid "Alert"
-msgstr ""
+msgstr "警報"
 
 #: lib/presentation_strings.ex:73
 #, elixir-autogen, elixir-format
 msgid "Amber Alert"
-msgstr ""
+msgstr "安珀警報"
 
 #: lib/presentation_strings.ex:33
 #, elixir-autogen, elixir-format
 msgid "Amber alert"
-msgstr ""
+msgstr "安珀警報"
 
 #: lib/presentation_strings.ex:112
 #: lib/presentation_strings.ex:175
 #, elixir-autogen, elixir-format
 msgid "Amtrak"
-msgstr ""
+msgstr "Amtrak"
 
 #: lib/presentation_strings.ex:176
 #, elixir-autogen, elixir-format
 msgid "Amtrak Train Traffic"
-msgstr ""
+msgstr "Amtrak火車交通"
 
 #: lib/presentation_strings.ex:113
 #, elixir-autogen, elixir-format
 msgid "Amtrak train traffic"
-msgstr ""
+msgstr "Amtrak火車交通"
 
 #: lib/presentation_strings.ex:177
 #, elixir-autogen, elixir-format
 msgid "An Earlier Mechanical Problem"
-msgstr ""
+msgstr "早前的機械故障"
 
 #: lib/presentation_strings.ex:178
 #, elixir-autogen, elixir-format
 msgid "An Earlier Signal Problem"
-msgstr ""
+msgstr "早前的信號問題"
 
 #: lib/presentation_strings.ex:179
 #, elixir-autogen, elixir-format
 msgid "Autos Impeding Service"
-msgstr ""
+msgstr "交通事故"
 
 #: lib/presentation_strings.ex:74
 #, elixir-autogen, elixir-format
 msgid "Bike Issue"
-msgstr ""
+msgstr "自行車問題"
 
 #: lib/presentation_strings.ex:34
 #, elixir-autogen, elixir-format
 msgid "Bike issue"
-msgstr ""
+msgstr "自行車問題"
 
 #: lib/presentation_strings.ex:75
 #, elixir-autogen, elixir-format
 msgid "Cancellation"
-msgstr ""
+msgstr "取消"
 
 #: lib/presentation_strings.ex:180
 #, elixir-autogen, elixir-format
 msgid "Coast Guard Restriction"
-msgstr ""
+msgstr "海岸警衛隊警戒"
 
 #: lib/presentation_strings.ex:117
 #, elixir-autogen, elixir-format
 msgid "Coast Guard restriction"
-msgstr ""
+msgstr "海岸警衛隊警戒"
 
 #: lib/presentation_strings.ex:181
 #, elixir-autogen, elixir-format
 msgid "Congestion"
-msgstr ""
+msgstr "交通擁堵"
 
 #: lib/presentation_strings.ex:182
 #, elixir-autogen, elixir-format
 msgid "Construction"
-msgstr ""
+msgstr "建築施工"
 
 #: lib/presentation_strings.ex:183
 #, elixir-autogen, elixir-format
 msgid "Crossing Issue"
-msgstr ""
+msgstr "交通信號燈問題"
 
 #: lib/presentation_strings.ex:184
 #, elixir-autogen, elixir-format
 msgid "Crossing Malfunction"
-msgstr ""
+msgstr "交通信號燈故障"
 
 #: lib/presentation_strings.ex:36
 #: lib/presentation_strings.ex:76
 #, elixir-autogen, elixir-format
 msgid "Delay"
-msgstr ""
+msgstr "延誤"
 
 #: lib/presentation_strings.ex:185
 #, elixir-autogen, elixir-format
 msgid "Demonstration"
-msgstr ""
+msgstr "示威"
 
 #: lib/presentation_strings.ex:37
 #: lib/presentation_strings.ex:77
 #, elixir-autogen, elixir-format
 msgid "Detour"
-msgstr ""
+msgstr "交通改道"
 
 #: lib/presentation_strings.ex:186
 #, elixir-autogen, elixir-format
 msgid "Disabled Bus"
-msgstr ""
+msgstr "巴士拋錨"
 
 #: lib/presentation_strings.ex:187
 #, elixir-autogen, elixir-format
 msgid "Disabled Train"
-msgstr ""
+msgstr "列車停運"
 
 #: lib/presentation_strings.ex:78
 #, elixir-autogen, elixir-format
 msgid "Dock Closure"
-msgstr ""
+msgstr "碼頭關閉"
 
 #: lib/presentation_strings.ex:79
 #, elixir-autogen, elixir-format
 msgid "Dock Issue"
-msgstr ""
+msgstr "停靠區域問題"
 
 #: lib/presentation_strings.ex:38
 #, elixir-autogen, elixir-format
 msgid "Dock closed"
-msgstr ""
+msgstr "停靠區域已關閉"
 
 #: lib/presentation_strings.ex:39
 #, elixir-autogen, elixir-format
 msgid "Dock issue"
-msgstr ""
+msgstr "停靠區域問題"
 
 #: lib/presentation_strings.ex:188
 #, elixir-autogen, elixir-format
 msgid "Drawbridge Being Raised"
-msgstr ""
+msgstr "吊橋升起"
 
 #: lib/presentation_strings.ex:189
 #, elixir-autogen, elixir-format
 msgid "Drawbridge Issue"
-msgstr ""
+msgstr "吊橋問題"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:8
 #, elixir-autogen, elixir-format
 msgid "Eastbound"
-msgstr ""
+msgstr "東行"
 
 #: lib/presentation_strings.ex:190
 #, elixir-autogen, elixir-format
 msgid "Electrical Work"
-msgstr ""
+msgstr "電力作業"
 
 #: lib/presentation_strings.ex:80
 #, elixir-autogen, elixir-format
 msgid "Elevator Closure"
-msgstr ""
+msgstr "電梯關閉"
 
 #: lib/presentation_strings.ex:40
 #, elixir-autogen, elixir-format
 msgid "Elevator closed"
-msgstr ""
+msgstr "直梯已關閉"
 
 #: lib/presentation_strings.ex:81
 #, elixir-autogen, elixir-format
 msgid "Escalator Closure"
-msgstr ""
+msgstr "自動扶梯關閉"
 
 #: lib/presentation_strings.ex:41
 #, elixir-autogen, elixir-format
 msgid "Escalator closed"
-msgstr ""
+msgstr "自動扶梯已關閉"
 
 #: lib/presentation_strings.ex:82
 #, elixir-autogen, elixir-format
 msgid "Extra Service"
-msgstr ""
+msgstr "額外服務"
 
 #: lib/presentation_strings.ex:42
 #, elixir-autogen, elixir-format
 msgid "Extra service"
-msgstr ""
+msgstr "額外服務"
 
 #: lib/presentation_strings.ex:83
 #, elixir-autogen, elixir-format
 msgid "Facility Issue"
-msgstr ""
+msgstr "設施問題"
 
 #: lib/presentation_strings.ex:43
 #, elixir-autogen, elixir-format
 msgid "Facility issue"
-msgstr ""
+msgstr "設施問題"
 
 #: lib/presentation_strings.ex:191
 #, elixir-autogen, elixir-format
 msgid "Fire"
-msgstr ""
+msgstr "火災"
 
 #: lib/presentation_strings.ex:192
 #, elixir-autogen, elixir-format
 msgid "Fire Department Activity"
-msgstr ""
+msgstr "消防局活動"
 
 #: lib/presentation_strings.ex:193
 #, elixir-autogen, elixir-format
 msgid "Flooding"
-msgstr ""
+msgstr "洪水"
 
 #: lib/presentation_strings.ex:194
 #, elixir-autogen, elixir-format
 msgid "Fog"
-msgstr ""
+msgstr "大霧"
 
 #: lib/presentation_strings.ex:195
 #, elixir-autogen, elixir-format
 msgid "Freight Train Interference"
-msgstr ""
+msgstr "貨運列車干擾"
 
 #: lib/presentation_strings.ex:196
 #, elixir-autogen, elixir-format
 msgid "Hazmat Condition"
-msgstr ""
+msgstr "危險物質"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:17
 #, elixir-autogen, elixir-format
 msgid "Heading"
-msgstr ""
+msgstr "方向"
 
 #: lib/presentation_strings.ex:197
 #, elixir-autogen, elixir-format
 msgid "Heavy Ridership"
-msgstr ""
+msgstr "客流過大"
 
 #: lib/presentation_strings.ex:198
 #, elixir-autogen, elixir-format
 msgid "High Winds"
-msgstr ""
+msgstr "強風"
 
 #: lib/presentation_strings.ex:199
 #, elixir-autogen, elixir-format
 msgid "Holiday"
-msgstr ""
+msgstr "節假日"
 
 #: lib/presentation_strings.ex:200
 #, elixir-autogen, elixir-format
 msgid "Hurricane"
-msgstr ""
+msgstr "颶風"
 
 #: lib/presentation_strings.ex:201
 #, elixir-autogen, elixir-format
 msgid "Ice In Harbor"
-msgstr ""
+msgstr "港口結冰"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:10
 #, elixir-autogen, elixir-format
 msgid "Inbound"
-msgstr ""
+msgstr "進站"
 
 #: lib/presentation_strings.ex:202
 #, elixir-autogen, elixir-format
 msgid "Maintenance"
-msgstr ""
+msgstr "維護"
 
 #: lib/presentation_strings.ex:203
 #, elixir-autogen, elixir-format
 msgid "Mechanical Issue"
-msgstr ""
+msgstr "機械問題"
 
 #: lib/presentation_strings.ex:204
 #, elixir-autogen, elixir-format
 msgid "Mechanical Problem"
-msgstr ""
+msgstr "機械故障"
 
 #: lib/presentation_strings.ex:205
 #, elixir-autogen, elixir-format
 msgid "Medical Emergency"
-msgstr ""
+msgstr "醫療急救"
 
 #: lib/presentation_strings.ex:84
 #, elixir-autogen, elixir-format
 msgid "Modified Service"
-msgstr ""
+msgstr "調整後的服務"
 
 #: lib/presentation_strings.ex:44
 #, elixir-autogen, elixir-format
 msgid "Modified service"
-msgstr ""
+msgstr "調整後的服務"
 
 #: lib/mobile_app_backend/notifications/notification_title.ex:69
 #, elixir-autogen, elixir-format
 msgid "Multiple routes"
-msgstr ""
+msgstr "多條路線"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:282
 #, elixir-autogen, elixir-format
 msgid "Multiple trips"
-msgstr ""
+msgstr "多次旅行"
 
 #: lib/presentation_strings.ex:85
 #, elixir-autogen, elixir-format
 msgid "No Service"
-msgstr ""
+msgstr "無服務"
 
 #: lib/presentation_strings.ex:45
 #, elixir-autogen, elixir-format
 msgid "No service"
-msgstr ""
+msgstr "無服務"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:6
 #, elixir-autogen, elixir-format
 msgid "Northbound"
-msgstr ""
+msgstr "北行"
 
 #: lib/presentation_strings.ex:46
 #: lib/presentation_strings.ex:86
 #, elixir-autogen, elixir-format
 msgid "Notice"
-msgstr ""
+msgstr "注意"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:11
 #, elixir-autogen, elixir-format
 msgid "Outbound"
-msgstr ""
+msgstr "出站"
 
 #: lib/presentation_strings.ex:206
 #, elixir-autogen, elixir-format
 msgid "Parade"
-msgstr ""
+msgstr "遊行"
 
 #: lib/presentation_strings.ex:87
 #, elixir-autogen, elixir-format
 msgid "Parking Closure"
-msgstr ""
+msgstr "停車關閉"
 
 #: lib/presentation_strings.ex:88
 #, elixir-autogen, elixir-format
 msgid "Parking Issue"
-msgstr ""
+msgstr "停車問題"
 
 #: lib/presentation_strings.ex:47
 #, elixir-autogen, elixir-format
 msgid "Parking closed"
-msgstr ""
+msgstr "停車已關閉"
 
 #: lib/presentation_strings.ex:48
 #, elixir-autogen, elixir-format
 msgid "Parking issue"
-msgstr ""
+msgstr "停車問題"
 
 #: lib/presentation_strings.ex:207
 #, elixir-autogen, elixir-format
 msgid "Police Action"
-msgstr ""
+msgstr "警方行動"
 
 #: lib/presentation_strings.ex:208
 #, elixir-autogen, elixir-format
 msgid "Police Activity"
-msgstr ""
+msgstr "警方活動"
 
 #: lib/presentation_strings.ex:89
 #, elixir-autogen, elixir-format
 msgid "Policy Change"
-msgstr ""
+msgstr "政策變化"
 
 #: lib/presentation_strings.ex:49
 #, elixir-autogen, elixir-format
 msgid "Policy change"
-msgstr ""
+msgstr "政策變化"
 
 #: lib/presentation_strings.ex:209
 #, elixir-autogen, elixir-format
 msgid "Power Problem"
-msgstr ""
+msgstr "電力故障"
 
 #: lib/presentation_strings.ex:210
 #, elixir-autogen, elixir-format
 msgid "Rail Defect"
-msgstr ""
+msgstr "軌道缺陷"
 
 #: lib/presentation_strings.ex:90
 #, elixir-autogen, elixir-format
 msgid "Schedule Change"
-msgstr ""
+msgstr "時刻表變更"
 
 #: lib/presentation_strings.ex:50
 #, elixir-autogen, elixir-format
 msgid "Schedule change"
-msgstr ""
+msgstr "時刻表變更"
 
 #: lib/presentation_strings.ex:91
 #, elixir-autogen, elixir-format
 msgid "Service Change"
-msgstr ""
+msgstr "服務變更"
 
 #: lib/presentation_strings.ex:51
 #, elixir-autogen, elixir-format
 msgid "Service change"
-msgstr ""
+msgstr "服務變更"
 
 #: lib/presentation_strings.ex:61
 #, elixir-autogen, elixir-format
 msgid "Service suspended"
-msgstr ""
+msgstr "服務暫停"
 
 #: lib/presentation_strings.ex:211
 #, elixir-autogen, elixir-format
 msgid "Severe Weather"
-msgstr ""
+msgstr "惡劣天氣"
 
 #: lib/presentation_strings.ex:92
 #, elixir-autogen, elixir-format
 msgid "Shuttle"
-msgstr ""
+msgstr "擺渡巴士"
 
 #: lib/presentation_strings.ex:52
 #, elixir-autogen, elixir-format
 msgid "Shuttle buses"
-msgstr ""
+msgstr "擺渡巴士"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:298
 #, elixir-autogen, elixir-format
 msgid "Shuttle buses replace %{trip_identity} from **%{start_stop}** to **%{end_stop}**%{recurrence}"
-msgstr ""
+msgstr "接駁巴士取代了從 **%{start_stop}** 到 **%{end_stop}**%{recurrence} 的 %{trip_identity}"
 
 #: lib/presentation_strings.ex:212
 #, elixir-autogen, elixir-format
 msgid "Signal Issue"
-msgstr ""
+msgstr "信號問題"
 
 #: lib/presentation_strings.ex:213
 #, elixir-autogen, elixir-format
 msgid "Signal Problem"
-msgstr ""
+msgstr "信號故障"
 
 #: lib/presentation_strings.ex:214
 #, elixir-autogen, elixir-format
 msgid "Single Tracking"
-msgstr ""
+msgstr "單軌道"
 
 #: lib/presentation_strings.ex:215
 #, elixir-autogen, elixir-format
 msgid "Slippery Rail"
-msgstr ""
+msgstr "軌道濕滑"
 
 #: lib/presentation_strings.ex:216
 #, elixir-autogen, elixir-format
 msgid "Snow"
-msgstr ""
+msgstr "降雪"
 
 #: lib/presentation_strings.ex:93
 #, elixir-autogen, elixir-format
 msgid "Snow Route"
-msgstr ""
+msgstr "雪地線路"
 
 #: lib/presentation_strings.ex:53
 #, elixir-autogen, elixir-format
 msgid "Snow route"
-msgstr ""
+msgstr "雪道"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:7
 #, elixir-autogen, elixir-format
 msgid "Southbound"
-msgstr ""
+msgstr "南行"
 
 #: lib/presentation_strings.ex:217
 #, elixir-autogen, elixir-format
 msgid "Special Event"
-msgstr ""
+msgstr "特殊事件"
 
 #: lib/presentation_strings.ex:218
 #, elixir-autogen, elixir-format
 msgid "Speed Restriction"
-msgstr ""
+msgstr "速度限制"
 
 #: lib/presentation_strings.ex:94
 #, elixir-autogen, elixir-format
 msgid "Station Closure"
-msgstr ""
+msgstr "車站關閉"
 
 #: lib/presentation_strings.ex:95
 #, elixir-autogen, elixir-format
 msgid "Station Issue"
-msgstr ""
+msgstr "車站問題"
 
 #: lib/presentation_strings.ex:54
 #, elixir-autogen, elixir-format
 msgid "Station closed"
-msgstr ""
+msgstr "車站已關閉"
 
 #: lib/presentation_strings.ex:55
 #, elixir-autogen, elixir-format
 msgid "Station issue"
-msgstr ""
+msgstr "車站問題"
 
 #: lib/presentation_strings.ex:96
 #, elixir-autogen, elixir-format
 msgid "Stop Closure"
-msgstr ""
+msgstr "網站關閉"
 
 #: lib/presentation_strings.ex:97
 #: lib/presentation_strings.ex:98
 #, elixir-autogen, elixir-format
 msgid "Stop Moved"
-msgstr ""
+msgstr "網站已移動"
 
 #: lib/presentation_strings.ex:99
 #, elixir-autogen, elixir-format
 msgid "Stop Shoveling"
-msgstr ""
+msgstr "網站鏟雪中"
 
 #: lib/presentation_strings.ex:56
 #, elixir-autogen, elixir-format
 msgid "Stop closed"
-msgstr ""
+msgstr "站點已關閉"
 
 #: lib/presentation_strings.ex:57
 #: lib/presentation_strings.ex:58
 #, elixir-autogen, elixir-format
 msgid "Stop moved"
-msgstr ""
+msgstr "網站已移動"
 
 #: lib/presentation_strings.ex:59
 #, elixir-autogen, elixir-format
 msgid "Stop shoveling"
-msgstr ""
+msgstr "網站鏟雪中"
 
 #: lib/presentation_strings.ex:219
 #, elixir-autogen, elixir-format
 msgid "Strike"
-msgstr ""
+msgstr "罷工"
 
 #: lib/presentation_strings.ex:60
 #: lib/presentation_strings.ex:100
 #, elixir-autogen, elixir-format
 msgid "Summary"
-msgstr ""
+msgstr "概觀"
 
 #: lib/presentation_strings.ex:101
 #, elixir-autogen, elixir-format
 msgid "Suspension"
-msgstr ""
+msgstr "暫停"
 
 #: lib/presentation_strings.ex:220
 #, elixir-autogen, elixir-format
 msgid "Switch Issue"
-msgstr ""
+msgstr "道岔問題"
 
 #: lib/presentation_strings.ex:221
 #, elixir-autogen, elixir-format
 msgid "Switch Problem"
-msgstr ""
+msgstr "道岔故障"
 
 #: lib/presentation_strings.ex:222
 #, elixir-autogen, elixir-format
 msgid "Technical Problem"
-msgstr ""
+msgstr "技術故障"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:263
 #, elixir-autogen, elixir-format
 msgid "This %{route_type}"
-msgstr ""
+msgstr "這 %{route_type}"
 
 #: lib/presentation_strings.ex:223
 #, elixir-autogen, elixir-format
 msgid "Tie Replacement"
-msgstr ""
+msgstr "更換軌枕"
 
 #: lib/presentation_strings.ex:102
 #, elixir-autogen, elixir-format
 msgid "Track Change"
-msgstr ""
+msgstr "軌道變更"
 
 #: lib/presentation_strings.ex:224
 #, elixir-autogen, elixir-format
 msgid "Track Problem"
-msgstr ""
+msgstr "軌道故障"
 
 #: lib/presentation_strings.ex:225
 #, elixir-autogen, elixir-format
 msgid "Track Work"
-msgstr ""
+msgstr "軌道作業"
 
 #: lib/presentation_strings.ex:62
 #, elixir-autogen, elixir-format
 msgid "Track change"
-msgstr ""
+msgstr "軌道變更"
 
 #: lib/presentation_strings.ex:226
 #, elixir-autogen, elixir-format
 msgid "Traffic"
-msgstr ""
+msgstr "交通"
 
 #: lib/presentation_strings.ex:227
 #, elixir-autogen, elixir-format
 msgid "Train Traffic"
-msgstr ""
+msgstr "火車交通"
 
 #: lib/presentation_strings.ex:35
 #, elixir-autogen, elixir-format
 msgid "Trip cancelled"
-msgstr ""
+msgstr "行程已取消"
 
 #: lib/presentation_strings.ex:228
 #, elixir-autogen, elixir-format
 msgid "Unruly Passenger"
-msgstr ""
+msgstr "乘客干擾"
 
 #: lib/presentation_strings.ex:229
 #, elixir-autogen, elixir-format
 msgid "Weather"
-msgstr ""
+msgstr "天氣"
 
 #: lib/mobile_app_backend/alerts/direction_label.ex:9
 #, elixir-autogen, elixir-format
 msgid "Westbound"
-msgstr ""
+msgstr "西行"
 
 #: lib/presentation_strings.ex:111
 #, elixir-autogen, elixir-format
 msgid "accident"
-msgstr ""
+msgstr "事故"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:424
 #, elixir-autogen, elixir-format
 msgid "affected by %{effect} %{day}"
-msgstr ""
+msgstr "受 %{effect} %{day} 影響"
 
 #: lib/presentation_strings.ex:114
 #, elixir-autogen, elixir-format
 msgid "an earlier mechanical problem"
-msgstr ""
+msgstr "早前的機械故障"
 
 #: lib/presentation_strings.ex:115
 #, elixir-autogen, elixir-format
 msgid "an earlier signal problem"
-msgstr ""
+msgstr "早前的信號問題"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:382
 #, elixir-autogen, elixir-format
 msgid "are cancelled %{day}"
-msgstr ""
+msgstr "已取消 %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:417
 #, elixir-autogen, elixir-format
 msgid "are suspended %{day}"
-msgstr ""
+msgstr "已暫停 %{day}"
 
 #: lib/presentation_strings.ex:116
 #, elixir-autogen, elixir-format
 msgid "autos impeding service"
-msgstr ""
+msgstr "交通事故"
 
 #: lib/presentation_strings.ex:12
 #, elixir-autogen, elixir-format
 msgid "bus"
-msgstr ""
+msgstr "巴士"
 
 #: lib/presentation_strings.ex:13
 #, elixir-autogen, elixir-format
 msgid "buses"
-msgstr ""
+msgstr "巴士"
 
 #: lib/presentation_strings.ex:118
 #, elixir-autogen, elixir-format
 msgid "congestion"
-msgstr ""
+msgstr "交通擁堵"
 
 #: lib/presentation_strings.ex:119
 #, elixir-autogen, elixir-format
 msgid "construction"
-msgstr ""
+msgstr "建築施工"
 
 #: lib/presentation_strings.ex:120
 #, elixir-autogen, elixir-format
 msgid "crossing issue"
-msgstr ""
+msgstr "交通信號燈問題"
 
 #: lib/presentation_strings.ex:121
 #, elixir-autogen, elixir-format
 msgid "crossing malfunction"
-msgstr ""
+msgstr "交通信號燈故障"
 
 #: lib/presentation_strings.ex:122
 #, elixir-autogen, elixir-format
 msgid "demonstration"
-msgstr ""
+msgstr "示威"
 
 #: lib/presentation_strings.ex:123
 #, elixir-autogen, elixir-format
 msgid "disabled bus"
-msgstr ""
+msgstr "巴士拋錨"
 
 #: lib/presentation_strings.ex:124
 #, elixir-autogen, elixir-format
 msgid "disabled train"
-msgstr ""
+msgstr "列車停運"
 
 #: lib/presentation_strings.ex:125
 #, elixir-autogen, elixir-format
 msgid "drawbridge being raised"
-msgstr ""
+msgstr "吊橋升起"
 
 #: lib/presentation_strings.ex:126
 #, elixir-autogen, elixir-format
 msgid "drawbridge issue"
-msgstr ""
+msgstr "吊橋問題"
 
 #: lib/presentation_strings.ex:127
 #, elixir-autogen, elixir-format
 msgid "electrical work"
-msgstr ""
+msgstr "電力作業"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:193
 #, elixir-autogen, elixir-format
 msgid "end of service"
-msgstr ""
+msgstr "服務結束"
 
 #: lib/presentation_strings.ex:15
 #, elixir-autogen, elixir-format
 msgid "ferries"
-msgstr ""
+msgstr "輪渡"
 
 #: lib/presentation_strings.ex:14
 #, elixir-autogen, elixir-format
 msgid "ferry"
-msgstr ""
+msgstr "輪渡"
 
 #: lib/presentation_strings.ex:128
 #, elixir-autogen, elixir-format
 msgid "fire"
-msgstr ""
+msgstr "火災"
 
 #: lib/presentation_strings.ex:129
 #, elixir-autogen, elixir-format
 msgid "fire department activity"
-msgstr ""
+msgstr "消防局活動"
 
 #: lib/presentation_strings.ex:130
 #, elixir-autogen, elixir-format
 msgid "flooding"
-msgstr ""
+msgstr "洪水"
 
 #: lib/presentation_strings.ex:131
 #, elixir-autogen, elixir-format
 msgid "fog"
-msgstr ""
+msgstr "大霧"
 
 #: lib/presentation_strings.ex:132
 #, elixir-autogen, elixir-format
 msgid "freight train interference"
-msgstr ""
+msgstr "貨運列車干擾"
 
 #: lib/presentation_strings.ex:133
 #, elixir-autogen, elixir-format
 msgid "hazmat condition"
-msgstr ""
+msgstr "危險物質"
 
 #: lib/presentation_strings.ex:134
 #, elixir-autogen, elixir-format
 msgid "heavy ridership"
-msgstr ""
+msgstr "客流過大"
 
 #: lib/presentation_strings.ex:135
 #, elixir-autogen, elixir-format
 msgid "high winds"
-msgstr ""
+msgstr "強風"
 
 #: lib/presentation_strings.ex:136
 #, elixir-autogen, elixir-format
 msgid "holiday"
-msgstr ""
+msgstr "節假日"
 
 #: lib/presentation_strings.ex:137
 #, elixir-autogen, elixir-format
 msgid "hurricane"
-msgstr ""
+msgstr "颶風"
 
 #: lib/presentation_strings.ex:138
 #, elixir-autogen, elixir-format
 msgid "ice in harbor"
-msgstr ""
+msgstr "港口結冰"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:385
 #, elixir-autogen, elixir-format
 msgid "is cancelled %{day}"
-msgstr ""
+msgstr "已取消 %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:420
 #, elixir-autogen, elixir-format
 msgid "is suspended %{day}"
-msgstr ""
+msgstr "已暫停 %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:239
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_recurrence_end_day_later_date"
-msgstr ""
+msgstr " 直到 %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:247
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_recurrence_end_day_this_week"
-msgstr ""
+msgstr " 直到 %{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:144
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_timeframe_later_date"
-msgstr ""
+msgstr " 至%{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:152
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_timeframe_this_week"
-msgstr ""
+msgstr " 至%{1}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:160
 #, elixir-autogen, elixir-format
 msgid "key/alert_summary_timeframe_time"
-msgstr ""
+msgstr " 至%{1}"
 
 #: lib/presentation_strings.ex:139
 #, elixir-autogen, elixir-format
 msgid "maintenance"
-msgstr ""
+msgstr "維護"
 
 #: lib/presentation_strings.ex:140
 #, elixir-autogen, elixir-format
 msgid "mechanical issue"
-msgstr ""
+msgstr "機械問題"
 
 #: lib/presentation_strings.ex:141
 #, elixir-autogen, elixir-format
 msgid "mechanical problem"
-msgstr ""
+msgstr "機械故障"
 
 #: lib/presentation_strings.ex:142
 #, elixir-autogen, elixir-format
 msgid "medical emergency"
-msgstr ""
+msgstr "醫療急救"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:333
 #, elixir-autogen, elixir-format
 msgid "multiple trips"
-msgstr ""
+msgstr "多次旅行"
 
 #: lib/presentation_strings.ex:143
 #, elixir-autogen, elixir-format
 msgid "parade"
-msgstr ""
+msgstr "遊行"
 
 #: lib/presentation_strings.ex:144
 #, elixir-autogen, elixir-format
 msgid "police action"
-msgstr ""
+msgstr "警方行動"
 
 #: lib/presentation_strings.ex:145
 #, elixir-autogen, elixir-format
 msgid "police activity"
-msgstr ""
+msgstr "警方活動"
 
 #: lib/presentation_strings.ex:146
 #, elixir-autogen, elixir-format
 msgid "power problem"
-msgstr ""
+msgstr "電力故障"
 
 #: lib/presentation_strings.ex:147
 #, elixir-autogen, elixir-format
 msgid "rail defect"
-msgstr ""
+msgstr "軌道缺陷"
 
 #: lib/presentation_strings.ex:148
 #, elixir-autogen, elixir-format
 msgid "severe weather"
-msgstr ""
+msgstr "惡劣天氣"
 
 #: lib/presentation_strings.ex:149
 #, elixir-autogen, elixir-format
 msgid "signal issue"
-msgstr ""
+msgstr "信號問題"
 
 #: lib/presentation_strings.ex:150
 #, elixir-autogen, elixir-format
 msgid "signal problem"
-msgstr ""
+msgstr "信號故障"
 
 #: lib/presentation_strings.ex:151
 #, elixir-autogen, elixir-format
 msgid "single tracking"
-msgstr ""
+msgstr "單軌道"
 
 #: lib/presentation_strings.ex:152
 #, elixir-autogen, elixir-format
 msgid "slippery rail"
-msgstr ""
+msgstr "軌道濕滑"
 
 #: lib/presentation_strings.ex:153
 #, elixir-autogen, elixir-format
 msgid "snow"
-msgstr ""
+msgstr "降雪"
 
 #: lib/presentation_strings.ex:154
 #, elixir-autogen, elixir-format
 msgid "special event"
-msgstr ""
+msgstr "特殊事件"
 
 #: lib/presentation_strings.ex:155
 #, elixir-autogen, elixir-format
 msgid "speed restriction"
-msgstr ""
+msgstr "速度限制"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:190
 #, elixir-autogen, elixir-format
 msgid "start of service"
-msgstr ""
+msgstr "服務開始"
 
 #: lib/presentation_strings.ex:156
 #, elixir-autogen, elixir-format
 msgid "strike"
-msgstr ""
+msgstr "罷工"
 
 #: lib/presentation_strings.ex:157
 #, elixir-autogen, elixir-format
 msgid "switch issue"
-msgstr ""
+msgstr "道岔問題"
 
 #: lib/presentation_strings.ex:158
 #, elixir-autogen, elixir-format
 msgid "switch problem"
-msgstr ""
+msgstr "道岔故障"
 
 #: lib/presentation_strings.ex:159
 #, elixir-autogen, elixir-format
 msgid "technical problem"
-msgstr ""
+msgstr "技術故障"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:320
 #, elixir-autogen, elixir-format
 msgid "the **%{time}** %{vehicle}"
-msgstr ""
+msgstr "**%{time}** %{vehicle}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:328
 #, elixir-autogen, elixir-format
 msgid "this %{vehicle}"
-msgstr ""
+msgstr "這 %{vehicle}"
 
 #: lib/presentation_strings.ex:160
 #, elixir-autogen, elixir-format
 msgid "tie replacement"
-msgstr ""
+msgstr "更換軌枕"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:377
 #, elixir-autogen, elixir-format
 msgid "today"
-msgstr ""
+msgstr "今天"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:377
 #, elixir-autogen, elixir-format
 msgid "tomorrow"
-msgstr ""
+msgstr "明天"
 
 #: lib/presentation_strings.ex:161
 #, elixir-autogen, elixir-format
 msgid "track problem"
-msgstr ""
+msgstr "軌道故障"
 
 #: lib/presentation_strings.ex:162
 #, elixir-autogen, elixir-format
 msgid "track work"
-msgstr ""
+msgstr "軌道作業"
 
 #: lib/presentation_strings.ex:163
 #, elixir-autogen, elixir-format
 msgid "traffic"
-msgstr ""
+msgstr "交通"
 
 #: lib/presentation_strings.ex:16
 #, elixir-autogen, elixir-format
 msgid "train"
-msgstr ""
+msgstr "列車"
 
 #: lib/presentation_strings.ex:164
 #, elixir-autogen, elixir-format
 msgid "train traffic"
-msgstr ""
+msgstr "火車交通"
 
 #: lib/presentation_strings.ex:17
 #, elixir-autogen, elixir-format
 msgid "trains"
-msgstr ""
+msgstr "列車"
 
 #: lib/presentation_strings.ex:165
 #, elixir-autogen, elixir-format
 msgid "unruly passenger"
-msgstr ""
+msgstr "乘客干擾"
 
 #: lib/presentation_strings.ex:166
 #, elixir-autogen, elixir-format
 msgid "weather"
-msgstr ""
+msgstr "天氣"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:388
 #, elixir-autogen, elixir-format
 msgid "will not stop at %{stop_list} %{day}"
-msgstr ""
+msgstr "不會止步於 %{stop_list} %{day}"
 
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:411
 #, elixir-autogen, elixir-format
 msgid "will terminate at %{terminating_stop} %{day}"
-msgstr ""
+msgstr "將在 %{terminating_stop} %{day} 處終止"
 
 #: lib/mobile_app_backend_web/components/core_components.ex:484
 #, elixir-autogen, elixir-format, import-optional

--- a/priv/gettext/zh-Hant-TW/LC_MESSAGES/errors.po
+++ b/priv/gettext/zh-Hant-TW/LC_MESSAGES/errors.po
@@ -1,0 +1,12 @@
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: zh-Hant-TW\n"
+"Plural-Forms: nplurals=1\n"

--- a/test/mix/tasks/import_localizations_test.exs
+++ b/test/mix/tasks/import_localizations_test.exs
@@ -1,0 +1,22 @@
+defmodule Mix.Tasks.ImportLocalizationsTest do
+  use ExUnit.Case, async: true
+
+  alias Mix.Tasks.ImportLocalizations
+
+  test "rewrites messages" do
+    po_message = %Expo.Message.Singular{msgid: ["Have a %{quality} %{time}!"], msgstr: [""]}
+
+    xcstrings = %{
+      "strings" => %{
+        "Have a %@ %@!" => %{
+          "localizations" => %{
+            "es" => %{"stringUnit" => %{"value" => "¡Que tenga un %2$@ %1$@!"}}
+          }
+        }
+      }
+    }
+
+    assert %Expo.Message.Singular{msgstr: ["¡Que tenga un %{time} %{quality}!"]} =
+             ImportLocalizations.rewrite_message(po_message, "es", xcstrings)
+  end
+end

--- a/test/mobile_app_backend/alerts/formatted_alert_test.exs
+++ b/test/mobile_app_backend/alerts/formatted_alert_test.exs
@@ -180,7 +180,7 @@ defmodule MobileAppBackend.Alerts.FormattedAlertTest do
         }
       }
 
-      assert "the 10:31 AM train from North Station is replaced by shuttle buses from North Station to Oak Grove some days until Apr 29" ==
+      assert "10:31 AM train from North Station is replaced by shuttle buses from North Station to Oak Grove some days until Apr 29" ==
                FormattedAlert.summary(
                  %FormattedAlert{alert: alert, alert_summary: alert_summary},
                  "en"
@@ -224,7 +224,7 @@ defmodule MobileAppBackend.Alerts.FormattedAlertTest do
         recurrence: nil
       }
 
-      assert "the 10:31 AM train from Concord is replaced by shuttle buses from Porter to North Station" ==
+      assert "10:31 AM train from Concord is replaced by shuttle buses from Porter to North Station" ==
                FormattedAlert.summary(
                  %FormattedAlert{alert: alert, alert_summary: alert_summary},
                  "en"
@@ -451,7 +451,7 @@ defmodule MobileAppBackend.Alerts.FormattedAlertTest do
 
   describe "summary_trip_shuttle_identity/1" do
     test "one trip" do
-      assert "the **10:31 AM** train from Oak Grove" ==
+      assert "**10:31 AM** train from **Oak Grove**" ==
                FormattedAlert.summary_trip_shuttle_identity(%TripShuttle.SingleTrip{
                  trip_time: ~B[2026-04-29 10:31:00],
                  route_type: :commuter_rail,

--- a/test/mobile_app_backend/alerts/formatted_alert_test.exs
+++ b/test/mobile_app_backend/alerts/formatted_alert_test.exs
@@ -86,7 +86,7 @@ defmodule MobileAppBackend.Alerts.FormattedAlertTest do
         is_update: true
       }
 
-      assert "Update: Service suspended from Oak Grove to North Station daily through Apr 29" ==
+      assert "Update: Service suspended from Oak Grove to North Station daily until Apr 29" ==
                FormattedAlert.summary(
                  %FormattedAlert{alert: alert, alert_summary: alert_summary},
                  "en"
@@ -111,7 +111,7 @@ defmodule MobileAppBackend.Alerts.FormattedAlertTest do
         recurrence: %Recurrence.Daily{ending: %Timeframe.LaterDate{time: ~B[2026-04-29 10:31:00]}}
       }
 
-      assert "10:31 AM train from North Station is suspended today due to accident daily through Apr 29" ==
+      assert "10:31 AM train from North Station is suspended today due to accident daily until Apr 29" ==
                FormattedAlert.summary(
                  %FormattedAlert{alert: alert, alert_summary: alert_summary},
                  "en"
@@ -180,7 +180,7 @@ defmodule MobileAppBackend.Alerts.FormattedAlertTest do
         }
       }
 
-      assert "the 10:31 AM train from North Station is replaced by shuttle buses from North Station to Oak Grove some days through Apr 29" ==
+      assert "the 10:31 AM train from North Station is replaced by shuttle buses from North Station to Oak Grove some days until Apr 29" ==
                FormattedAlert.summary(
                  %FormattedAlert{alert: alert, alert_summary: alert_summary},
                  "en"
@@ -203,7 +203,7 @@ defmodule MobileAppBackend.Alerts.FormattedAlertTest do
         }
       }
 
-      assert "Shuttle buses replace the 10:31 AM train from North Station to Oak Grove some days through Apr 29" ==
+      assert "Shuttle buses replace the 10:31 AM train from North Station to Oak Grove some days until Apr 29" ==
                FormattedAlert.summary(
                  %FormattedAlert{alert: alert, alert_summary: alert_summary},
                  "en"
@@ -262,7 +262,7 @@ defmodule MobileAppBackend.Alerts.FormattedAlertTest do
         }
       }
 
-      assert "Shuttle buses replace multiple trips from North Station to Oak Grove daily through Apr 29" ==
+      assert "Shuttle buses replace multiple trips from North Station to Oak Grove daily until Apr 29" ==
                FormattedAlert.summary(
                  %FormattedAlert{alert: alert, alert_summary: alert_summary},
                  "en"
@@ -410,14 +410,14 @@ defmodule MobileAppBackend.Alerts.FormattedAlertTest do
     end
 
     test "some days until later date" do
-      assert " some days through Apr 29" =
+      assert " some days until Apr 29" =
                FormattedAlert.summary_recurrence(%Recurrence.SomeDays{
                  ending: %Timeframe.LaterDate{time: ~B[2026-04-29 10:31:00]}
                })
     end
 
     test "some days through this week" do
-      assert " some days through Wednesday" =
+      assert " some days until Wednesday" =
                FormattedAlert.summary_recurrence(%Recurrence.SomeDays{
                  ending: %Timeframe.ThisWeek{time: ~B[2026-04-29 10:31:00]}
                })


### PR DESCRIPTION
### Summary

_Ticket:_ [Add translations for notifications on backend](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214403748817186?focus=true)

Some of the strings weren’t quite one-to-one with what the frontend does, so I’ve tweaked those.