### PR TITLE
fix: wrong location case for all clear

### DIFF
--- a/lib/mobile_app_backend/alerts/alert_summary.ex
+++ b/lib/mobile_app_backend/alerts/alert_summary.ex
@@ -559,6 +559,11 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
     end
   end
 
+  defp alert_location_closure(alert, affected_stops) do
+    alert.effect in [:station_closure, :stop_closure] and
+      length(affected_stops) > 0 and Alert.active?(alert)
+  end
+
   @spec alert_location(Alert.t(), Stop.id(), 0 | 1, [RoutePattern.t()], GlobalDataCache.data()) ::
           Location.t() | nil
   def alert_location(alert, stop_id, direction_id, patterns, global) do
@@ -588,8 +593,7 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
       downstream = Enum.all?(affected_stops, &(&1.id != stop_id))
 
       cond do
-        alert.effect in [:station_closure, :stop_closure] and
-          length(affected_stops) > 0 and Alert.active?(alert) ->
+        alert_location_closure(alert, affected_stops) ->
           %Location.AffectedStops{
             stops: Enum.map(affected_stops, fn stop -> stop.name end)
           }

--- a/lib/mobile_app_backend/alerts/alert_summary.ex
+++ b/lib/mobile_app_backend/alerts/alert_summary.ex
@@ -589,7 +589,7 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
 
       cond do
         alert.effect in [:station_closure, :stop_closure] and
-            length(affected_stops) > 0 ->
+          length(affected_stops) > 0 and Alert.active?(alert) ->
           %Location.AffectedStops{
             stops: Enum.map(affected_stops, fn stop -> stop.name end)
           }

--- a/test/mobile_app_backend/alerts/alert_summary_test.exs
+++ b/test/mobile_app_backend/alerts/alert_summary_test.exs
@@ -2203,6 +2203,99 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                AlertSummary.combine_summaries(alert, [summary1, summary2])
     end
 
+    test "all clear doesn't return affected stops for closure alerts" do
+      first_stop = build(:stop, name: "First Stop")
+      successive_stops = build_list(4, :stop)
+      last_stop = build(:stop, name: "Last Stop")
+
+      stops = [first_stop] ++ successive_stops ++ [last_stop]
+
+      route = build(:route, type: :light_rail)
+      trip = build(:trip, stop_ids: Enum.map(stops, & &1.id))
+
+      pattern =
+        build(:route_pattern,
+          route_id: route.id,
+          direction_id: 0,
+          representative_trip_id: trip.id
+        )
+
+      now = DateTime.now!("America/New_York")
+      upstream_timestamp = DateTime.add(now, -2)
+
+      alert =
+        build(:alert,
+          active_period: [
+            %Alert.ActivePeriod{start: DateTime.add(now, -10), end: DateTime.add(now, -5)}
+          ],
+          closed_timestamp: upstream_timestamp,
+          effect: :stop_closure,
+          informed_entity:
+            Enum.map(
+              successive_stops ++ [last_stop],
+              &%Alert.InformedEntity{
+                activities: ~w(board exit ride)a,
+                route: route.id,
+                stop: &1.id
+              }
+            ),
+          last_push_notification_timestamp: upstream_timestamp
+        )
+
+      assert %AlertSummary.AllClear{
+               location: %AlertSummary.Location.SuccessiveStops{
+                 start_stop_name: "Harvard Sq @ Garden St - Dawes Island",
+                 end_stop_name: "Last Stop",
+                 downstream: false
+               }
+             } =
+               AlertSummary.summarizing(
+                 alert,
+                 Enum.at(successive_stops, 2).id,
+                 0,
+                 [pattern],
+                 now,
+                 nil,
+                 %{
+                   routes: %{route.id => route},
+                   stops: Map.new(stops, &{&1.id, &1}),
+                   trips: %{trip.id => trip}
+                 }
+               )
+    end
+
+    test "stop closure returns affected stops when active", %{now: now} do
+      stop = build(:stop, name: "Parent Name")
+      child_stop = build(:stop, parent_station_id: stop.id)
+      stop = put_in(stop.child_stop_ids, [child_stop.id])
+
+      route = build(:route)
+      pattern = build(:route_pattern, route_id: route.id, direction_id: 0)
+
+      alert =
+        build(:alert,
+          active_period: [%Alert.ActivePeriod{start: DateTime.add(now, -1), end: nil}],
+          effect: :stop_closure,
+          informed_entity: [
+            %Alert.InformedEntity{
+              activities: ~w(board exit ride)a,
+              route: route.id,
+              stop: child_stop.id
+            }
+          ]
+        )
+
+      assert %AlertSummary.Standard{
+               location: %AlertSummary.Location.AffectedStops{
+                 stops: ["Parent Name"]
+               }
+             } =
+               AlertSummary.summarizing(alert, "", 0, [pattern], now, nil, %{
+                 routes: %{route.id => route},
+                 stops: %{stop.id => stop, child_stop.id => child_stop}
+               })
+    end
+
     test "trip specific - same trip and stops" do
       now = DateTime.now!("America/New_York")
 

--- a/test/mobile_app_backend/alerts/formatted_alert_test.exs
+++ b/test/mobile_app_backend/alerts/formatted_alert_test.exs
@@ -50,6 +50,23 @@ defmodule MobileAppBackend.Alerts.FormattedAlertTest do
                  "en"
                )
     end
+
+    test "all clear single stop" do
+      alert = build(:alert, effect: :suspension)
+
+      alert_summary = %AlertSummary.AllClear{
+        location: %Location.SingleStop{
+          stop_name: "Ruggles",
+          downstream: false
+        }
+      }
+
+      assert "All clear: Regular service at Ruggles" ==
+               FormattedAlert.summary(
+                 %FormattedAlert{alert: alert, alert_summary: alert_summary},
+                 "en"
+               )
+    end
   end
 
   describe "summary/2 standard" do


### PR DESCRIPTION
### Summary

_Ticket:_ [Notifications | All clear for stop alerts](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214584716899330?focus=true)

Whoops 😓 AffectedStops Location type should only be used for active closure alerts.

frontend PR: https://github.com/mbta/mobile_app/pull/1712
