### PR TITLE
feat: add trip_headsign field

### DIFF
--- a/lib/mbta_v3_api/prediction.ex
+++ b/lib/mbta_v3_api/prediction.ex
@@ -12,6 +12,7 @@ defmodule MBTAV3API.Prediction do
           schedule_relationship: schedule_relationship(),
           status: String.t(),
           stop_sequence: integer() | nil,
+          trip_headsign: String.t() | nil,
           route_id: String.t(),
           stop_id: String.t(),
           trip_id: String.t(),
@@ -37,6 +38,7 @@ defmodule MBTAV3API.Prediction do
     :schedule_relationship,
     :status,
     :stop_sequence,
+    :trip_headsign,
     :route_id,
     :stop_id,
     :trip_id,
@@ -52,7 +54,8 @@ defmodule MBTAV3API.Prediction do
       :revenue_status,
       :schedule_relationship,
       :status,
-      :stop_sequence
+      :stop_sequence,
+      :trip_headsign
     ]
   end
 
@@ -77,6 +80,7 @@ defmodule MBTAV3API.Prediction do
       schedule_relationship:
         parse_schedule_relationship(item.attributes["schedule_relationship"]),
       stop_sequence: item.attributes["stop_sequence"],
+      trip_headsign: item.attributes["trip_headsign"],
       status: item.attributes["status"],
       route_id: JsonApi.Object.get_one_id(item.relationships["route"]),
       stop_id: JsonApi.Object.get_one_id(item.relationships["stop"]),

--- a/test/mbta_v3_api/prediction_test.exs
+++ b/test/mbta_v3_api/prediction_test.exs
@@ -15,7 +15,8 @@ defmodule MBTAV3API.PredictionTest do
                "last_trip" => true,
                "schedule_relationship" => "ADDED",
                "status" => nil,
-               "stop_sequence" => 440
+               "stop_sequence" => 440,
+               "trip_headsign" => "Kenmore"
              },
              relationships: %{
                "route" => %JsonApi.Reference{id: "Green-C", type: "route"},
@@ -33,6 +34,7 @@ defmodule MBTAV3API.PredictionTest do
              schedule_relationship: :added,
              status: nil,
              stop_sequence: 440,
+             trip_headsign: "Kenmore",
              route_id: "Green-C",
              stop_id: "70237",
              trip_id: "ADDED-1591587107",


### PR DESCRIPTION
### Summary

_Ticket:_ [Use new trip_headsign field](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214110029669184?focus=true)

Adds trip_headsign field to prediction model.
