### PR TITLE
fix: Include active alert in next hour as upcoming

### DIFF
--- a/lib/mbta_v3_api/alert.ex
+++ b/lib/mbta_v3_api/alert.ex
@@ -203,8 +203,7 @@ defmodule MBTAV3API.Alert do
   @spec next_period(t(), DateTime.t()) :: ActivePeriod.t() | nil
   def next_period(alert, now) do
     Enum.find(alert.active_period, fn %ActivePeriod{start: ap_start} ->
-      hours_in_future = DateTime.diff(ap_start, now, :hour)
-      hours_in_future > 0 and hours_in_future < 24
+      DateTime.after?(ap_start, now) and DateTime.diff(ap_start, now, :hour) < 24
     end)
   end
 

--- a/test/mobile_app_backend/notifications/engine_test.exs
+++ b/test/mobile_app_backend/notifications/engine_test.exs
@@ -559,7 +559,7 @@ defmodule MobileAppBackend.Notifications.EngineTest do
 
     alert =
       build(:alert,
-        active_period: [%Alert.ActivePeriod{start: DateTime.add(now, 1), end: nil}],
+        active_period: [%Alert.ActivePeriod{start: DateTime.add(now, -1), end: nil}],
         effect: :suspension,
         informed_entity: [%Alert.InformedEntity{activities: [:board], stop: "place-sstat"}],
         last_push_notification_timestamp: upstream_timestamp
@@ -596,7 +596,7 @@ defmodule MobileAppBackend.Notifications.EngineTest do
                summary: %AlertSummary.Standard{
                  effect: :suspension,
                  location: %AlertSummary.Location.SingleStop{stop_name: "South Station"},
-                 timeframe: nil
+                 timeframe: %AlertSummary.Timeframe.UntilFurtherNotice{}
                },
                subscriptions: [_, _],
                alert: ^alert,
@@ -716,7 +716,7 @@ defmodule MobileAppBackend.Notifications.EngineTest do
 
     alert =
       build(:alert,
-        active_period: [%Alert.ActivePeriod{start: DateTime.add(now, 1), end: nil}],
+        active_period: [%Alert.ActivePeriod{start: DateTime.add(now, -1), end: nil}],
         effect: :suspension,
         informed_entity: [
           %Alert.InformedEntity{activities: [:board], stop: "place-sstat"},
@@ -756,7 +756,7 @@ defmodule MobileAppBackend.Notifications.EngineTest do
                summary: %AlertSummary.Standard{
                  effect: :suspension,
                  location: nil,
-                 timeframe: nil
+                 timeframe: %AlertSummary.Timeframe.UntilFurtherNotice{}
                },
                subscriptions: [^subscription1, ^subscription2],
                alert: ^alert,

--- a/test/mobile_app_backend/notifications/scheduler_test.exs
+++ b/test/mobile_app_backend/notifications/scheduler_test.exs
@@ -534,4 +534,126 @@ defmodule MobileAppBackend.Notifications.SchedulerTest do
       }
     )
   end
+
+  test "sends trip cancellation reminder with near future active period" do
+    now = DateTime.now!("America/New_York")
+
+    route =
+      build(:route,
+        id: "CR-Fitchburg",
+        line_id: "line-Fitchburg",
+        long_name: "Fitchburg Line",
+        type: :commuter_rail
+      )
+
+    trip =
+      build(:trip,
+        id: "ERMLTieJob-819597-438",
+        route_id: "CR-Fitchburg",
+        direction_id: 1,
+        stop_ids: ["FR-0201-02"]
+      )
+
+    start_time = DateTime.add(now, 20, :minute)
+
+    alert =
+      build(:alert,
+        active_period: [
+          %MBTAV3API.Alert.ActivePeriod{
+            start: start_time,
+            end: DateTime.add(now, 7, :hour)
+          }
+        ],
+        effect: :cancellation,
+        informed_entity: [
+          %MBTAV3API.Alert.InformedEntity{
+            activities: [:board, :exit, :ride],
+            route: route.id,
+            route_type: :commuter_rail,
+            direction_id: 1,
+            trip: trip.id
+          }
+        ],
+        last_push_notification_timestamp: DateTime.add(now, -1, :minute)
+      )
+
+    parent_stop = build(:stop, id: "place-FR-0201", name: "Concord")
+    stop = build(:stop, id: "FR-0201-02", name: "Concord", parent_station_id: parent_stop.id)
+
+    reassign_env(:mobile_app_backend, MBTAV3API.Repository, RepositoryMock)
+
+    RepositoryMock
+    |> expect(:schedules, fn _, _ ->
+      ok_response(
+        [
+          build(:schedule,
+            trip_id: trip.id,
+            stop_id: stop.id,
+            route_id: route.id
+          )
+        ],
+        [trip]
+      )
+    end)
+
+    reassign_env(
+      :mobile_app_backend,
+      MobileAppBackend.GlobalDataCache.Module,
+      GlobalDataCacheMock
+    )
+
+    GlobalDataCacheMock
+    |> expect(:default_key, fn -> :default_key end)
+    |> expect(:get_data, fn _ ->
+      %{
+        routes: %{route.id => route},
+        route_patterns: %{
+          "CR-Fitchburg-d82ea33a-1" =>
+            build(:route_pattern,
+              id: "CR-Fitchburg-d82ea33a-1",
+              route_id: route.id,
+              representative_trip_id: trip.id
+            )
+        },
+        trips: %{trip.id => trip},
+        stops: %{
+          parent_stop.id => parent_stop,
+          stop.id => stop
+        },
+        lines: %{
+          "line-Fitchburg" => build(:line, id: "line-Fitchburg")
+        }
+      }
+    end)
+
+    user = NotificationsFactory.insert(:user)
+
+    NotificationsFactory.insert(:notification_subscription,
+      user_id: user.id,
+      route_id: route.id,
+      stop_id: parent_stop.id,
+      direction_id: 1,
+      windows: [NotificationsFactory.perpetual_window_factory()]
+    )
+
+    start_link_supervised!(Store.Alerts)
+    Store.Alerts.process_reset([alert], [])
+    {:ok, _} = perform_job(MobileAppBackend.Notifications.Scheduler, %{})
+
+    assert_enqueued(
+      worker: Notifications.Deliverer,
+      args: %{
+        "user_id" => user.id,
+        "alert_id" => alert.id,
+        "title" => "Fitchburg Line",
+        "body" =>
+          "Trip cancelled starting #{Util.datetime_to_string(start_time, :short_time)} today",
+        "subscriptions" => [
+          %{"route" => route.id, "stop" => parent_stop.id, "direction" => 1}
+        ],
+        "type" => "reminder",
+        "upstream_timestamp" => nil
+      }
+    )
+  end
 end


### PR DESCRIPTION
### Summary

_Ticket:_ [Notifications QA | No alert sent for cancellation of future trip](https://app.asana.com/1/15492006741476/project/1205425564113216/task/1214429661481092?focus=true)

Found it 😅 

`DateTime.diff(ap_start, now, :hour)` truncates any fraction, so alerts between now and now + 1hr will return 0, which `Alert.next_period` considered to be happening now, so it wasn't included in currently active or soon active.