### PR TITLE
feat: add analytics label to notifications

### DIFF
--- a/lib/mobile_app_backend/notifications/deliverer.ex
+++ b/lib/mobile_app_backend/notifications/deliverer.ex
@@ -16,7 +16,8 @@ defmodule MobileAppBackend.Notifications.Deliverer do
           "body" => body,
           "deep_link_path" => deep_link_path,
           "upstream_timestamp" => upstream_timestamp,
-          "type" => type
+          "type" => type,
+          "analytics_label" => analytics_label
         }
       }) do
     upstream_timestamp =
@@ -58,6 +59,9 @@ defmodule MobileAppBackend.Notifications.Deliverer do
         },
         apns: %FCM.Model.ApnsConfig{
           payload: %{aps: %{sound: "default"}}
+        },
+        fcmOptions: %FCM.Model.FcmOptions{
+          analyticsLabel: analytics_label
         },
         token: user.fcm_token
       }

--- a/lib/mobile_app_backend/notifications/engine/outgoing_notification.ex
+++ b/lib/mobile_app_backend/notifications/engine/outgoing_notification.ex
@@ -22,10 +22,11 @@ defmodule MobileAppBackend.Notifications.Engine.OutgoingNotification do
             body: String.t(),
             subscriptions: [Subscription.t()],
             alert_id: Alert.id(),
+            alert_effect: Alert.effect(),
             type: DeliveredNotification.type(),
             locale: Gettext.locale()
           }
-    defstruct [:title, :body, :subscriptions, :alert_id, :type, :locale]
+    defstruct [:title, :body, :subscriptions, :alert_id, :alert_effect, :type, :locale]
   end
 
   @spec localize(t(), Gettext.locale()) :: Localized.t()
@@ -45,6 +46,7 @@ defmodule MobileAppBackend.Notifications.Engine.OutgoingNotification do
         ),
       subscriptions: outgoing_notification.subscriptions,
       alert_id: outgoing_notification.alert.id,
+      alert_effect: outgoing_notification.alert.effect,
       type: outgoing_notification.type,
       locale: locale
     }

--- a/lib/mobile_app_backend/notifications/scheduler.ex
+++ b/lib/mobile_app_backend/notifications/scheduler.ex
@@ -168,7 +168,8 @@ defmodule MobileAppBackend.Notifications.Scheduler do
       body: notification.body,
       deep_link_path: deep_link_path(notification.alert_id, subscriptions),
       upstream_timestamp: upstream_timestamp,
-      type: type
+      type: type,
+      analytics_label: analytics_label(subscriptions, notification.alert_effect, type)
     }
     |> Deliverer.new()
     |> Oban.insert!()
@@ -216,6 +217,16 @@ defmodule MobileAppBackend.Notifications.Scheduler do
     else
       "/a/#{alert_id}" <> route_piece <> stop_piece
     end
+  end
+
+  @spec analytics_label(
+          [%{route: MBTAV3API.Route.id(), stop: MBTAV3API.Stop.id(), direction: 0 | 1}],
+          Alert.effect(),
+          atom()
+        ) :: String.t()
+  defp analytics_label(subscriptions, alert_effect, type) do
+    route_ids = subscriptions |> Enum.map(& &1.route) |> Enum.uniq() |> Enum.join(",")
+    "route=#{route_ids};effect=#{alert_effect};type=#{type}"
   end
 
   defp log_exception(step_name, metadata, error) do

--- a/test/mobile_app_backend/notifications/deliverer_test.exs
+++ b/test/mobile_app_backend/notifications/deliverer_test.exs
@@ -30,6 +30,7 @@ defmodule MobileAppBackend.Notifications.DelivererTest do
     title = "Notification title"
     body = "Notification body"
     deep_link_path = "/a/#{alert_id}/r/1/s/1"
+    analytics_label = "route=1;effect=delay;type=notification"
 
     reassign_persistent_term(GCPToken.default_key(), %GCPToken.StoredToken{
       token: "gcp_token",
@@ -52,7 +53,8 @@ defmodule MobileAppBackend.Notifications.DelivererTest do
         body: body,
         deep_link_path: deep_link_path,
         upstream_timestamp: upstream_timestamp,
-        type: type
+        type: type,
+        analytics_label: analytics_label
       })
 
     assert_received_tesla_call(received_env, received_opts, adapter: TeslaMockAdapter)
@@ -75,7 +77,8 @@ defmodule MobileAppBackend.Notifications.DelivererTest do
                notification: %{title: title, body: body},
                data: %{deep_link_path: deep_link_path},
                android: %{notification: %{tag: alert_id, sound: "default"}},
-               apns: %{payload: %{aps: %{sound: "default"}}}
+               apns: %{payload: %{aps: %{sound: "default"}}},
+               fcmOptions: %{analyticsLabel: analytics_label}
              }
            }
 
@@ -106,6 +109,7 @@ defmodule MobileAppBackend.Notifications.DelivererTest do
     title = "Notification title"
     body = "Notification body"
     deep_link_path = "/a/#{alert_id}/r/1/s/1"
+    analytics_label = "route=1;effect=delay;type=notification"
 
     reassign_persistent_term(GCPToken.default_key(), %GCPToken.StoredToken{
       token: "gcp_token",
@@ -129,7 +133,8 @@ defmodule MobileAppBackend.Notifications.DelivererTest do
           body: body,
           deep_link_path: deep_link_path,
           upstream_timestamp: upstream_timestamp,
-          type: type
+          type: type,
+          analytics_label: analytics_label
         })
       end)
 
@@ -171,7 +176,8 @@ defmodule MobileAppBackend.Notifications.DelivererTest do
           body: "body",
           deep_link_path: "/a/#{alert_id}/r/1/s/1",
           upstream_timestamp: upstream_timestamp,
-          type: type
+          type: type,
+          analytics_label: "route=1;effect=delay;type=notification"
         })
       end)
 

--- a/test/mobile_app_backend/notifications/scheduler_test.exs
+++ b/test/mobile_app_backend/notifications/scheduler_test.exs
@@ -61,7 +61,9 @@ defmodule MobileAppBackend.Notifications.SchedulerTest do
         "title" => "66 bus",
         "body" => "Service suspended until further notice",
         "deep_link_path" => "/s/1/r/66/d/0",
-        "upstream_timestamp" => alert.last_push_notification_timestamp
+        "upstream_timestamp" => alert.last_push_notification_timestamp,
+        "type" => "notification",
+        "analytics_label" => "route=66;effect=suspension;type=notification"
       }
     )
   end
@@ -115,7 +117,9 @@ defmodule MobileAppBackend.Notifications.SchedulerTest do
         "title" => "66 autobús",
         "body" => "Servicio suspendido hasta nuevo aviso",
         "deep_link_path" => "/s/1/r/66/d/0",
-        "upstream_timestamp" => alert.last_push_notification_timestamp
+        "upstream_timestamp" => alert.last_push_notification_timestamp,
+        "type" => "notification",
+        "analytics_label" => "route=66;effect=suspension;type=notification"
       }
     )
   end
@@ -217,7 +221,8 @@ defmodule MobileAppBackend.Notifications.SchedulerTest do
         "body" => "Service suspended starting tomorrow",
         "deep_link_path" => "/s/1/r/66/d/0",
         "type" => "reminder",
-        "upstream_timestamp" => nil
+        "upstream_timestamp" => nil,
+        "analytics_label" => "route=66;effect=suspension;type=reminder"
       }
     )
   end
@@ -358,7 +363,8 @@ defmodule MobileAppBackend.Notifications.SchedulerTest do
         "body" => "All clear: Regular service",
         "deep_link_path" => "/s/1/r/66/d/0",
         "type" => "all_clear",
-        "upstream_timestamp" => nil
+        "upstream_timestamp" => nil,
+        "analytics_label" => "route=66;effect=suspension;type=all_clear"
       }
     )
   end
@@ -528,7 +534,8 @@ defmodule MobileAppBackend.Notifications.SchedulerTest do
           "Trip cancelled starting #{Util.datetime_to_string(start_time, :short_time)} today",
         "deep_link_path" => "/s/#{parent_stop.id}/r/#{route.id}/d/1",
         "type" => "reminder",
-        "upstream_timestamp" => nil
+        "upstream_timestamp" => nil,
+        "analytics_label" => "route=CR-Fitchburg;effect=cancellation;type=reminder"
       }
     )
   end
@@ -648,7 +655,8 @@ defmodule MobileAppBackend.Notifications.SchedulerTest do
           "Trip cancelled starting #{Util.datetime_to_string(start_time, :short_time)} today",
         "deep_link_path" => "/s/#{parent_stop.id}/r/#{route.id}/d/1",
         "type" => "reminder",
-        "upstream_timestamp" => nil
+        "upstream_timestamp" => nil,
+        "analytics_label" => "route=CR-Fitchburg;effect=cancellation;type=reminder"
       }
     )
   end
@@ -824,7 +832,10 @@ defmodule MobileAppBackend.Notifications.SchedulerTest do
 
       assert_enqueued(
         worker: Notifications.Deliverer,
-        args: %{"deep_link_path" => "/s/1"}
+        args: %{
+          "deep_link_path" => "/s/1",
+          "analytics_label" => "route=66,68;effect=suspension;type=notification"
+        }
       )
     end
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Notifications | Click analytics](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214587659492421)

Distinguishing updates from regular notifications is tricky, so I’m spinning that out into its own PR.