### PR TITLE
feat: include analytics label directly in notification payload

### DIFF
--- a/lib/mobile_app_backend/notifications/deliverer.ex
+++ b/lib/mobile_app_backend/notifications/deliverer.ex
@@ -50,7 +50,7 @@ defmodule MobileAppBackend.Notifications.Deliverer do
           title: title,
           body: body
         },
-        data: %{deep_link_path: deep_link_path},
+        data: %{deep_link_path: deep_link_path, analytics_label: analytics_label},
         android: %FCM.Model.AndroidConfig{
           notification: %FCM.Model.AndroidNotification{
             sound: "default",

--- a/test/mobile_app_backend/notifications/deliverer_test.exs
+++ b/test/mobile_app_backend/notifications/deliverer_test.exs
@@ -75,7 +75,7 @@ defmodule MobileAppBackend.Notifications.DelivererTest do
              message: %{
                token: fcm_token,
                notification: %{title: title, body: body},
-               data: %{deep_link_path: deep_link_path},
+               data: %{deep_link_path: deep_link_path, analytics_label: analytics_label},
                android: %{notification: %{tag: alert_id, sound: "default"}},
                apns: %{payload: %{aps: %{sound: "default"}}},
                fcmOptions: %{analyticsLabel: analytics_label}


### PR DESCRIPTION
### Summary

_Ticket:_ [Notifications | Click analytics](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214587659492421)

If these are the important fields, we can use these on the frontend (https://github.com/mbta/mobile_app/pull/1733) to set the analytics metadata.

Tangential to #514. Builds on #513.
