### PR TITLE
feat: Include summary entities in v3 alert stream

### DIFF
--- a/lib/mbta_v3_api/alert.ex
+++ b/lib/mbta_v3_api/alert.ex
@@ -7,6 +7,7 @@ defmodule MBTAV3API.Alert do
   alias MBTAV3API.RoutePattern
   alias MBTAV3API.Stop
   alias MBTAV3API.Trip
+  alias MobileAppBackend.Alerts.SummaryEntity
 
   @type t :: %__MODULE__{
           id: String.t(),
@@ -22,6 +23,7 @@ defmodule MBTAV3API.Alert do
           last_push_notification_timestamp: DateTime.t() | nil,
           lifecycle: lifecycle(),
           severity: integer(),
+          summaries: [SummaryEntity.t()] | nil,
           updated_at: DateTime.t()
         }
 
@@ -158,6 +160,7 @@ defmodule MBTAV3API.Alert do
     :last_push_notification_timestamp,
     :lifecycle,
     :severity,
+    :summaries,
     :updated_at
   ]
 
@@ -176,6 +179,7 @@ defmodule MBTAV3API.Alert do
       :last_push_notification_timestamp,
       :lifecycle,
       :severity,
+      :summaries,
       :updated_at
     ]
   end

--- a/lib/mbta_v3_api/alert.ex
+++ b/lib/mbta_v3_api/alert.ex
@@ -7,7 +7,6 @@ defmodule MBTAV3API.Alert do
   alias MBTAV3API.RoutePattern
   alias MBTAV3API.Stop
   alias MBTAV3API.Trip
-  alias MobileAppBackend.Alerts.SummaryEntity
 
   @type t :: %__MODULE__{
           id: String.t(),
@@ -23,7 +22,6 @@ defmodule MBTAV3API.Alert do
           last_push_notification_timestamp: DateTime.t() | nil,
           lifecycle: lifecycle(),
           severity: integer(),
-          summaries: [SummaryEntity.t()] | nil,
           updated_at: DateTime.t()
         }
 
@@ -160,7 +158,6 @@ defmodule MBTAV3API.Alert do
     :last_push_notification_timestamp,
     :lifecycle,
     :severity,
-    :summaries,
     :updated_at
   ]
 
@@ -179,7 +176,6 @@ defmodule MBTAV3API.Alert do
       :last_push_notification_timestamp,
       :lifecycle,
       :severity,
-      :summaries,
       :updated_at
     ]
   end

--- a/lib/mbta_v3_api/route_pattern.ex
+++ b/lib/mbta_v3_api/route_pattern.ex
@@ -1,5 +1,6 @@
 defmodule MBTAV3API.RoutePattern do
   alias MBTAV3API.Trip
+  alias MobileAppBackend.GlobalDataCache
   use MBTAV3API.JsonApi.Object
   require Util
 
@@ -95,7 +96,7 @@ defmodule MBTAV3API.RoutePattern do
 
   @spec canonical_or_most_typical([t()]) :: [t()]
   # Filter the list of route patterns to include only the canonical or most typical patterns
-  defp canonical_or_most_typical(route_patterns) do
+  def canonical_or_most_typical(route_patterns) do
     canonical_patterns = Enum.filter(route_patterns, & &1.canonical)
 
     case canonical_patterns do
@@ -126,5 +127,32 @@ defmodule MBTAV3API.RoutePattern do
     route_patterns
     |> Enum.map(& &1.route)
     |> Map.new(&{&1.id, &1})
+  end
+
+  @spec get_relevant_patterns(
+          String.t() | nil,
+          String.t() | nil,
+          integer() | nil,
+          GlobalDataCache.data()
+        ) :: [t()]
+  def get_relevant_patterns(route_id, stop_id, direction_id, global_data) do
+    global_data.route_patterns
+    |> Stream.map(fn {_, pattern} -> pattern end)
+    |> Enum.filter(fn pattern ->
+      (route_id == nil or pattern.route_id == route_id or
+         global_data.routes[pattern.route_id].line_id == route_id) and
+        (direction_id == nil or pattern.direction_id == direction_id) and
+        (stop_id == nil or
+           Enum.any?(
+             with trip_id when is_binary(trip_id) <- pattern.representative_trip_id,
+                  %Trip{} = trip <- global_data.trips[trip_id] do
+               trip.stop_ids
+             else
+               _ -> []
+             end,
+             &(&1 == stop_id or
+                 &1 in global_data.stops[stop_id].child_stop_ids)
+           ))
+    end)
   end
 end

--- a/lib/mbta_v3_api/route_pattern.ex
+++ b/lib/mbta_v3_api/route_pattern.ex
@@ -139,20 +139,37 @@ defmodule MBTAV3API.RoutePattern do
     global_data.route_patterns
     |> Stream.map(fn {_, pattern} -> pattern end)
     |> Enum.filter(fn pattern ->
-      (route_id == nil or pattern.route_id == route_id or
-         global_data.routes[pattern.route_id].line_id == route_id) and
-        (direction_id == nil or pattern.direction_id == direction_id) and
-        (stop_id == nil or
-           Enum.any?(
-             with trip_id when is_binary(trip_id) <- pattern.representative_trip_id,
-                  %Trip{} = trip <- global_data.trips[trip_id] do
-               trip.stop_ids
-             else
-               _ -> []
-             end,
-             &(&1 == stop_id or
-                 &1 in global_data.stops[stop_id].child_stop_ids)
-           ))
+      match_pattern_route?(pattern, route_id, global_data) and
+        match_pattern_stop?(pattern, stop_id, global_data) and
+        match_pattern_direction?(pattern, direction_id)
     end)
+  end
+
+  defp match_pattern_route?(
+         %__MODULE__{route_id: pattern_route_id},
+         route_id,
+         global
+       ) do
+    route_id == nil or pattern_route_id == route_id or
+      global.routes[pattern_route_id].line_id == route_id
+  end
+
+  defp match_pattern_stop?(
+         %__MODULE__{representative_trip_id: representative_trip_id},
+         stop_id,
+         global
+       ) do
+    stop_id == nil or
+      with trip_id when is_binary(trip_id) <- representative_trip_id,
+           %Trip{} = trip <- global.trips[trip_id] do
+        trip.stop_ids
+      else
+        _ -> []
+      end
+      |> Enum.any?(&(&1 == stop_id or &1 in global.stops[stop_id].child_stop_ids))
+  end
+
+  defp match_pattern_direction?(%__MODULE__{direction_id: pattern_direction_id}, direction_id) do
+    direction_id == nil or pattern_direction_id == direction_id
   end
 end

--- a/lib/mbta_v3_api/stop.ex
+++ b/lib/mbta_v3_api/stop.ex
@@ -90,8 +90,8 @@ defmodule MBTAV3API.Stop do
   If the stop has a parent station and that parent is present in the map of stops, return the parent.
   Otherwise, returns the stop as-is.
   """
-  def parent_if_exists(%__MODULE__{parent_station_id: nil} = child_stop, _stops_by_id) do
-    child_stop
+  def parent_if_exists(%__MODULE__{parent_station_id: nil} = parent_stop, _stops_by_id) do
+    parent_stop
   end
 
   def parent_if_exists(

--- a/lib/mobile_app_backend/alerts/alert_with_summaries.ex
+++ b/lib/mobile_app_backend/alerts/alert_with_summaries.ex
@@ -1,0 +1,47 @@
+defmodule MobileAppBackend.Alerts.AlertWithSummaries do
+  alias MBTAV3API.Alert
+  alias MBTAV3API.Alert.ActivePeriod
+  alias MBTAV3API.Alert.InformedEntity
+  alias MobileAppBackend.Alerts.SummaryEntity
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          active_period: [ActivePeriod.t()],
+          cause: Alert.cause(),
+          closed_timestamp: DateTime.t() | nil,
+          description: String.t() | nil,
+          duration_certainty: Alert.duration_certainty(),
+          effect: Alert.effect(),
+          effect_name: String.t() | nil,
+          header: String.t() | nil,
+          informed_entity: [InformedEntity.t()],
+          last_push_notification_timestamp: DateTime.t() | nil,
+          lifecycle: Alert.lifecycle(),
+          severity: integer(),
+          summaries: [SummaryEntity.t()],
+          updated_at: DateTime.t()
+        }
+
+  @derive Jason.Encoder
+  defstruct [
+    :id,
+    :active_period,
+    :cause,
+    :closed_timestamp,
+    :description,
+    :duration_certainty,
+    :effect,
+    :effect_name,
+    :header,
+    :informed_entity,
+    :last_push_notification_timestamp,
+    :lifecycle,
+    :severity,
+    :summaries,
+    :updated_at
+  ]
+
+  @spec from_alert(Alert.t(), [SummaryEntity.t()]) :: t()
+  def from_alert(alert, summaries),
+    do: struct(%__MODULE__{summaries: summaries}, Map.from_struct(alert))
+end

--- a/lib/mobile_app_backend/alerts/pub_sub.ex
+++ b/lib/mobile_app_backend/alerts/pub_sub.ex
@@ -21,9 +21,9 @@ defmodule MobileAppBackend.Alerts.PubSub do
       Application.compile_env(:mobile_app_backend, :alerts_broadcast_interval_ms, 500)
 
   alias MBTAV3API.Alert
-  alias MBTAV3API.JsonApi
   alias MBTAV3API.Store
   alias MBTAV3API.Stream
+  alias MobileAppBackend.Alerts.AlertWithSummaries
   alias MobileAppBackend.Alerts.PubSub
   alias MobileAppBackend.Alerts.SummaryEntityBuilder
 
@@ -50,7 +50,9 @@ defmodule MobileAppBackend.Alerts.PubSub do
   The legacy alert channel needs to filter out any references to new alert causes,
   they will break old versions of the app entirely if they're sent to the frontend.
   """
-  @spec map_data([Alert.t()], boolean(), boolean(), String.t()) :: [Alert.t()]
+  @spec map_data([Alert.t()], boolean(), boolean(), String.t()) :: %{
+          String.t() => Alert.t() | AlertWithSummaries.t()
+        }
   def map_data(data, legacy_compatibility, include_summaries, locale) do
     summaries_by_alert =
       if include_summaries, do: SummaryEntityBuilder.build_all(data, locale), else: nil
@@ -62,7 +64,7 @@ defmodule MobileAppBackend.Alerts.PubSub do
     end
 
     summary_map = fn alert ->
-      %Alert{alert | summaries: Map.get(summaries_by_alert, alert.id, [])}
+      AlertWithSummaries.from_alert(alert, Map.get(summaries_by_alert, alert.id, []))
     end
 
     cond do
@@ -70,6 +72,8 @@ defmodule MobileAppBackend.Alerts.PubSub do
       include_summaries -> data |> Enum.map(summary_map)
       true -> data
     end
+    |> Enum.map(fn alert -> {alert.id, alert} end)
+    |> Map.new()
   end
 
   @impl true
@@ -77,13 +81,15 @@ defmodule MobileAppBackend.Alerts.PubSub do
     fetch_keys = []
 
     format_fn = fn data ->
-      data
-      |> map_data(
-        Keyword.get(opts, :legacy_compatibility, true),
-        Keyword.get(opts, :include_summaries, false),
-        Keyword.get(opts, :locale, @default_locale)
-      )
-      |> JsonApi.Object.to_full_map()
+      %{
+        alerts:
+          data
+          |> map_data(
+            Keyword.get(opts, :legacy_compatibility, true),
+            Keyword.get(opts, :include_summaries, false),
+            Keyword.get(opts, :locale, @default_locale)
+          )
+      }
     end
 
     Registry.register(

--- a/lib/mobile_app_backend/alerts/pub_sub.ex
+++ b/lib/mobile_app_backend/alerts/pub_sub.ex
@@ -1,10 +1,17 @@
 defmodule MobileAppBackend.Alerts.PubSub.Behaviour do
-  alias MBTAV3API.JsonApi.Object
+  alias MBTAV3API.Alert
+  alias MobileAppBackend.Alerts.AlertWithSummaries
 
   @doc """
   Subscribe to updates for all alerts
   """
-  @callback subscribe(legacy_compatibility: boolean()) :: Object.full_map()
+  @callback subscribe(
+              legacy_compatibility: boolean(),
+              include_summaries: boolean(),
+              locale: String.t()
+            ) :: %{
+              alerts: %{String.t() => Alert.t() | AlertWithSummaries.t()}
+            }
 end
 
 defmodule MobileAppBackend.Alerts.PubSub do

--- a/lib/mobile_app_backend/alerts/pub_sub.ex
+++ b/lib/mobile_app_backend/alerts/pub_sub.ex
@@ -25,6 +25,7 @@ defmodule MobileAppBackend.Alerts.PubSub do
   alias MBTAV3API.Store
   alias MBTAV3API.Stream
   alias MobileAppBackend.Alerts.PubSub
+  alias MobileAppBackend.Alerts.SummaryEntityBuilder
 
   @behaviour PubSub.Behaviour
 
@@ -48,15 +49,25 @@ defmodule MobileAppBackend.Alerts.PubSub do
   The legacy alert channel needs to filter out any references to new alert causes,
   they will break old versions of the app entirely if they're sent to the frontend.
   """
-  @spec map_data([Alert.t()], boolean()) :: [Alert.t()]
-  def map_data(data, legacy_compatibility) do
-    Enum.map(data, fn alert ->
-      if legacy_compatibility && MapSet.member?(Alert.v2_causes(), alert.cause) do
-        %Alert{alert | cause: :unknown_cause}
-      else
-        alert
-      end
-    end)
+  @spec map_data([Alert.t()], boolean(), boolean()) :: [Alert.t()]
+  def map_data(data, legacy_compatibility, include_summaries) do
+    summaries_by_alert = if include_summaries, do: SummaryEntityBuilder.build_all(data), else: nil
+
+    legacy_map = fn alert ->
+      if MapSet.member?(Alert.v2_causes(), alert.cause),
+        do: %Alert{alert | cause: :unknown_cause},
+        else: alert
+    end
+
+    summary_map = fn alert ->
+      %Alert{alert | summaries: Map.get(summaries_by_alert, alert.id, [])}
+    end
+
+    cond do
+      legacy_compatibility -> data |> Enum.map(legacy_map)
+      include_summaries -> data |> Enum.map(summary_map)
+      true -> data
+    end
   end
 
   @impl true
@@ -65,7 +76,10 @@ defmodule MobileAppBackend.Alerts.PubSub do
 
     format_fn = fn data ->
       data
-      |> map_data(Keyword.get(opts, :legacy_compatibility, true))
+      |> map_data(
+        Keyword.get(opts, :legacy_compatibility, true),
+        Keyword.get(opts, :include_summaries, false)
+      )
       |> JsonApi.Object.to_full_map()
     end
 

--- a/lib/mobile_app_backend/alerts/pub_sub.ex
+++ b/lib/mobile_app_backend/alerts/pub_sub.ex
@@ -29,6 +29,7 @@ defmodule MobileAppBackend.Alerts.PubSub do
 
   @behaviour PubSub.Behaviour
 
+  @default_locale Application.compile_env!(:mobile_app_backend, :default_locale_code)
   @fetch_registry_key :fetch_registry_key
 
   @type state :: %{last_dispatched_table_name: atom()}
@@ -49,9 +50,10 @@ defmodule MobileAppBackend.Alerts.PubSub do
   The legacy alert channel needs to filter out any references to new alert causes,
   they will break old versions of the app entirely if they're sent to the frontend.
   """
-  @spec map_data([Alert.t()], boolean(), boolean()) :: [Alert.t()]
-  def map_data(data, legacy_compatibility, include_summaries) do
-    summaries_by_alert = if include_summaries, do: SummaryEntityBuilder.build_all(data), else: nil
+  @spec map_data([Alert.t()], boolean(), boolean(), String.t()) :: [Alert.t()]
+  def map_data(data, legacy_compatibility, include_summaries, locale) do
+    summaries_by_alert =
+      if include_summaries, do: SummaryEntityBuilder.build_all(data, locale), else: nil
 
     legacy_map = fn alert ->
       if MapSet.member?(Alert.v2_causes(), alert.cause),
@@ -78,7 +80,8 @@ defmodule MobileAppBackend.Alerts.PubSub do
       data
       |> map_data(
         Keyword.get(opts, :legacy_compatibility, true),
-        Keyword.get(opts, :include_summaries, false)
+        Keyword.get(opts, :include_summaries, false),
+        Keyword.get(opts, :locale, @default_locale)
       )
       |> JsonApi.Object.to_full_map()
     end

--- a/lib/mobile_app_backend/alerts/pub_sub.ex
+++ b/lib/mobile_app_backend/alerts/pub_sub.ex
@@ -29,7 +29,7 @@ defmodule MobileAppBackend.Alerts.PubSub do
 
   @behaviour PubSub.Behaviour
 
-  @default_locale Application.compile_env!(:mobile_app_backend, :default_locale_code)
+  @default_locale MobileAppBackend.Application.default_locale()
   @fetch_registry_key :fetch_registry_key
 
   @type state :: %{last_dispatched_table_name: atom()}

--- a/lib/mobile_app_backend/alerts/summary_entity.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity.ex
@@ -1,0 +1,12 @@
+defmodule MobileAppBackend.Alerts.SummaryEntity do
+  @type t :: %__MODULE__{
+          alert_id: String.t(),
+          route_id: String.t() | nil,
+          stop_id: String.t() | nil,
+          trip_id: String.t() | nil,
+          direction_id: (0 | 1) | nil,
+          summary: String.t() | nil
+        }
+
+  defstruct [:alert_id, :route_id, :stop_id, :trip_id, :direction_id, :summary]
+end

--- a/lib/mobile_app_backend/alerts/summary_entity.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity.ex
@@ -8,5 +8,6 @@ defmodule MobileAppBackend.Alerts.SummaryEntity do
           summary: String.t() | nil
         }
 
+  @derive Jason.Encoder
   defstruct [:alert_id, :route_id, :stop_id, :trip_id, :direction_id, :summary]
 end

--- a/lib/mobile_app_backend/alerts/summary_entity_builder.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity_builder.ex
@@ -221,10 +221,15 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
           GlobalDataCache.data()
         ) :: String.t() | nil
   defp resolve_stop_id(stop_id, trip_id, patterns, trips, stops, global) do
+    # If a stop ID is provided in the informed entities, we can return it directly,
+    # but if not, we need to determine a relevant stop from the pattern or trip
     stop_id ||
       stop_parent_id(
         case trip_id do
           nil ->
+            # We need to provide a specific stop ID to AlertSummary.summarizing, but if the informed entity
+            # only specifies a route ID without a stop or trip, the only way for us to get a relevant stop ID
+            # is to pull one from a pattern's representative trip, since the summary shouldn't be different across stops
             RoutePattern.canonical_or_most_typical(patterns)
             |> List.first()
             |> case do
@@ -236,6 +241,7 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
             end
 
           _ ->
+            # If a trip ID is provided, we can pull a stop ID from the trip's stop list
             trips[trip_id].stop_ids |> List.first()
         end,
         stops

--- a/lib/mobile_app_backend/alerts/summary_entity_builder.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity_builder.ex
@@ -11,28 +11,31 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
   alias MobileAppBackend.Alerts.SummaryEntity
   alias MobileAppBackend.GlobalDataCache
 
-  @default_locale Application.compile_env!(:mobile_app_backend, :default_locale_code)
 
   @doc """
   Given a list of alerts and global data, produces a list of summary entites keyed by alert id
   """
-  @spec build_all([Alert.t()], DateTime.t(), GlobalDataCache.data()) :: %{
+  @spec build_all([Alert.t()], DateTime.t(), String.t(), GlobalDataCache.data()) :: %{
           String.t() => [SummaryEntity.t()]
         }
-  def build_all(alerts, at_time, global) do
-    Map.new(Enum.map(alerts, fn alert -> {alert.id, build_for_alert(alert, at_time, global)} end))
+  def build_all(alerts, at_time, locale, global) do
+    Map.new(
+      Enum.map(alerts, fn alert -> {alert.id, build_for_alert(alert, at_time, locale, global)} end)
+    )
   end
 
-  @spec build_all([Alert.t()]) :: %{String.t() => [SummaryEntity.t()]}
-  def build_all(alerts) do
+  @spec build_all([Alert.t()], String.t()) :: %{String.t() => [SummaryEntity.t()]}
+  def build_all(alerts, locale) do
     at_time = DateTime.now!("America/New_York")
     global = GlobalDataCache.get_data()
 
-    build_all(alerts, at_time, global)
+    build_all(alerts, at_time, locale, global)
   end
 
-  @spec build_for_alert(Alert.t(), DateTime.t(), GlobalDataCache.data()) :: [SummaryEntity.t()]
-  defp build_for_alert(alert, at_time, global) do
+  @spec build_for_alert(Alert.t(), DateTime.t(), String.t(), GlobalDataCache.data()) :: [
+          SummaryEntity.t()
+        ]
+  defp build_for_alert(alert, at_time, locale, global) do
     # Fetch schedules once for the whole alert for any trips included in the informed entities
     {schedules, trips} = fetch_schedules_for_alert(alert)
 
@@ -40,7 +43,6 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
     stops = fetch_all_stops()
 
     combinations = relevant_combinations(alert, stops, global)
-    locale = @default_locale
 
     combinations
     |> Enum.flat_map(fn {route_id, stop_id, trip_id, direction_id} ->

--- a/lib/mobile_app_backend/alerts/summary_entity_builder.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity_builder.ex
@@ -123,7 +123,7 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
   @spec relevant_combinations(Alert.t(), %{String.t() => Stop.t()}, GlobalDataCache.data()) :: [
           Combination.t()
         ]
-  defp relevant_combinations(alert, stops, global) do
+  def relevant_combinations(alert, stops, global) do
     combinations =
       alert.informed_entity
       |> Enum.flat_map(&combination_from_entity(&1, global))
@@ -138,12 +138,8 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
       |> Enum.uniq()
 
     # Filter out any combinations that are already covered by another wildcard in the list
-    # We don't need to check nil direction wildcards because any nils in the input will have been
-    # expanded to both directions
     Enum.reject(combinations, fn combination ->
-      redundant_combination?(combination, :route, combinations) and
-        redundant_combination?(combination, :stop, combinations) and
-        redundant_combination?(combination, :trip, combinations)
+      redundant_combination?(combination, combinations)
     end)
   end
 
@@ -157,7 +153,7 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
       %Alert.InformedEntity{route_type: route_type, route: nil, stop: nil, direction_id: nil}
       when not is_nil(route_type) ->
         global.routes
-        |> Enum.filter(fn route -> route.type == Route.parse_type!(route_type) end)
+        |> Enum.filter(fn {_id, route} -> route.type == Route.parse_type!(route_type) end)
         |> Enum.map(fn {route_id, _} -> %Combination{route: route_id} end)
 
       %Alert.InformedEntity{
@@ -185,24 +181,23 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
     end
   end
 
-  # A combination is redundant if there exists another combination in the list that matches it
-  # on all non-nil fields except for the field at the given index, where the other combination has nil.
+  # A combination is redundant if there exists another combination in the list where
+  # all fields are either nil if a non-nil field exists in the redundant one or equal
   @spec redundant_combination?(
           Combination.t(),
-          :route | :stop | :trip,
           [Combination.t()]
         ) :: boolean()
-  defp redundant_combination?(combination, key, combinations) do
-    match_key? = fn combination, other, check_key ->
-      if check_key == key,
-        do: is_nil(Map.get(other, check_key)),
-        else: Map.get(other, check_key) == Map.get(combination, check_key)
-    end
+  defp redundant_combination?(combination, combinations) do
+    keys = %Combination{} |> Map.from_struct() |> Map.keys()
 
-    not is_nil(Map.get(combination, key)) and
-      Enum.any?(combinations, fn other ->
-        Enum.all?(Map.keys(combination), &match_key?.(combination, other, &1))
-      end)
+    Enum.any?(combinations, fn other ->
+      combination != other and
+        Enum.all?(
+          keys,
+          &((not is_nil(Map.get(combination, &1)) and is_nil(Map.get(other, &1))) or
+              Map.get(combination, &1) == Map.get(other, &1))
+        )
+    end)
   end
 
   defp fetch_all_stops do
@@ -322,9 +317,9 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
 
   # Collapse entities where both directions produce identical summaries
   @spec dedup_summaries([SummaryEntity.t()]) :: [SummaryEntity.t()]
-  defp dedup_summaries(entities) do
+  def dedup_summaries(entities) do
     entities
-    |> Enum.group_by(&{&1.alert_id, &1.route_id, &1.trip_id, &1.stop_id})
+    |> Enum.group_by(&{&1.alert_id, &1.route_id, &1.stop_id, &1.trip_id})
     |> Enum.flat_map(fn {_key, grouped} ->
       case grouped do
         [a, b] when a.summary == b.summary ->

--- a/lib/mobile_app_backend/alerts/summary_entity_builder.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity_builder.ex
@@ -11,6 +11,15 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
   alias MobileAppBackend.Alerts.SummaryEntity
   alias MobileAppBackend.GlobalDataCache
 
+  defmodule Combination do
+    @type t :: %__MODULE__{
+            route: String.t() | nil,
+            stop: String.t() | nil,
+            trip: String.t() | nil,
+            direction: 0 | 1 | nil
+          }
+    defstruct [:route, :stop, :trip, :direction]
+  end
 
   @doc """
   Given a list of alerts and global data, produces a list of summary entites keyed by alert id
@@ -44,64 +53,87 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
 
     combinations = relevant_combinations(alert, stops, global)
 
-    combinations
-    |> Enum.flat_map(fn {route_id, stop_id, trip_id, direction_id} ->
-      RoutePattern.get_relevant_patterns(route_id, stop_id, direction_id, global)
-      |> Enum.group_by(&{&1.route_id, &1.direction_id})
-      |> Enum.map(fn {{resolved_route_id, resolved_direction_id}, patterns} ->
-        resolved_stop_id = resolve_stop_id(stop_id, trip_id, patterns, trips, stops, global)
-
-        resolved_schedules =
-          filter_schedules(
-            schedules,
-            trips,
-            resolved_route_id,
-            resolved_stop_id,
-            resolved_direction_id,
-            stops,
-            global
-          )
-
-        summary =
-          AlertSummary.summarizing(
-            alert,
-            resolved_stop_id,
-            resolved_direction_id,
-            patterns,
-            at_time,
-            resolved_schedules,
-            global
-          )
-
-        formatted =
-          FormattedAlert.summary(
-            %FormattedAlert{alert: alert, alert_summary: summary},
-            locale
-          )
-
-        %{
-          alert_id: alert.id,
-          route_id: resolved_route_id,
-          stop_id: stop_id,
-          trip_id: trip_id,
-          direction_id: resolved_direction_id,
-          summary: formatted
-        }
-      end)
-    end)
+    Enum.flat_map(
+      combinations,
+      &combination_to_summaries(&1, alert, at_time, locale, schedules, trips, stops, global)
+    )
     |> dedup_summaries()
+  end
+
+  defp combination_to_summaries(
+         %Combination{
+           route: route_id,
+           stop: stop_id,
+           trip: trip_id,
+           direction: direction_id
+         },
+         alert,
+         at_time,
+         locale,
+         schedules,
+         trips,
+         stops,
+         global
+       ) do
+    RoutePattern.get_relevant_patterns(route_id, stop_id, direction_id, global)
+    |> Enum.group_by(&{&1.route_id, &1.direction_id})
+    |> Enum.map(fn {{resolved_route_id, resolved_direction_id}, patterns} ->
+      resolved_stop_id = resolve_stop_id(stop_id, trip_id, patterns, trips, stops, global)
+
+      resolved_schedules =
+        filter_schedules(
+          schedules,
+          trips,
+          resolved_route_id,
+          resolved_stop_id,
+          resolved_direction_id,
+          stops,
+          global
+        )
+
+      summary =
+        AlertSummary.summarizing(
+          alert,
+          resolved_stop_id,
+          resolved_direction_id,
+          patterns,
+          at_time,
+          resolved_schedules,
+          global
+        )
+
+      formatted =
+        FormattedAlert.summary(
+          %FormattedAlert{alert: alert, alert_summary: summary},
+          locale
+        )
+
+      %SummaryEntity{
+        alert_id: alert.id,
+        route_id: resolved_route_id,
+        stop_id: stop_id,
+        trip_id: trip_id,
+        direction_id: resolved_direction_id,
+        summary: formatted
+      }
+    end)
   end
 
   # Get the route, stop, trip, and direction combinations relevant to the alert based on its informed_entity list
   @spec relevant_combinations(Alert.t(), %{String.t() => Stop.t()}, GlobalDataCache.data()) :: [
-          {String.t() | nil, String.t() | nil, String.t() | nil, 0 | 1 | nil}
+          Combination.t()
         ]
   defp relevant_combinations(alert, stops, global) do
     combinations =
       alert.informed_entity
       |> Enum.flat_map(&combination_from_entity(&1, global))
-      |> Enum.map(fn {route, stop, trip, direction} ->
-        {route, stop_parent_id(stop, stops), trip, direction}
+      |> Enum.map(fn %Combination{route: route, stop: stop, trip: trip, direction: direction} ->
+        %Combination{
+          route: route,
+          stop: stop_parent_id(stop, stops),
+          trip: trip,
+          direction: direction
+        }
       end)
       |> Enum.uniq()
 
@@ -109,9 +141,9 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
     # We don't need to check nil direction wildcards because any nils in the input will have been
     # expanded to both directions
     Enum.reject(combinations, fn combination ->
-      redundant_combination?(combination, 0, combinations) and
-        redundant_combination?(combination, 1, combinations) and
-        redundant_combination?(combination, 2, combinations)
+      redundant_combination?(combination, :route, combinations) and
+        redundant_combination?(combination, :stop, combinations) and
+        redundant_combination?(combination, :trip, combinations)
     end)
   end
 
@@ -126,7 +158,7 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
       when not is_nil(route_type) ->
         global.routes
         |> Enum.filter(fn route -> route.type == Route.parse_type!(route_type) end)
-        |> Enum.map(fn {route_id, _} -> {route_id, nil, nil, nil} end)
+        |> Enum.map(fn {route_id, _} -> %Combination{route: route_id} end)
 
       %Alert.InformedEntity{
         route: route_id,
@@ -135,15 +167,18 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
         direction_id: direction_id
       }
       when not is_nil(trip_id) ->
-        [{route_id, stop_id, trip_id, direction_id}]
+        [%Combination{route: route_id, stop: stop_id, trip: trip_id, direction: direction_id}]
 
       %Alert.InformedEntity{route: route_id, stop: stop_id, direction_id: nil}
       when not is_nil(stop_id) or not is_nil(route_id) ->
-        [{route_id, stop_id, nil, 0}, {route_id, stop_id, nil, 1}]
+        [
+          %Combination{route: route_id, stop: stop_id, direction: 0},
+          %Combination{route: route_id, stop: stop_id, direction: 1}
+        ]
 
       %Alert.InformedEntity{route: route_id, stop: stop_id, direction_id: direction_id}
       when not is_nil(stop_id) or not is_nil(route_id) ->
-        [{route_id, stop_id, nil, direction_id}]
+        [%Combination{route: route_id, stop: stop_id, direction: direction_id}]
 
       _ ->
         []
@@ -153,20 +188,20 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
   # A combination is redundant if there exists another combination in the list that matches it
   # on all non-nil fields except for the field at the given index, where the other combination has nil.
   @spec redundant_combination?(
-          {String.t() | nil, String.t() | nil, String.t() | nil, 0 | 1 | nil},
-          integer(),
-          [{String.t() | nil, String.t() | nil, String.t() | nil, 0 | 1 | nil}]
+          Combination.t(),
+          :route | :stop | :trip,
+          [Combination.t()]
         ) :: boolean()
-  defp redundant_combination?(combination, index, combinations) do
-    match_index? = fn combination, other, i ->
-      if i == index,
-        do: is_nil(elem(other, i)),
-        else: elem(other, i) == elem(combination, i)
+  defp redundant_combination?(combination, key, combinations) do
+    match_key? = fn combination, other, check_key ->
+      if check_key == key,
+        do: is_nil(Map.get(other, check_key)),
+        else: Map.get(other, check_key) == Map.get(combination, check_key)
     end
 
-    not is_nil(elem(combination, index)) and
+    not is_nil(Map.get(combination, key)) and
       Enum.any?(combinations, fn other ->
-        Enum.all?(0..3, &match_index?.(combination, other, &1))
+        Enum.all?(Map.keys(combination), &match_key?.(combination, other, &1))
       end)
   end
 

--- a/lib/mobile_app_backend/alerts/summary_entity_builder.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity_builder.ex
@@ -1,0 +1,295 @@
+defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
+  alias MBTAV3API.Alert
+  alias MBTAV3API.Repository
+  alias MBTAV3API.Route
+  alias MBTAV3API.RoutePattern
+  alias MBTAV3API.Schedule
+  alias MBTAV3API.Stop
+  alias MBTAV3API.Trip
+  alias MobileAppBackend.Alerts.AlertSummary
+  alias MobileAppBackend.Alerts.FormattedAlert
+  alias MobileAppBackend.Alerts.SummaryEntity
+  alias MobileAppBackend.GlobalDataCache
+
+  @default_locale Application.compile_env!(:mobile_app_backend, :default_locale_code)
+
+  @doc """
+  Given a list of alerts and global data, produces a list of summary entites keyed by alert id
+  """
+  @spec build_all([Alert.t()], DateTime.t(), GlobalDataCache.data()) :: %{
+          String.t() => [SummaryEntity.t()]
+        }
+  def build_all(alerts, at_time, global) do
+    Map.new(Enum.map(alerts, fn alert -> {alert.id, build_for_alert(alert, at_time, global)} end))
+  end
+
+  @spec build_all([Alert.t()]) :: %{String.t() => [SummaryEntity.t()]}
+  def build_all(alerts) do
+    at_time = DateTime.now!("America/New_York")
+    global = GlobalDataCache.get_data()
+
+    build_all(alerts, at_time, global)
+  end
+
+  @spec build_for_alert(Alert.t(), DateTime.t(), GlobalDataCache.data()) :: [SummaryEntity.t()]
+  defp build_for_alert(alert, at_time, global) do
+    # Fetch schedules once for the whole alert for any trips included in the informed entities
+    {schedules, trips} = fetch_schedules_for_alert(alert)
+
+    # The global stops don't include all child stops, so we need to fetch them separately
+    stops = fetch_all_stops()
+
+    combinations = relevant_combinations(alert, stops, global)
+    locale = @default_locale
+
+    combinations
+    |> Enum.flat_map(fn {route_id, stop_id, trip_id, direction_id} ->
+      RoutePattern.get_relevant_patterns(route_id, stop_id, direction_id, global)
+      |> Enum.group_by(&{&1.route_id, &1.direction_id})
+      |> Enum.map(fn {{resolved_route_id, resolved_direction_id}, patterns} ->
+        resolved_stop_id = resolve_stop_id(stop_id, trip_id, patterns, trips, stops, global)
+
+        resolved_schedules =
+          filter_schedules(
+            schedules,
+            trips,
+            resolved_route_id,
+            resolved_stop_id,
+            resolved_direction_id,
+            stops,
+            global
+          )
+
+        summary =
+          AlertSummary.summarizing(
+            alert,
+            resolved_stop_id,
+            resolved_direction_id,
+            patterns,
+            at_time,
+            resolved_schedules,
+            global
+          )
+
+        formatted =
+          FormattedAlert.summary(
+            %FormattedAlert{alert: alert, alert_summary: summary},
+            locale
+          )
+
+        %{
+          alert_id: alert.id,
+          route_id: resolved_route_id,
+          stop_id: stop_id,
+          trip_id: trip_id,
+          direction_id: resolved_direction_id,
+          summary: formatted
+        }
+      end)
+    end)
+    |> dedup_summaries()
+  end
+
+  # Get the route, stop, trip, and direction combinations relevant to the alert based on its informed_entity list
+  @spec relevant_combinations(Alert.t(), %{String.t() => Stop.t()}, GlobalDataCache.data()) :: [
+          {String.t() | nil, String.t() | nil, String.t() | nil, 0 | 1 | nil}
+        ]
+  defp relevant_combinations(alert, stops, global) do
+    combinations =
+      alert.informed_entity
+      |> Enum.flat_map(&combination_from_entity(&1, global))
+      |> Enum.map(fn {route, stop, trip, direction} ->
+        {route, stop_parent_id(stop, stops), trip, direction}
+      end)
+      |> Enum.uniq()
+
+    # Filter out any combinations that are already covered by another wildcard in the list
+    # We don't need to check nil direction wildcards because any nils in the input will have been
+    # expanded to both directions
+    Enum.reject(combinations, fn combination ->
+      redundant_combination?(combination, 0, combinations) and
+        redundant_combination?(combination, 1, combinations) and
+        redundant_combination?(combination, 2, combinations)
+    end)
+  end
+
+  @spec combination_from_entity(Alert.InformedEntity.t(), GlobalDataCache.data()) :: [
+          {String.t() | nil, String.t() | nil, String.t() | nil, 0 | 1 | nil}
+        ]
+  defp combination_from_entity(entity, global) do
+    case entity do
+      # Expand route type entities into a combination for each route of that type,
+      # since each route will have a different summary
+      %Alert.InformedEntity{route_type: route_type, route: nil, stop: nil, direction_id: nil}
+      when not is_nil(route_type) ->
+        global.routes
+        |> Enum.filter(fn route -> route.type == Route.parse_type!(route_type) end)
+        |> Enum.map(fn {route_id, _} -> {route_id, nil, nil, nil} end)
+
+      %Alert.InformedEntity{
+        route: route_id,
+        stop: stop_id,
+        trip: trip_id,
+        direction_id: direction_id
+      }
+      when not is_nil(trip_id) ->
+        [{route_id, stop_id, trip_id, direction_id}]
+
+      %Alert.InformedEntity{route: route_id, stop: stop_id, direction_id: nil}
+      when not is_nil(stop_id) or not is_nil(route_id) ->
+        [{route_id, stop_id, nil, 0}, {route_id, stop_id, nil, 1}]
+
+      %Alert.InformedEntity{route: route_id, stop: stop_id, direction_id: direction_id}
+      when not is_nil(stop_id) or not is_nil(route_id) ->
+        [{route_id, stop_id, nil, direction_id}]
+
+      _ ->
+        []
+    end
+  end
+
+  # A combination is redundant if there exists another combination in the list that matches it
+  # on all non-nil fields except for the field at the given index, where the other combination has nil.
+  @spec redundant_combination?(
+          {String.t() | nil, String.t() | nil, String.t() | nil, 0 | 1 | nil},
+          integer(),
+          [{String.t() | nil, String.t() | nil, String.t() | nil, 0 | 1 | nil}]
+        ) :: boolean()
+  defp redundant_combination?(combination, index, combinations) do
+    match_index? = fn combination, other, i ->
+      if i == index,
+        do: is_nil(elem(other, i)),
+        else: elem(other, i) == elem(combination, i)
+    end
+
+    not is_nil(elem(combination, index)) and
+      Enum.any?(combinations, fn other ->
+        Enum.all?(0..3, &match_index?.(combination, other, &1))
+      end)
+  end
+
+  defp fetch_all_stops do
+    {:ok, %{data: stops}} =
+      Repository.stops(include: [:child_stops])
+
+    Map.new(stops, &{&1.id, &1})
+  end
+
+  @spec resolve_stop_id(
+          String.t() | nil,
+          String.t() | nil,
+          [RoutePattern.t()],
+          %{String.t() => Trip.t()},
+          %{String.t() => Stop.t()},
+          GlobalDataCache.data()
+        ) :: String.t() | nil
+  defp resolve_stop_id(stop_id, trip_id, patterns, trips, stops, global) do
+    stop_id ||
+      stop_parent_id(
+        case trip_id do
+          nil ->
+            RoutePattern.canonical_or_most_typical(patterns)
+            |> List.first()
+            |> case do
+              %RoutePattern{representative_trip_id: representative_trip_id} ->
+                global.trips[representative_trip_id].stop_ids |> List.first()
+
+              _ ->
+                nil
+            end
+
+          _ ->
+            trips[trip_id].stop_ids |> List.first()
+        end,
+        stops
+      )
+  end
+
+  def stop_parent_id(nil, _stops), do: nil
+
+  def stop_parent_id(stop_id, stops) do
+    case Stop.parent_if_exists(
+           stops[stop_id],
+           stops
+         ) do
+      %Stop{id: id} -> id
+      _ -> nil
+    end
+  end
+
+  # Fetch schedules for all trip IDs referenced in the alert's informed_entity list
+  @spec fetch_schedules_for_alert(Alert.t()) ::
+          {[Schedule.t()] | nil, %{String.t() => Trip.t()} | nil}
+  defp fetch_schedules_for_alert(alert) do
+    trip_ids =
+      alert.informed_entity
+      |> Enum.map(& &1.trip)
+      |> Enum.uniq()
+      |> Enum.reject(&is_nil/1)
+
+    case trip_ids do
+      [] ->
+        {nil, nil}
+
+      trip_ids ->
+        case Repository.schedules(
+               filter: [trip: trip_ids],
+               include: [trip: :stops],
+               sort: {:stop_sequence, :asc}
+             ) do
+          {:ok, %{data: schedules, included: %{trips: trips}}} -> {schedules, trips}
+          _ -> {nil, nil}
+        end
+    end
+  end
+
+  # Get the schedules relevant to a particular combination of route, stop, direction
+  # by filtering the full list of schedules for the alert
+  @spec filter_schedules(
+          [Schedule.t()] | nil,
+          %{String.t() => Trip.t()} | nil,
+          String.t(),
+          String.t(),
+          0 | 1,
+          %{String.t() => Stop.t()},
+          GlobalDataCache.data()
+        ) :: [Schedule.t()] | nil
+  defp filter_schedules(schedules, trips, _route_id, _stop_id, _direction_id, _stops, _global)
+       when is_nil(schedules) or is_nil(trips),
+       do: nil
+
+  defp filter_schedules(schedules, trips, route_id, stop_id, direction_id, stops, global) do
+    Enum.filter(schedules, fn schedule ->
+      route_matches? =
+        schedule.route_id == route_id or
+          global.routes[schedule.route_id].line_id == route_id
+
+      stop_matches? =
+        schedule.stop_id == stop_id or stop_parent_id(schedule.stop_id, stops) == stop_id
+
+      direction_matches? =
+        case trips[schedule.trip_id] do
+          %Trip{direction_id: ^direction_id} -> true
+          _ -> direction_id == nil
+        end
+
+      route_matches? and stop_matches? and direction_matches?
+    end)
+  end
+
+  # Collapse entities where both directions produce identical summaries
+  @spec dedup_summaries([SummaryEntity.t()]) :: [SummaryEntity.t()]
+  defp dedup_summaries(entities) do
+    entities
+    |> Enum.group_by(&{&1.alert_id, &1.route_id, &1.trip_id, &1.stop_id})
+    |> Enum.flat_map(fn {_key, grouped} ->
+      case grouped do
+        [a, b] when a.summary == b.summary ->
+          [%{a | direction_id: nil}]
+
+        _ ->
+          grouped
+      end
+    end)
+  end
+end

--- a/lib/mobile_app_backend/application.ex
+++ b/lib/mobile_app_backend/application.ex
@@ -5,6 +5,9 @@ defmodule MobileAppBackend.Application do
 
   use Application
 
+  @default_locale Application.compile_env!(:mobile_app_backend, :default_locale_code)
+  def default_locale, do: @default_locale
+
   @impl true
   def start(_type, _args) do
     Logger.add_handlers(:mobile_app_backend)

--- a/lib/mobile_app_backend/cldr.ex
+++ b/lib/mobile_app_backend/cldr.ex
@@ -1,6 +1,6 @@
 defmodule MobileAppBackend.Cldr do
   use Cldr,
-    default_locale: Application.compile_env!(:mobile_app_backend, :default_locale_code),
+    default_locale: MobileAppBackend.Application.default_locale(),
     gettext: Application.compile_env!(:mobile_app_backend, :gettext_backend),
     json_library: Jason,
     locales: Application.compile_env!(:mobile_app_backend, :locale_codes),

--- a/lib/mobile_app_backend/notifications/engine.ex
+++ b/lib/mobile_app_backend/notifications/engine.ex
@@ -2,9 +2,9 @@ defmodule MobileAppBackend.Notifications.Engine do
   alias MBTAV3API.Alert
   alias MBTAV3API.Line
   alias MBTAV3API.Repository
+  alias MBTAV3API.RoutePattern
   alias MBTAV3API.Schedule
   alias MBTAV3API.Stop
-  alias MBTAV3API.Trip
   alias MobileAppBackend.Alerts.AlertSummary
   alias MobileAppBackend.GlobalDataCache
   alias MobileAppBackend.Notifications.DeliveredNotification
@@ -236,23 +236,12 @@ defmodule MobileAppBackend.Notifications.Engine do
 
   defp summary_for_subscription(alert, subscription, now, global_data) do
     patterns =
-      global_data.route_patterns
-      |> Stream.map(fn {_, pattern} -> pattern end)
-      |> Enum.filter(fn pattern ->
-        (pattern.route_id == subscription.route_id or
-           global_data.routes[pattern.route_id].line_id == subscription.route_id) and
-          pattern.direction_id == subscription.direction_id and
-          Enum.any?(
-            with trip_id when is_binary(trip_id) <- pattern.representative_trip_id,
-                 %Trip{} = trip <- global_data.trips[trip_id] do
-              trip.stop_ids
-            else
-              _ -> []
-            end,
-            &(&1 == subscription.stop_id or
-                &1 in global_data.stops[subscription.stop_id].child_stop_ids)
-          )
-      end)
+      RoutePattern.get_relevant_patterns(
+        subscription.route_id,
+        subscription.stop_id,
+        subscription.direction_id,
+        global_data
+      )
 
     schedules = schedules_for_subscription(alert, subscription, global_data)
 

--- a/lib/mobile_app_backend/notifications/scheduler.ex
+++ b/lib/mobile_app_backend/notifications/scheduler.ex
@@ -12,7 +12,7 @@ defmodule MobileAppBackend.Notifications.Scheduler do
   alias MobileAppBackend.Repo
   alias MobileAppBackend.User
 
-  @default_locale Application.compile_env!(:mobile_app_backend, :default_locale_code)
+  @default_locale MobileAppBackend.Application.default_locale()
 
   @impl Oban.Worker
   def perform(_) do

--- a/lib/mobile_app_backend_web/channels/alerts_channel.ex
+++ b/lib/mobile_app_backend_web/channels/alerts_channel.ex
@@ -46,10 +46,13 @@ defmodule MobileAppBackendWeb.AlertsChannel do
         MobileAppBackend.Alerts.PubSub
       )
 
+    locale = socket.assigns[:locale]
+
     data =
       pubsub_module.subscribe(
         legacy_compatibility: false,
-        include_summaries: true
+        include_summaries: true,
+        locale: locale
       )
 
     {:ok, data, socket}

--- a/lib/mobile_app_backend_web/channels/alerts_channel.ex
+++ b/lib/mobile_app_backend_web/channels/alerts_channel.ex
@@ -10,7 +10,12 @@ defmodule MobileAppBackendWeb.AlertsChannel do
         MobileAppBackend.Alerts.PubSub
       )
 
-    data = pubsub_module.subscribe(legacy_compatibility: true)
+    data =
+      pubsub_module.subscribe(
+        legacy_compatibility: true,
+        include_summaries: false
+      )
+
     {:ok, data, socket}
   end
 
@@ -23,7 +28,30 @@ defmodule MobileAppBackendWeb.AlertsChannel do
         MobileAppBackend.Alerts.PubSub
       )
 
-    data = pubsub_module.subscribe(legacy_compatibility: false)
+    data =
+      pubsub_module.subscribe(
+        legacy_compatibility: false,
+        include_summaries: false
+      )
+
+    {:ok, data, socket}
+  end
+
+  @impl true
+  def join("alerts:v3", _payload, socket) do
+    pubsub_module =
+      Application.get_env(
+        :mobile_app_backend,
+        MobileAppBackend.Alerts.PubSub,
+        MobileAppBackend.Alerts.PubSub
+      )
+
+    data =
+      pubsub_module.subscribe(
+        legacy_compatibility: false,
+        include_summaries: true
+      )
+
     {:ok, data, socket}
   end
 

--- a/lib/mobile_app_backend_web/channels/alerts_channel.ex
+++ b/lib/mobile_app_backend_web/channels/alerts_channel.ex
@@ -2,7 +2,7 @@ defmodule MobileAppBackendWeb.AlertsChannel do
   use MobileAppBackendWeb, :channel
 
   @impl true
-  def join("alerts", _payload, socket) do
+  def join("alerts" = topic, _payload, socket) do
     pubsub_module =
       Application.get_env(
         :mobile_app_backend,
@@ -10,17 +10,12 @@ defmodule MobileAppBackendWeb.AlertsChannel do
         MobileAppBackend.Alerts.PubSub
       )
 
-    data =
-      pubsub_module.subscribe(
-        legacy_compatibility: true,
-        include_summaries: false
-      )
-
+    data = pubsub_module.subscribe(get_opts(topic, socket))
     {:ok, data, socket}
   end
 
   @impl true
-  def join("alerts:v2", _payload, socket) do
+  def join("alerts:v2" = topic, _payload, socket) do
     pubsub_module =
       Application.get_env(
         :mobile_app_backend,
@@ -28,17 +23,12 @@ defmodule MobileAppBackendWeb.AlertsChannel do
         MobileAppBackend.Alerts.PubSub
       )
 
-    data =
-      pubsub_module.subscribe(
-        legacy_compatibility: false,
-        include_summaries: false
-      )
-
+    data = pubsub_module.subscribe(get_opts(topic, socket))
     {:ok, data, socket}
   end
 
   @impl true
-  def join("alerts:v3", _payload, socket) do
+  def join("alerts:v3" = topic, _payload, socket) do
     pubsub_module =
       Application.get_env(
         :mobile_app_backend,
@@ -46,16 +36,27 @@ defmodule MobileAppBackendWeb.AlertsChannel do
         MobileAppBackend.Alerts.PubSub
       )
 
-    locale = socket.assigns[:locale]
-
-    data =
-      pubsub_module.subscribe(
-        legacy_compatibility: false,
-        include_summaries: true,
-        locale: locale
-      )
-
+    data = pubsub_module.subscribe(get_opts(topic, socket))
     {:ok, data, socket}
+  end
+
+  defp get_opts(topic, socket) do
+    case topic do
+      "alerts" ->
+        [legacy_compatibility: true, include_summaries: false]
+
+      "alerts:v2" ->
+        [legacy_compatibility: false, include_summaries: false]
+
+      "alerts:v3" ->
+        Keyword.merge(
+          [legacy_compatibility: false, include_summaries: true],
+          case Map.get(socket.assigns, :locale) do
+            nil -> []
+            locale -> [locale: locale]
+          end
+        )
+    end
   end
 
   @impl true

--- a/lib/mobile_app_backend_web/channels/user_socket.ex
+++ b/lib/mobile_app_backend_web/channels/user_socket.ex
@@ -18,6 +18,8 @@ defmodule MobileAppBackendWeb.UserSocket do
   channel "vehicles:*", MobileAppBackendWeb.VehiclesForRouteChannel
   channel "vehicle:id:*", MobileAppBackendWeb.VehicleChannel
 
+  @default_locale Application.compile_env!(:mobile_app_backend, :default_locale_code)
+
   # Socket params are passed from the client and can
   # be used to verify and authenticate a user. After
   # verification, you can put default assigns into
@@ -33,8 +35,13 @@ defmodule MobileAppBackendWeb.UserSocket do
   # See `Phoenix.Token` documentation for examples in
   # performing token verification on connect.
   @impl true
+  def connect(%{"locale" => locale}, socket, _connect_info) do
+    {:ok, assign(socket, :locale, locale)}
+  end
+
+  @impl true
   def connect(_params, socket, _connect_info) do
-    {:ok, socket}
+    {:ok, assign(socket, :locale, @default_locale)}
   end
 
   # Socket id's are topics that allow you to identify all sockets for a given user:

--- a/lib/mobile_app_backend_web/channels/user_socket.ex
+++ b/lib/mobile_app_backend_web/channels/user_socket.ex
@@ -18,8 +18,6 @@ defmodule MobileAppBackendWeb.UserSocket do
   channel "vehicles:*", MobileAppBackendWeb.VehiclesForRouteChannel
   channel "vehicle:id:*", MobileAppBackendWeb.VehicleChannel
 
-  @default_locale Application.compile_env!(:mobile_app_backend, :default_locale_code)
-
   # Socket params are passed from the client and can
   # be used to verify and authenticate a user. After
   # verification, you can put default assigns into
@@ -41,7 +39,7 @@ defmodule MobileAppBackendWeb.UserSocket do
 
   @impl true
   def connect(_params, socket, _connect_info) do
-    {:ok, assign(socket, :locale, @default_locale)}
+    {:ok, socket}
   end
 
   # Socket id's are topics that allow you to identify all sockets for a given user:

--- a/lib/mobile_app_backend_web/channels/user_socket.ex
+++ b/lib/mobile_app_backend_web/channels/user_socket.ex
@@ -14,6 +14,7 @@ defmodule MobileAppBackendWeb.UserSocket do
   channel "predictions:trip:*", MobileAppBackendWeb.PredictionsForTripChannel
   channel "alerts", MobileAppBackendWeb.AlertsChannel
   channel "alerts:v2", MobileAppBackendWeb.AlertsChannel
+  channel "alerts:v3", MobileAppBackendWeb.AlertsChannel
   channel "vehicles:*", MobileAppBackendWeb.VehiclesForRouteChannel
   channel "vehicle:id:*", MobileAppBackendWeb.VehicleChannel
 

--- a/test/mobile_app_backend/alerts/pub_sub_test.exs
+++ b/test/mobile_app_backend/alerts/pub_sub_test.exs
@@ -2,7 +2,6 @@ defmodule MobileAppBackend.Alerts.PubSubTests do
   use ExUnit.Case
 
   alias MBTAV3API.Alert
-  alias MBTAV3API.JsonApi.Object
   alias MBTAV3API.Store
   alias MBTAV3API.Stream
   alias MobileAppBackend.Alerts.PubSub
@@ -18,6 +17,15 @@ defmodule MobileAppBackend.Alerts.PubSubTests do
 
   # make sure mocks are globally accessible, including from the PubSub genserver
   setup :set_mox_from_context
+
+  defp to_alert_map(alerts) do
+    %{
+      alerts:
+        alerts
+        |> Enum.map(&{&1.id, &1})
+        |> Map.new()
+    }
+  end
 
   describe "init/1" do
     test "subscribes to alert events" do
@@ -40,7 +48,7 @@ defmodule MobileAppBackend.Alerts.PubSubTests do
         [alert_1]
       end)
 
-      assert Object.to_full_map([alert_1]) == PubSub.subscribe()
+      assert to_alert_map([alert_1]) == PubSub.subscribe()
     end
 
     test "returns empty list when no alerts" do
@@ -48,7 +56,7 @@ defmodule MobileAppBackend.Alerts.PubSubTests do
         []
       end)
 
-      assert Object.to_full_map([]) == PubSub.subscribe()
+      assert to_alert_map([]) == PubSub.subscribe()
     end
   end
 
@@ -81,7 +89,7 @@ defmodule MobileAppBackend.Alerts.PubSubTests do
 
       assert_receive {:new_alerts, new_alerts}
 
-      assert Object.to_full_map([alert_2]) == new_alerts
+      assert to_alert_map([alert_2]) == new_alerts
 
       # Doesn't re-send the same alerts that have already been seen
       PubSub.handle_info(:broadcast, state)
@@ -93,7 +101,7 @@ defmodule MobileAppBackend.Alerts.PubSubTests do
 
       assert_receive {:new_alerts, new_alerts}
 
-      assert Object.to_full_map([alert_1]) == new_alerts
+      assert to_alert_map([alert_1]) == new_alerts
     end
 
     test "legacy compatibility converts v2 alert causes", state do
@@ -108,12 +116,12 @@ defmodule MobileAppBackend.Alerts.PubSubTests do
       |> expect(:fetch, fn _ -> [alert_2, alert_3] end)
 
       initial_alerts = PubSub.subscribe(legacy_compatibility: true)
-      assert Object.to_full_map([%Alert{alert_1 | cause: :unknown_cause}]) == initial_alerts
+      assert to_alert_map([%Alert{alert_1 | cause: :unknown_cause}]) == initial_alerts
 
       PubSub.handle_info(:broadcast, state)
 
       assert_receive {:new_alerts, new_alerts}
-      assert Object.to_full_map([%Alert{alert_2 | cause: :unknown_cause}, alert_3]) == new_alerts
+      assert to_alert_map([%Alert{alert_2 | cause: :unknown_cause}, alert_3]) == new_alerts
     end
   end
 end

--- a/test/mobile_app_backend/alerts/summary_entity_builder_test.exs
+++ b/test/mobile_app_backend/alerts/summary_entity_builder_test.exs
@@ -1,0 +1,855 @@
+defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
+  use ExUnit.Case
+
+  alias MBTAV3API.Alert.InformedEntity
+  alias MobileAppBackend.Alerts.SummaryEntity
+  alias MobileAppBackend.Alerts.SummaryEntityBuilder
+  alias MobileAppBackend.Alerts.SummaryEntityBuilder.Combination
+  alias MobileAppBackend.GlobalDataCache
+
+  import Mox
+  import Test.Support.Helpers
+  import Test.Support.Sigils
+  import MobileAppBackend.Factory
+
+  setup do
+    verify_on_exit!()
+    reassign_env(:mobile_app_backend, :base_url, "")
+    reassign_env(:mobile_app_backend, :api_key, "")
+
+    reassign_env(
+      :mobile_app_backend,
+      MobileAppBackend.GlobalDataCache.Module,
+      GlobalDataCacheMock
+    )
+
+    MBTAV3API.RepositoryCache.delete_all()
+
+    :ok
+  end
+
+  defp stop_response(stops) do
+    {:ok,
+     Req.Response.json(%{
+       data:
+         stops
+         |> Enum.map(fn stop ->
+           %{
+             "attributes" => %{
+               "address" => nil,
+               "at_street" => nil,
+               "description" => "Broadway - Red Line - Alewife",
+               "latitude" => stop.latitude,
+               "location_type" => 0,
+               "longitude" => stop.longitude,
+               "municipality" => "Boston",
+               "name" => stop.name,
+               "on_street" => nil,
+               "platform_code" => nil,
+               "platform_name" => stop.name,
+               "vehicle_type" => 0,
+               "wheelchair_boarding" => 1
+             },
+             "id" => stop.id,
+             "relationships" =>
+               if stop.parent_station_id do
+                 %{
+                   "parent_station" => %{
+                     "data" => %{
+                       "id" => stop.parent_station_id,
+                       "type" => "stop"
+                     }
+                   }
+                 }
+               else
+                 %{}
+               end,
+             "type" => "stop"
+           }
+         end)
+     })}
+  end
+
+  defp schedule_response(schedules, trip, stops) do
+    dt_or_nil = fn dt ->
+      case dt do
+        nil -> nil
+        dt -> DateTime.to_iso8601(dt)
+      end
+    end
+
+    {:ok,
+     Req.Response.json(%{
+       data:
+         schedules
+         |> Enum.map(fn schedule ->
+           %{
+             "attributes" => %{
+               "arrival_time" => dt_or_nil.(schedule.arrival_time),
+               "departure_time" => dt_or_nil.(schedule.departure_time),
+               "drop_off_type" => 1,
+               "id" => schedule.id,
+               "pickup_type" => 0,
+               "stop_headsign" => schedule.stop_headsign,
+               "stop_sequence" => schedule.stop_sequence
+             },
+             "id" => schedule.id,
+             "relationships" => %{
+               "added_routes" => %{
+                 "data" => []
+               },
+               "route" => %{
+                 "data" => %{
+                   "id" => schedule.route_id,
+                   "type" => "route"
+                 }
+               },
+               "trip" => %{
+                 "data" => %{
+                   "id" => schedule.trip_id,
+                   "type" => "trip"
+                 }
+               },
+               "stop" => %{
+                 "data" => %{
+                   "id" => schedule.stop_id,
+                   "type" => "stop"
+                 }
+               }
+             },
+             "type" => "schedule"
+           }
+         end),
+       included:
+         [
+           %{
+             "attributes" => %{
+               "headsign" => trip.headsign,
+               "direction_id" => trip.direction_id
+             },
+             "id" => trip.id,
+             "type" => "trip",
+             "relationships" => %{
+               "route" => %{
+                 "data" => %{
+                   "id" => trip.route_id,
+                   "type" => "route"
+                 }
+               },
+               "stops" => %{
+                 "data" =>
+                   trip.stop_ids
+                   |> Enum.map(fn stop_id ->
+                     %{
+                       "id" => stop_id,
+                       "type" => "stop"
+                     }
+                   end)
+               }
+             }
+           }
+         ] ++
+           (stops
+            |> Enum.map(fn stop ->
+              %{
+                "attributes" => %{
+                  "latitude" => stop.latitude,
+                  "location_type" => stop.location_type,
+                  "longitude" => stop.longitude,
+                  "name" => stop.name
+                },
+                "id" => stop.id,
+                "type" => "stop"
+              }
+            end))
+     })}
+  end
+
+  # make sure mocks are globally accessible, including from the PubSub genserver
+  setup :set_mox_from_context
+
+  describe "build_all/4" do
+    test "build basic alert" do
+      now = DateTime.now!("America/New_York")
+
+      stop = build(:stop, parent_station_id: nil)
+      route = build(:route, type: :heavy_rail, long_name: "Red Line", short_name: "Red")
+      trip = build(:trip, route_id: route.id, stop_ids: [stop.id])
+
+      pattern =
+        build(:route_pattern,
+          route_id: route.id,
+          representative_trip_id: trip.id,
+          typicality: :typical
+        )
+
+      GlobalDataCacheMock
+      |> expect(:default_key, fn -> :default_key end)
+      |> expect(:get_data, fn _ ->
+        %{
+          lines: %{},
+          pattern_ids_by_stop: %{stop.id => [pattern.id]},
+          routes: [route] |> Map.new(&{&1.id, &1}),
+          route_patterns: [pattern] |> Map.new(&{&1.id, &1}),
+          stops: [stop] |> Map.new(&{&1.id, &1}),
+          trips: [trip] |> Map.new(&{&1.id, &1})
+        }
+      end)
+
+      expect(
+        MobileAppBackend.HTTPMock,
+        :request,
+        fn %Req.Request{url: %URI{path: "/stops"}} ->
+          stop_response([stop])
+        end
+      )
+
+      global = GlobalDataCache.get_data()
+
+      alert =
+        build(:alert,
+          cause: :maintenance,
+          effect: :suspension,
+          informed_entity: [%InformedEntity{route: route.id}]
+        )
+
+      alert_id = alert.id
+      route_id = route.id
+
+      assert %{
+               ^alert_id => [
+                 %SummaryEntity{
+                   alert_id: ^alert_id,
+                   route_id: ^route_id,
+                   stop_id: nil,
+                   trip_id: nil,
+                   direction_id: 0,
+                   summary: "Service suspended on Red Line"
+                 }
+               ]
+             } = SummaryEntityBuilder.build_all([alert], now, "en", global)
+    end
+
+    test "build trip alert" do
+      now = ~B[2026-06-03 12:00:00]
+
+      stop1 = build(:stop, parent_station_id: nil)
+      stop2 = build(:stop, parent_station_id: nil)
+      route = build(:route, type: :heavy_rail, long_name: "Red Line", short_name: "Red")
+      representative_trip = build(:trip, route_id: route.id, stop_ids: [stop1.id])
+      trip = build(:trip, route_id: route.id, stop_ids: [stop2.id])
+      schedule = build(:schedule, trip_id: trip.id, route_id: route.id, stop_id: stop2.id)
+
+      pattern =
+        build(:route_pattern,
+          route_id: route.id,
+          representative_trip_id: representative_trip.id,
+          typicality: :typical
+        )
+
+      GlobalDataCacheMock
+      |> expect(:default_key, fn -> :default_key end)
+      |> expect(:get_data, fn _ ->
+        %{
+          lines: %{},
+          pattern_ids_by_stop: %{stop1.id => [pattern.id], stop2.id => [pattern.id]},
+          routes: [route] |> Map.new(&{&1.id, &1}),
+          route_patterns: [pattern] |> Map.new(&{&1.id, &1}),
+          stops: [stop1, stop2] |> Map.new(&{&1.id, &1}),
+          trips: [representative_trip] |> Map.new(&{&1.id, &1})
+        }
+      end)
+
+      expect(
+        MobileAppBackend.HTTPMock,
+        :request,
+        fn %Req.Request{url: %URI{path: "/schedules"}} ->
+          schedule_response([schedule], trip, [stop2])
+        end
+      )
+
+      expect(
+        MobileAppBackend.HTTPMock,
+        :request,
+        fn %Req.Request{url: %URI{path: "/stops"}} ->
+          stop_response([stop1, stop2])
+        end
+      )
+
+      global = GlobalDataCache.get_data()
+
+      alert =
+        build(:alert,
+          cause: :maintenance,
+          effect: :suspension,
+          informed_entity: [%InformedEntity{route: route.id, trip: trip.id}]
+        )
+
+      alert_id = alert.id
+      route_id = route.id
+      trip_id = trip.id
+
+      assert %{
+               ^alert_id => [
+                 %SummaryEntity{
+                   alert_id: ^alert_id,
+                   route_id: ^route_id,
+                   stop_id: nil,
+                   trip_id: ^trip_id,
+                   direction_id: 0,
+                   summary:
+                     "4:41 PM train from Harvard Sq @ Garden St - Dawes Island is suspended tomorrow due to maintenance"
+                 }
+               ]
+             } = SummaryEntityBuilder.build_all([alert], now, "en", global)
+    end
+
+    test "build stop alert" do
+      now = DateTime.now!("America/New_York")
+
+      stop = build(:stop, parent_station_id: nil)
+      route = build(:route, type: :heavy_rail, long_name: "Red Line", short_name: "Red")
+      trip = build(:trip, route_id: route.id, stop_ids: [stop.id])
+
+      pattern =
+        build(:route_pattern,
+          route_id: route.id,
+          representative_trip_id: trip.id,
+          typicality: :typical
+        )
+
+      GlobalDataCacheMock
+      |> expect(:default_key, fn -> :default_key end)
+      |> expect(:get_data, fn _ ->
+        %{
+          lines: %{},
+          pattern_ids_by_stop: %{stop.id => [pattern.id]},
+          routes: [route] |> Map.new(&{&1.id, &1}),
+          route_patterns: [pattern] |> Map.new(&{&1.id, &1}),
+          stops: [stop] |> Map.new(&{&1.id, &1}),
+          trips: [trip] |> Map.new(&{&1.id, &1})
+        }
+      end)
+
+      expect(
+        MobileAppBackend.HTTPMock,
+        :request,
+        fn %Req.Request{url: %URI{path: "/stops"}} ->
+          stop_response([stop])
+        end
+      )
+
+      global = GlobalDataCache.get_data()
+
+      alert =
+        build(:alert,
+          cause: :maintenance,
+          effect: :suspension,
+          informed_entity: [%InformedEntity{stop: stop.id}]
+        )
+
+      alert_id = alert.id
+      route_id = route.id
+      stop_id = stop.id
+
+      assert %{
+               ^alert_id => [
+                 %SummaryEntity{
+                   alert_id: ^alert_id,
+                   route_id: ^route_id,
+                   stop_id: ^stop_id,
+                   trip_id: nil,
+                   direction_id: 0,
+                   summary: "Service suspended at Harvard Sq @ Garden St - Dawes Island"
+                 }
+               ]
+             } = SummaryEntityBuilder.build_all([alert], now, "en", global)
+    end
+
+    test "build route type alert" do
+      now = DateTime.now!("America/New_York")
+
+      stop1 = build(:stop, parent_station_id: nil)
+      stop2 = build(:stop, parent_station_id: nil)
+
+      route1 =
+        build(:route, id: "route1", type: :heavy_rail, long_name: "Red Line", short_name: "Red")
+
+      route2 =
+        build(:route, id: "route2", type: :heavy_rail, long_name: "Blue Line", short_name: "Blue")
+
+      trip1 = build(:trip, route_id: route1.id, stop_ids: [stop1.id])
+      trip2 = build(:trip, route_id: route2.id, stop_ids: [stop2.id])
+
+      pattern1 =
+        build(:route_pattern,
+          route_id: route1.id,
+          representative_trip_id: trip1.id,
+          typicality: :typical
+        )
+
+      pattern2 =
+        build(:route_pattern,
+          route_id: route2.id,
+          representative_trip_id: trip2.id,
+          typicality: :typical
+        )
+
+      GlobalDataCacheMock
+      |> expect(:default_key, fn -> :default_key end)
+      |> expect(:get_data, fn _ ->
+        %{
+          lines: %{},
+          pattern_ids_by_stop: %{stop1.id => [pattern1.id], stop2.id => [pattern2.id]},
+          routes: [route1, route2] |> Map.new(&{&1.id, &1}),
+          route_patterns: [pattern1, pattern2] |> Map.new(&{&1.id, &1}),
+          stops: [stop1, stop2] |> Map.new(&{&1.id, &1}),
+          trips: [trip1, trip2] |> Map.new(&{&1.id, &1})
+        }
+      end)
+
+      expect(
+        MobileAppBackend.HTTPMock,
+        :request,
+        fn %Req.Request{url: %URI{path: "/stops"}} ->
+          stop_response([stop1, stop2])
+        end
+      )
+
+      global = GlobalDataCache.get_data()
+
+      alert =
+        build(:alert,
+          cause: :maintenance,
+          effect: :suspension,
+          informed_entity: [%InformedEntity{route_type: 1}]
+        )
+
+      alert_id = alert.id
+      route1_id = route1.id
+      route2_id = route2.id
+
+      assert %{
+               ^alert_id => summary_entities
+             } = SummaryEntityBuilder.build_all([alert], now, "en", global)
+
+      assert [
+               %SummaryEntity{
+                 alert_id: ^alert_id,
+                 route_id: ^route1_id,
+                 stop_id: nil,
+                 trip_id: nil,
+                 direction_id: 0,
+                 summary: "Service suspended on Red Line"
+               },
+               %SummaryEntity{
+                 alert_id: ^alert_id,
+                 route_id: ^route2_id,
+                 stop_id: nil,
+                 trip_id: nil,
+                 direction_id: 0,
+                 summary: "Service suspended on Blue Line"
+               }
+             ] = summary_entities |> Enum.sort_by(& &1.route_id)
+    end
+  end
+
+  describe "relevant_combinations/3" do
+    test "splits route entities into both directions" do
+      route = build(:route, type: :heavy_rail, long_name: "Red Line", short_name: "Red")
+
+      GlobalDataCacheMock
+      |> expect(:default_key, fn -> :default_key end)
+      |> expect(:get_data, fn _ ->
+        %{
+          lines: %{},
+          pattern_ids_by_stop: %{},
+          routes: [route] |> Map.new(&{&1.id, &1}),
+          route_patterns: %{},
+          stops: %{},
+          trips: %{}
+        }
+      end)
+
+      global = GlobalDataCache.get_data()
+
+      route_id = route.id
+
+      alert =
+        build(:alert,
+          cause: :maintenance,
+          effect: :suspension,
+          informed_entity: [
+            %InformedEntity{route: route_id}
+          ]
+        )
+
+      assert [
+               %Combination{route: ^route_id, direction: 0},
+               %Combination{route: ^route_id, direction: 1}
+             ] =
+               SummaryEntityBuilder.relevant_combinations(alert, global.stops, global)
+               |> Enum.sort_by(&{&1.route, &1.stop, &1.trip, &1.direction})
+    end
+
+    test "splits stop entities into both directions" do
+      stop = build(:stop, parent_station_id: nil)
+
+      GlobalDataCacheMock
+      |> expect(:default_key, fn -> :default_key end)
+      |> expect(:get_data, fn _ ->
+        %{
+          lines: %{},
+          pattern_ids_by_stop: %{},
+          routes: %{},
+          route_patterns: %{},
+          stops: [stop] |> Map.new(&{&1.id, &1}),
+          trips: %{}
+        }
+      end)
+
+      global = GlobalDataCache.get_data()
+
+      stop_id = stop.id
+
+      alert =
+        build(:alert,
+          cause: :maintenance,
+          effect: :suspension,
+          informed_entity: [%InformedEntity{stop: stop_id}]
+        )
+
+      assert [
+               %Combination{stop: ^stop_id, direction: 0},
+               %Combination{stop: ^stop_id, direction: 1}
+             ] =
+               SummaryEntityBuilder.relevant_combinations(alert, global.stops, global)
+               |> Enum.sort_by(&{&1.route, &1.stop, &1.trip, &1.direction})
+    end
+
+    test "trip entities set trip" do
+      stop = build(:stop, parent_station_id: nil)
+      route = build(:route, type: :heavy_rail, long_name: "Red Line", short_name: "Red")
+      trip = build(:trip, route_id: route.id, stop_ids: [stop.id])
+
+      GlobalDataCacheMock
+      |> expect(:default_key, fn -> :default_key end)
+      |> expect(:get_data, fn _ ->
+        %{
+          lines: %{},
+          pattern_ids_by_stop: %{},
+          routes: [route] |> Map.new(&{&1.id, &1}),
+          route_patterns: %{},
+          stops: [stop] |> Map.new(&{&1.id, &1}),
+          trips: %{}
+        }
+      end)
+
+      global = GlobalDataCache.get_data()
+
+      route_id = route.id
+      stop_id = stop.id
+      trip_id = trip.id
+
+      alert =
+        build(:alert,
+          cause: :maintenance,
+          effect: :suspension,
+          informed_entity: [
+            %InformedEntity{route: route_id, stop: stop_id, trip: trip_id, direction_id: 1}
+          ]
+        )
+
+      assert [%Combination{route: ^route_id, stop: ^stop_id, trip: ^trip_id, direction: 1}] =
+               SummaryEntityBuilder.relevant_combinations(alert, global.stops, global)
+    end
+
+    test "creates a combination for every route with a route_type entity" do
+      stop = build(:stop, parent_station_id: nil)
+      route1 = build(:route, id: "route1", type: :heavy_rail, long_name: "Red Line")
+      route2 = build(:route, id: "route2", type: :heavy_rail, long_name: "Blue Line")
+      route3 = build(:route, id: "route3", type: :ferry, long_name: "Quincy Ferry")
+      route4 = build(:route, id: "route4", type: :bus, long_name: "1 Bus")
+
+      GlobalDataCacheMock
+      |> expect(:default_key, fn -> :default_key end)
+      |> expect(:get_data, fn _ ->
+        %{
+          lines: %{},
+          pattern_ids_by_stop: %{},
+          routes: [route1, route2, route3, route4] |> Map.new(&{&1.id, &1}),
+          route_patterns: %{},
+          stops: [stop] |> Map.new(&{&1.id, &1}),
+          trips: %{}
+        }
+      end)
+
+      global = GlobalDataCache.get_data()
+
+      route1_id = route1.id
+      route2_id = route2.id
+
+      alert =
+        build(:alert,
+          cause: :maintenance,
+          effect: :suspension,
+          informed_entity: [
+            %InformedEntity{route_type: 1}
+          ]
+        )
+
+      assert [
+               %Combination{route: ^route1_id},
+               %Combination{route: ^route2_id}
+             ] =
+               SummaryEntityBuilder.relevant_combinations(alert, global.stops, global)
+               |> Enum.sort_by(&{&1.route, &1.stop, &1.trip, &1.direction})
+    end
+
+    test "filters identical combinations" do
+      stop = build(:stop, parent_station_id: nil)
+      child_stop = build(:stop, parent_station_id: stop.id)
+      route = build(:route, type: :heavy_rail, long_name: "Red Line")
+
+      GlobalDataCacheMock
+      |> expect(:default_key, fn -> :default_key end)
+      |> expect(:get_data, fn _ ->
+        %{
+          lines: %{},
+          pattern_ids_by_stop: %{},
+          routes: [route] |> Map.new(&{&1.id, &1}),
+          route_patterns: %{},
+          stops: [stop, child_stop] |> Map.new(&{&1.id, &1}),
+          trips: %{}
+        }
+      end)
+
+      global = GlobalDataCache.get_data()
+
+      route_id = route.id
+      stop_id = stop.id
+
+      alert =
+        build(:alert,
+          cause: :maintenance,
+          effect: :suspension,
+          informed_entity: [
+            %InformedEntity{route: route_id, stop: stop.id},
+            %InformedEntity{route: route_id, stop: child_stop.id}
+          ]
+        )
+
+      assert [
+               %Combination{route: ^route_id, stop: ^stop_id, direction: 0},
+               %Combination{route: ^route_id, stop: ^stop_id, direction: 1}
+             ] =
+               SummaryEntityBuilder.relevant_combinations(alert, global.stops, global)
+               |> Enum.sort_by(&{&1.route, &1.stop, &1.trip, &1.direction})
+    end
+
+    test "filters combinations covered by another stop wildcard" do
+      stop = build(:stop, parent_station_id: nil)
+      child_stop = build(:stop, parent_station_id: stop.id)
+      route = build(:route, type: :heavy_rail, long_name: "Red Line")
+
+      GlobalDataCacheMock
+      |> expect(:default_key, fn -> :default_key end)
+      |> expect(:get_data, fn _ ->
+        %{
+          lines: %{},
+          pattern_ids_by_stop: %{},
+          routes: [route] |> Map.new(&{&1.id, &1}),
+          route_patterns: %{},
+          stops: [stop, child_stop] |> Map.new(&{&1.id, &1}),
+          trips: %{}
+        }
+      end)
+
+      global = GlobalDataCache.get_data()
+
+      route_id = route.id
+
+      alert =
+        build(:alert,
+          cause: :maintenance,
+          effect: :suspension,
+          informed_entity: [
+            %InformedEntity{route: route_id, stop: nil},
+            %InformedEntity{route: route_id, stop: stop.id}
+          ]
+        )
+
+      assert [
+               %Combination{route: ^route_id, stop: nil, direction: 0},
+               %Combination{route: ^route_id, stop: nil, direction: 1}
+             ] =
+               SummaryEntityBuilder.relevant_combinations(alert, global.stops, global)
+               |> Enum.sort_by(&{&1.route, &1.stop, &1.trip, &1.direction})
+    end
+
+    test "filters combinations covered by another route wildcard" do
+      stop = build(:stop, parent_station_id: nil)
+      child_stop = build(:stop, parent_station_id: stop.id)
+      route = build(:route, type: :heavy_rail, long_name: "Red Line")
+
+      GlobalDataCacheMock
+      |> expect(:default_key, fn -> :default_key end)
+      |> expect(:get_data, fn _ ->
+        %{
+          lines: %{},
+          pattern_ids_by_stop: %{},
+          routes: [route] |> Map.new(&{&1.id, &1}),
+          route_patterns: %{},
+          stops: [stop, child_stop] |> Map.new(&{&1.id, &1}),
+          trips: %{}
+        }
+      end)
+
+      global = GlobalDataCache.get_data()
+
+      route_id = route.id
+      stop_id = stop.id
+
+      alert =
+        build(:alert,
+          cause: :maintenance,
+          effect: :suspension,
+          informed_entity: [
+            %InformedEntity{route: nil, stop: stop.id},
+            %InformedEntity{route: route_id, stop: stop.id}
+          ]
+        )
+
+      assert [
+               %Combination{route: nil, stop: ^stop_id, direction: 0},
+               %Combination{route: nil, stop: ^stop_id, direction: 1}
+             ] =
+               SummaryEntityBuilder.relevant_combinations(alert, global.stops, global)
+               |> Enum.sort_by(&{&1.route, &1.stop, &1.trip, &1.direction})
+    end
+
+    test "filters combinations covered by another trip wildcard" do
+      stop = build(:stop, parent_station_id: nil)
+      child_stop = build(:stop, parent_station_id: stop.id)
+      route = build(:route, type: :heavy_rail, long_name: "Red Line")
+      trip = build(:trip, route_id: route.id, stop_ids: [child_stop.id])
+
+      GlobalDataCacheMock
+      |> expect(:default_key, fn -> :default_key end)
+      |> expect(:get_data, fn _ ->
+        %{
+          lines: %{},
+          pattern_ids_by_stop: %{},
+          routes: [route] |> Map.new(&{&1.id, &1}),
+          route_patterns: %{},
+          stops: [stop, child_stop] |> Map.new(&{&1.id, &1}),
+          trips: %{}
+        }
+      end)
+
+      global = GlobalDataCache.get_data()
+
+      route_id = route.id
+      stop_id = stop.id
+      trip_id = trip.id
+
+      alert =
+        build(:alert,
+          cause: :maintenance,
+          effect: :suspension,
+          informed_entity: [
+            %InformedEntity{route: nil, stop: stop.id, trip: nil},
+            %InformedEntity{route: route_id, stop: stop.id, trip: trip_id, direction_id: 1}
+          ]
+        )
+
+      assert [
+               %Combination{route: nil, stop: ^stop_id, direction: 0},
+               %Combination{route: nil, stop: ^stop_id, direction: 1}
+             ] =
+               SummaryEntityBuilder.relevant_combinations(alert, global.stops, global)
+               |> Enum.sort_by(&{&1.route, &1.stop, &1.trip, &1.direction})
+    end
+  end
+
+  describe "dedup_summaries/1" do
+    test "removes duplicate summaries" do
+      assert [
+               %SummaryEntity{
+                 alert_id: "alert",
+                 route_id: "route",
+                 stop_id: "stop1",
+                 trip_id: nil,
+                 direction_id: nil,
+                 summary: "identical summary"
+               },
+               %SummaryEntity{
+                 alert_id: "alert",
+                 route_id: "route",
+                 stop_id: "stop2",
+                 trip_id: nil,
+                 direction_id: 0,
+                 summary: "different summary 1"
+               },
+               %SummaryEntity{
+                 alert_id: "alert",
+                 route_id: "route",
+                 stop_id: "stop2",
+                 trip_id: nil,
+                 direction_id: 1,
+                 summary: "different summary 2"
+               },
+               %SummaryEntity{
+                 alert_id: "alert",
+                 route_id: "route",
+                 stop_id: "stop3",
+                 trip_id: nil,
+                 direction_id: nil,
+                 summary: "nil direction summary"
+               }
+             ] =
+               SummaryEntityBuilder.dedup_summaries([
+                 %SummaryEntity{
+                   alert_id: "alert",
+                   route_id: "route",
+                   stop_id: "stop1",
+                   trip_id: nil,
+                   direction_id: 0,
+                   summary: "identical summary"
+                 },
+                 %SummaryEntity{
+                   alert_id: "alert",
+                   route_id: "route",
+                   stop_id: "stop1",
+                   trip_id: nil,
+                   direction_id: 1,
+                   summary: "identical summary"
+                 },
+                 %SummaryEntity{
+                   alert_id: "alert",
+                   route_id: "route",
+                   stop_id: "stop2",
+                   trip_id: nil,
+                   direction_id: 0,
+                   summary: "different summary 1"
+                 },
+                 %SummaryEntity{
+                   alert_id: "alert",
+                   route_id: "route",
+                   stop_id: "stop2",
+                   trip_id: nil,
+                   direction_id: 1,
+                   summary: "different summary 2"
+                 },
+                 %SummaryEntity{
+                   alert_id: "alert",
+                   route_id: "route",
+                   stop_id: "stop3",
+                   trip_id: nil,
+                   direction_id: nil,
+                   summary: "nil direction summary"
+                 }
+               ])
+    end
+  end
+end


### PR DESCRIPTION
### Summary

_Ticket:_ [Alert Summary Consolidation | Initial setup of new Alerts V3 Channel (only give current state on join)](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214749715355765?focus=true)

This change adds a new field to alert objects which contains summary strings for each combination or route, stop, trip, and direction that the alert effects. The new entities mirror the structure of informed entities, with each containing nillable IDs for the route, stop, trip, and direction that they apply to (with nils as wildcards).

I opted to include the entities directly in the alert object so that we don't have to mess around with prop drilling another object on the frontend.

This PR doesn't include:
* Caching the generated summaries
* Any frontend vs backend summary differences ("this trip" vs "11:00 train from X")
* Diffing payloads with only new or updated alerts

Examples:
<img width="1845" height="226" alt="Screenshot 2026-06-01 at 3 14 46 PM" src="https://github.com/user-attachments/assets/1ff76aa4-3aab-4022-b2e8-89514177b092" />
<img width="1304" height="197" alt="Screenshot 2026-06-01 at 3 15 09 PM" src="https://github.com/user-attachments/assets/1334ed4e-ecee-4e12-a9c5-19883d60c70b" />
<img width="1393" height="196" alt="Screenshot 2026-06-01 at 3 16 12 PM" src="https://github.com/user-attachments/assets/4476e79f-010d-41bf-a824-574d3f90ab4a" />
<img width="1338" height="464" alt="Screenshot 2026-06-01 at 3 21 33 PM" src="https://github.com/user-attachments/assets/9c370738-4517-4c84-b55a-264486c2ad67" />
<img width="1570" height="472" alt="Screenshot 2026-06-01 at 3 20 23 PM" src="https://github.com/user-attachments/assets/f4a72cd3-50ca-419a-9f4d-f8eafc881c1a" />
