### PR TITLE
test: Add test for future cancelled trips

### DIFF
--- a/test/mobile_app_backend/notifications/scheduler_test.exs
+++ b/test/mobile_app_backend/notifications/scheduler_test.exs
@@ -5,6 +5,8 @@ defmodule MobileAppBackend.Notifications.SchedulerTest do
 
   import ExUnit.CaptureLog
   import MobileAppBackend.Factory
+  import Mox
+  import Test.Support.Helpers
   alias MBTAV3API.Store
   alias MobileAppBackend.Notifications
   alias MobileAppBackend.Notifications.DeliveredNotification
@@ -383,5 +385,134 @@ defmodule MobileAppBackend.Notifications.SchedulerTest do
     {:ok, _} = perform_job(MobileAppBackend.Notifications.Scheduler, %{})
 
     refute_enqueued(worker: Notifications.Deliverer)
+  end
+
+  test "sends trip cancellation with future active period" do
+    now = DateTime.now!("America/New_York")
+
+    route =
+      build(:route,
+        id: "CR-Fitchburg",
+        line_id: "line-Fitchburg",
+        long_name: "Fitchburg Line",
+        type: :commuter_rail
+      )
+
+    trip =
+      build(:trip,
+        id: "ERMLTieJob-819597-438",
+        route_id: "CR-Fitchburg",
+        direction_id: 1,
+        stop_ids: ["FR-0201-02"]
+      )
+
+    alert =
+      build(:alert,
+        active_period: [
+          %MBTAV3API.Alert.ActivePeriod{
+            start: DateTime.add(now, 3, :hour),
+            end: DateTime.add(now, 7, :hour)
+          }
+        ],
+        effect: :cancellation,
+        informed_entity: [
+          %MBTAV3API.Alert.InformedEntity{
+            activities: [:board, :exit, :ride],
+            route: route.id,
+            route_type: :commuter_rail,
+            direction_id: 1,
+            trip: trip.id
+          }
+        ],
+        last_push_notification_timestamp: DateTime.add(now, -1, :minute)
+      )
+
+    parent_stop = build(:stop, id: "place-FR-0201", name: "Concord")
+    stop = build(:stop, id: "FR-0201-02", name: "Concord", parent_station_id: parent_stop.id)
+
+    reassign_env(:mobile_app_backend, MBTAV3API.Repository, RepositoryMock)
+
+    RepositoryMock
+    |> expect(:schedules, fn _, _ ->
+      ok_response(
+        [
+          build(:schedule,
+            trip_id: trip.id,
+            stop_id: stop.id,
+            route_id: route.id
+          )
+        ],
+        [trip]
+      )
+    end)
+
+    reassign_env(
+      :mobile_app_backend,
+      MobileAppBackend.GlobalDataCache.Module,
+      GlobalDataCacheMock
+    )
+
+    GlobalDataCacheMock
+    |> expect(:default_key, fn -> :default_key end)
+    |> expect(:get_data, fn _ ->
+      %{
+        routes: %{route.id => route},
+        route_patterns: %{
+          "CR-Fitchburg-d82ea33a-1" =>
+            build(:route_pattern,
+              id: "CR-Fitchburg-d82ea33a-1",
+              route_id: route.id,
+              representative_trip_id: trip.id
+            )
+        },
+        trips: %{trip.id => trip},
+        stops: %{
+          parent_stop.id => parent_stop,
+          stop.id => stop
+        },
+        lines: %{
+          "line-Fitchburg" => build(:line, id: "line-Fitchburg")
+        }
+      }
+    end)
+
+    user = NotificationsFactory.insert(:user)
+
+    NotificationsFactory.insert(:notification_subscription,
+      user_id: user.id,
+      route_id: route.id,
+      stop_id: parent_stop.id,
+      direction_id: 1,
+      windows: [NotificationsFactory.perpetual_window_factory()]
+    )
+
+    start_link_supervised!(Store.Alerts)
+    Store.Alerts.process_reset([alert], [])
+    {:ok, _} = perform_job(MobileAppBackend.Notifications.Scheduler, %{})
+
+    assert_enqueued(
+      worker: Notifications.Deliverer,
+      args: %{
+        "user_id" => user.id,
+        "alert_id" => alert.id,
+        "title" => %{
+          "type" => "bare_label",
+          "label" => "Fitchburg Line"
+        },
+        "summary" => %{
+          "effect" => "cancellation",
+          "location" => nil,
+          "timeframe" => %{
+            "type" => "starting_later_today",
+            "time" => DateTime.to_iso8601(DateTime.add(now, 3, :hour))
+          }
+        },
+        "subscriptions" => [
+          %{"route" => route.id, "stop" => parent_stop.id, "direction" => 1}
+        ],
+        "type" => "reminder",
+        "upstream_timestamp" => nil
+      }
+    )
   end
 end


### PR DESCRIPTION
### Summary

_Ticket:_ [Notifications QA | No alert sent for cancellation of future trip](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214429661481092?focus=true)

I was attempting to debug an issue we were seeing with missing notifications for future trip cancellations, so I wrote a test for the case, then it just worked, and the alerts that I'm creating in dev orange are now sending notifications fine. So, now unsure what to do next, but I'll do some more testing on Monday to see if I can reproduce further.