### PR TITLE
fix: Missing route pattern ID nil key error

### DIFF
--- a/lib/mobile_app_backend_web/controllers/trip_controller.ex
+++ b/lib/mobile_app_backend_web/controllers/trip_controller.ex
@@ -1,5 +1,6 @@
 defmodule MobileAppBackendWeb.TripController do
   alias MBTAV3API.Repository
+  alias MBTAV3API.Trip
   alias MobileAppBackendWeb.ShapesController
   use MobileAppBackendWeb, :controller
 
@@ -44,6 +45,11 @@ defmodule MobileAppBackendWeb.TripController do
 
   def map_friendly(conn, %{"trip_id" => trip_id}) do
     case get_trip_shape_data(trip_id) do
+      {:ok, %{trip: %Trip{route_pattern_id: nil}}} ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{message: "Missing route pattern for trip #{trip_id}"})
+
       {:ok, data} ->
         json(conn, get_map_friendly_shapes(data))
 

--- a/test/mobile_app_backend_web/controllers/trip_controller_test.exs
+++ b/test/mobile_app_backend_web/controllers/trip_controller_test.exs
@@ -314,6 +314,41 @@ defmodule MobileAppBackendWeb.TripControllerTest do
                response
     end
 
+    test "when trip found without route pattern, returns 404 error",
+         %{conn: conn} do
+      trip =
+        build(:trip,
+          id: "trip_id",
+          route_id: "66",
+          route_pattern_id: nil,
+          direction_id: "1",
+          shape_id: "66_shape",
+          stop_ids: []
+        )
+
+      shape = build(:shape, id: trip.shape_id, polyline: "66_shape_polyline")
+
+      RepositoryMock
+      |> expect(:trips, 1, fn params, _opts ->
+        case params
+             |> Keyword.get(:filter)
+             |> Keyword.get(:id) do
+          "trip_id" ->
+            ok_response([trip], [shape])
+
+          _ ->
+            ok_response([])
+        end
+      end)
+
+      conn =
+        get(conn, "/api/trip/map-friendly", %{"trip_id" => trip.id})
+
+      response = json_response(conn, 404)
+
+      assert %{"message" => "Missing route pattern for trip trip_id"} = response
+    end
+
     @tag capture_log: true
     test "when trip not found, 404 error",
          %{conn: conn} do


### PR DESCRIPTION


### Summary

_Ticket:_ [Sentry | Trip Controller key nil not found in: %{}](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214499500943245?focus=true)

We're getting a bunch of Sentry errors for this when added trips are being returned from the API with a nil route pattern ID. This handles those cases by returning a 404 rather than crashing.
