### PR TITLE
chore: remove workaround for all-day recurring-some-days alert

### DIFF
--- a/lib/mbta_v3_api/alert.ex
+++ b/lib/mbta_v3_api/alert.ex
@@ -227,16 +227,9 @@ defmodule MBTAV3API.Alert do
   def parse!(%JsonApi.Item{} = item) do
     %__MODULE__{
       id: item.id,
-      # Temoporarily disable active period collapsing for GL alert 4/22-5/1
-      # Due to recurrence display issues
-      # https://mbta.slack.com/archives/C05QMG9GS9M/p1776863350368949
       active_period:
-        if item.id == "1001899" do
-          Enum.map(item.attributes["active_period"], &ActivePeriod.parse!/1)
-        else
-          Enum.map(item.attributes["active_period"], &ActivePeriod.parse!/1)
-          |> ActivePeriod.collapse()
-        end,
+        Enum.map(item.attributes["active_period"], &ActivePeriod.parse!/1)
+        |> ActivePeriod.collapse(),
       cause: parse_cause(item.attributes["cause"]),
       closed_timestamp: Util.parse_optional_datetime!(item.attributes["closed_timestamp"]),
       description: item.attributes["description"],


### PR DESCRIPTION
### Summary

_Ticket:_ [Undo GL-B alert backend special casing](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214187293359107)

Reverts #468 since that alert is over and we handle that case better as of https://github.com/mbta/mobile_app/pull/1689.