### PR TITLE
fix(Alerts.PubSub): Temporarily filter upcoming single tracking alerts

### DIFF
--- a/lib/mobile_app_backend/alerts/pub_sub.ex
+++ b/lib/mobile_app_backend/alerts/pub_sub.ex
@@ -66,6 +66,7 @@ defmodule MobileAppBackend.Alerts.PubSub do
     format_fn = fn data ->
       data
       |> map_data(Keyword.get(opts, :legacy_compatibility, true))
+      |> filter_upcoming_single_tracking_alerts()
       |> JsonApi.Object.to_full_map()
     end
 
@@ -78,6 +79,13 @@ defmodule MobileAppBackend.Alerts.PubSub do
     fetch_keys
     |> Store.Alerts.fetch()
     |> format_fn.()
+  end
+
+  # Temporary patch because upcoming single tracking alerts are displayed
+  # incorrectly in the app. Remove any single tracking alerts that aren't happening
+  # right now.
+  defp filter_upcoming_single_tracking_alerts(alerts) do
+    Enum.filter(alerts, &(!(&1.cause == :single_tracking && !Alert.active?(&1))))
   end
 
   @impl GenServer

--- a/test/mobile_app_backend/alerts/pub_sub_test.exs
+++ b/test/mobile_app_backend/alerts/pub_sub_test.exs
@@ -8,6 +8,7 @@ defmodule MobileAppBackend.Alerts.PubSubTests do
   alias MobileAppBackend.Alerts.PubSub
   import Mox
   import Test.Support.Helpers
+  import Test.Support.Sigils
   import MobileAppBackend.Factory
 
   setup do
@@ -64,7 +65,18 @@ defmodule MobileAppBackend.Alerts.PubSubTests do
     end
 
     test ":broadcast sends message to subscribed pid", state do
-      alert_1 = build(:alert, id: "a_1", cause: :single_tracking)
+      alert_1 =
+        build(:alert,
+          id: "a_1",
+          cause: :single_tracking,
+          active_period: [
+            %Alert.ActivePeriod{
+              start: ~B[2024-02-12 09:44:04],
+              end: nil
+            }
+          ]
+        )
+
       alert_2 = build(:alert, id: "a_2", cause: :rail_defect)
 
       AlertsStoreMock
@@ -94,6 +106,46 @@ defmodule MobileAppBackend.Alerts.PubSubTests do
       assert_receive {:new_alerts, new_alerts}
 
       assert Object.to_full_map([alert_1]) == new_alerts
+    end
+
+    test ":broadcast filters out upcoming single tracking alerts", state do
+      single_tracking_future =
+        build(:alert,
+          id: "a_1",
+          cause: :single_tracking,
+          active_period: [
+            %Alert.ActivePeriod{
+              start: DateTime.add(DateTime.now!("America/New_York"), 10, :minute),
+              end: nil
+            }
+          ]
+        )
+
+      single_tracking_now =
+        build(:alert,
+          id: "a_2",
+          cause: :single_tracking,
+          active_period: [
+            %Alert.ActivePeriod{
+              start: DateTime.add(DateTime.now!("America/New_York"), -10, :minute),
+              end: nil
+            }
+          ]
+        )
+
+      AlertsStoreMock
+      # Subscribe & first broadcast
+      |> expect(:fetch, fn _ -> [single_tracking_future, single_tracking_now] end)
+      |> expect(:fetch, fn _ -> [single_tracking_future] end)
+
+      assert Object.to_full_map([single_tracking_now]) ==
+               PubSub.subscribe(legacy_compatibility: false)
+
+      PubSub.handle_info(:broadcast, state)
+
+      assert_receive {:new_alerts, new_alerts}
+
+      assert Object.to_full_map([]) == new_alerts
     end
 
     test "legacy compatibility converts v2 alert causes", state do


### PR DESCRIPTION
### Summary

_Ticket:_ [Patch BL single tracking alert for 6/6-7](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215281875326185?focus=true)

<!-- What is this PR for? -->
As discussed in the office on 6/2, this generically filters out upcoming single tracking alerts until we fix how they are displayed in the frontend.

### Testing

<!-- What testing have you done? -->
Added unit test to confirm only upcoming single tracking alerts are filtered on initial channel join message & subsequent broadcasts.