### PR TITLE
fix(Notifications.Window): Handle daylight savings

### DIFF
--- a/lib/mbta_v3_api/alert.ex
+++ b/lib/mbta_v3_api/alert.ex
@@ -231,7 +231,8 @@ defmodule MBTAV3API.Alert do
         Enum.map(item.attributes["active_period"], &ActivePeriod.parse!/1)
         |> ActivePeriod.collapse(),
       cause: parse_cause(item.attributes["cause"]),
-      closed_timestamp: Util.parse_optional_datetime!(item.attributes["closed_timestamp"]),
+      closed_timestamp:
+        Util.DateTime.parse_optional_datetime!(item.attributes["closed_timestamp"]),
       description: item.attributes["description"],
       duration_certainty: parse_duration_certainty(item.attributes["duration_certainty"]),
       effect: parse_effect(item.attributes["effect"]),
@@ -241,10 +242,12 @@ defmodule MBTAV3API.Alert do
         Enum.map(item.attributes["informed_entity"], &InformedEntity.parse!/1)
         |> InformedEntity.expand_route_type(),
       last_push_notification_timestamp:
-        Util.parse_optional_datetime!(item.attributes["last_push_notification_timestamp"]),
+        Util.DateTime.parse_optional_datetime!(
+          item.attributes["last_push_notification_timestamp"]
+        ),
       lifecycle: parse_lifecycle!(item.attributes["lifecycle"]),
       severity: item.attributes["severity"],
-      updated_at: Util.parse_datetime!(item.attributes["updated_at"])
+      updated_at: Util.DateTime.parse_datetime!(item.attributes["updated_at"])
     }
   end
 
@@ -346,8 +349,8 @@ defmodule MBTAV3API.Alert do
         false
       else
         recurrence_info.start
-        |> Util.datetime_to_gtfs()
-        |> Date.range(Util.datetime_to_gtfs(recurrence_info.end, rounding: :backwards))
+        |> Util.DateTime.datetime_to_gtfs()
+        |> Date.range(Util.DateTime.datetime_to_gtfs(recurrence_info.end, rounding: :backwards))
         |> Enum.map(&Date.day_of_week(&1))
         |> MapSet.new() == recurrence_info.days
       end
@@ -361,14 +364,14 @@ defmodule MBTAV3API.Alert do
          last_period <- Enum.max_by(alert.active_period, & &1.end, DateTime),
          false <- last_period.end == nil,
          false <-
-           Util.datetime_to_gtfs(last_period.end, rounding: :backwards) ==
-             Util.datetime_to_gtfs(first_period.start) do
+           Util.DateTime.datetime_to_gtfs(last_period.end, rounding: :backwards) ==
+             Util.DateTime.datetime_to_gtfs(first_period.start) do
       seen_days_of_week =
         alert.active_period
         |> Enum.flat_map(fn ap ->
           ap.start
-          |> Util.datetime_to_gtfs()
-          |> Date.range(Util.datetime_to_gtfs(ap.end, rounding: :backwards))
+          |> Util.DateTime.datetime_to_gtfs()
+          |> Date.range(Util.DateTime.datetime_to_gtfs(ap.end, rounding: :backwards))
           |> Enum.map(&Date.day_of_week(&1))
         end)
         |> MapSet.new()

--- a/lib/mbta_v3_api/alert/active_period.ex
+++ b/lib/mbta_v3_api/alert/active_period.ex
@@ -7,8 +7,8 @@ defmodule MBTAV3API.Alert.ActivePeriod do
   @spec parse!(map()) :: t()
   def parse!(data) when is_map(data) do
     %__MODULE__{
-      start: Util.parse_datetime!(data["start"]),
-      end: Util.parse_optional_datetime!(data["end"])
+      start: Util.DateTime.parse_datetime!(data["start"]),
+      end: Util.DateTime.parse_optional_datetime!(data["end"])
     }
   end
 

--- a/lib/mbta_v3_api/prediction.ex
+++ b/lib/mbta_v3_api/prediction.ex
@@ -72,8 +72,8 @@ defmodule MBTAV3API.Prediction do
   def parse!(%JsonApi.Item{} = item) do
     %__MODULE__{
       id: item.id,
-      arrival_time: Util.parse_optional_datetime!(item.attributes["arrival_time"]),
-      departure_time: Util.parse_optional_datetime!(item.attributes["departure_time"]),
+      arrival_time: Util.DateTime.parse_optional_datetime!(item.attributes["arrival_time"]),
+      departure_time: Util.DateTime.parse_optional_datetime!(item.attributes["departure_time"]),
       direction_id: item.attributes["direction_id"],
       last_trip: item.attributes["last_trip"],
       revenue: Util.parse_revenue_status(item.attributes["revenue_status"]),

--- a/lib/mbta_v3_api/schedule.ex
+++ b/lib/mbta_v3_api/schedule.ex
@@ -62,8 +62,8 @@ defmodule MBTAV3API.Schedule do
   def parse!(%JsonApi.Item{} = item) do
     %__MODULE__{
       id: item.id,
-      arrival_time: Util.parse_optional_datetime!(item.attributes["arrival_time"]),
-      departure_time: Util.parse_optional_datetime!(item.attributes["departure_time"]),
+      arrival_time: Util.DateTime.parse_optional_datetime!(item.attributes["arrival_time"]),
+      departure_time: Util.DateTime.parse_optional_datetime!(item.attributes["departure_time"]),
       drop_off_type: parse_stop_edge_type!(item.attributes["drop_off_type"]),
       pick_up_type: parse_stop_edge_type!(item.attributes["pickup_type"]),
       stop_headsign: item.attributes["stop_headsign"],

--- a/lib/mbta_v3_api/vehicle.ex
+++ b/lib/mbta_v3_api/vehicle.ex
@@ -102,7 +102,7 @@ defmodule MBTAV3API.Vehicle do
       longitude: item.attributes["longitude"],
       occupancy_status: parse_optional_occupancy(item.attributes["occupancy_status"]),
       revenue: Util.parse_revenue_status(item.attributes["revenue_status"]),
-      updated_at: Util.parse_datetime!(item.attributes["updated_at"]),
+      updated_at: Util.DateTime.parse_datetime!(item.attributes["updated_at"]),
       route_id: JsonApi.Object.get_one_id(item.relationships["route"]),
       stop_id: JsonApi.Object.get_one_id(item.relationships["stop"]),
       trip_id: JsonApi.Object.get_one_id(item.relationships["trip"]),

--- a/lib/mobile_app_backend/alerts/alert_summary.ex
+++ b/lib/mobile_app_backend/alerts/alert_summary.ex
@@ -628,7 +628,7 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
   defp alert_timeframe(%Alert{duration_certainty: :estimated}, _, _), do: nil
 
   defp alert_timeframe(alert, at_time, has_recurrence?) do
-    service_date = Util.datetime_to_gtfs(at_time)
+    service_date = Util.DateTime.datetime_to_gtfs(at_time)
 
     case Alert.current_period(alert, at_time) do
       %Alert.ActivePeriod{end: nil} ->
@@ -671,7 +671,7 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
   end
 
   defp alert_timeframe_current(service_date, %Alert.ActivePeriod{end: end_time} = current_period) do
-    end_date = Util.datetime_to_gtfs(end_time, rounding: :backwards)
+    end_date = Util.DateTime.datetime_to_gtfs(end_time, rounding: :backwards)
 
     cond do
       service_date == end_date and Alert.ActivePeriod.to_end_of_service?(current_period) ->
@@ -692,7 +692,7 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
   end
 
   defp alert_timeframe_upcoming(service_date, %Alert.ActivePeriod{start: start_time}) do
-    start_service_date = Util.datetime_to_gtfs(start_time)
+    start_service_date = Util.DateTime.datetime_to_gtfs(start_time)
 
     if start_service_date == service_date do
       %Timeframe.StartingLaterToday{time: start_time}
@@ -704,9 +704,9 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
   @spec alert_recurrence(Alert.t(), DateTime.t()) :: Recurrence.t() | nil
   def alert_recurrence(alert, at_time) do
     with %Alert.RecurrenceInfo{end: last_period_end} = range <- Alert.recurrence_range(alert),
-         service_date = Util.datetime_to_gtfs(at_time),
+         service_date = Util.DateTime.datetime_to_gtfs(at_time),
          last_service_date when last_service_date != service_date <-
-           Util.datetime_to_gtfs(last_period_end, rounding: :backwards) do
+           Util.DateTime.datetime_to_gtfs(last_period_end, rounding: :backwards) do
       ending =
         cond do
           !range.end_day_known ->

--- a/lib/mobile_app_backend/alerts/alert_summary/trip_specific.ex
+++ b/lib/mobile_app_backend/alerts/alert_summary/trip_specific.ex
@@ -284,14 +284,14 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripSpecific do
            trip_time: trip_time,
            route_type: route_type,
            stop_name: global.stops[stop_id].name
-         }, Util.datetime_to_gtfs(trip_time) == Util.datetime_to_gtfs(at_time)}
+         }, Util.DateTime.datetime_to_gtfs(trip_time) == Util.DateTime.datetime_to_gtfs(at_time)}
 
       _ ->
         {%MultipleTrips{},
          Enum.any?(
            informed_schedules,
-           &(Util.datetime_to_gtfs(&1.departure_time || &1.arrival_time) ==
-               Util.datetime_to_gtfs(at_time))
+           &(Util.DateTime.datetime_to_gtfs(&1.departure_time || &1.arrival_time) ==
+               Util.DateTime.datetime_to_gtfs(at_time))
          )}
     end
   end

--- a/lib/mobile_app_backend/alerts/formatted_alert.ex
+++ b/lib/mobile_app_backend/alerts/formatted_alert.ex
@@ -161,21 +161,21 @@ defmodule MobileAppBackend.Alerts.FormattedAlert do
         gettext("key/alert_summary_timeframe_later_date",
           "1":
             timeframe.time
-            |> Util.datetime_to_gtfs(rounding: :backwards)
-            |> Util.datetime_to_string(:short_month_day)
+            |> Util.DateTime.datetime_to_gtfs(rounding: :backwards)
+            |> Util.DateTime.datetime_to_string(:short_month_day)
         )
 
       %Timeframe.ThisWeek{} ->
         gettext("key/alert_summary_timeframe_this_week",
           "1":
             timeframe.time
-            |> Util.datetime_to_gtfs(rounding: :backwards)
-            |> Util.datetime_to_string(:wide_weekday)
+            |> Util.DateTime.datetime_to_gtfs(rounding: :backwards)
+            |> Util.DateTime.datetime_to_string(:wide_weekday)
         )
 
       %Timeframe.Time{} ->
         gettext("key/alert_summary_timeframe_time",
-          "1": Util.datetime_to_string(timeframe.time, :short_time)
+          "1": Util.DateTime.datetime_to_string(timeframe.time, :short_time)
         )
 
       %Timeframe.StartingTomorrow{} ->
@@ -183,7 +183,7 @@ defmodule MobileAppBackend.Alerts.FormattedAlert do
 
       %Timeframe.StartingLaterToday{} ->
         gettext(" starting **%{formatted_time}** today",
-          formatted_time: Util.datetime_to_string(timeframe.time, :short_time)
+          formatted_time: Util.DateTime.datetime_to_string(timeframe.time, :short_time)
         )
 
       %Timeframe.TimeRange{} ->
@@ -210,7 +210,7 @@ defmodule MobileAppBackend.Alerts.FormattedAlert do
         gettext("end of service")
 
       %Timeframe.TimeRange.Time{} ->
-        Util.datetime_to_string(boundary.time, :short_time)
+        Util.DateTime.datetime_to_string(boundary.time, :short_time)
 
       _ ->
         nil
@@ -256,16 +256,16 @@ defmodule MobileAppBackend.Alerts.FormattedAlert do
         gettext("key/alert_summary_recurrence_end_day_later_date",
           "1":
             end_day.time
-            |> Util.datetime_to_gtfs(rounding: :backwards)
-            |> Util.datetime_to_string(:short_month_day)
+            |> Util.DateTime.datetime_to_gtfs(rounding: :backwards)
+            |> Util.DateTime.datetime_to_string(:short_month_day)
         )
 
       %Timeframe.ThisWeek{} ->
         gettext("key/alert_summary_recurrence_end_day_this_week",
           "1":
             end_day.time
-            |> Util.datetime_to_gtfs(rounding: :backwards)
-            |> Util.datetime_to_string(:wide_weekday)
+            |> Util.DateTime.datetime_to_gtfs(rounding: :backwards)
+            |> Util.DateTime.datetime_to_string(:wide_weekday)
         )
 
       _ ->
@@ -283,14 +283,14 @@ defmodule MobileAppBackend.Alerts.FormattedAlert do
 
       %AlertSummary.TripSpecific.TripFrom{} ->
         gettext("**%{trip_time}** %{route_type} from **%{stop_name}**",
-          trip_time: Util.datetime_to_string(trip_identity.trip_time, :short_time),
+          trip_time: Util.DateTime.datetime_to_string(trip_identity.trip_time, :short_time),
           route_type: PresentationStrings.route_type(trip_identity.route_type, true),
           stop_name: trip_identity.stop_name
         )
 
       %AlertSummary.TripSpecific.TripTo{} ->
         gettext("**%{trip_time}** %{route_type} to **%{headsign}**",
-          trip_time: Util.datetime_to_string(trip_identity.trip_time, :short_time),
+          trip_time: Util.DateTime.datetime_to_string(trip_identity.trip_time, :short_time),
           route_type: PresentationStrings.route_type(trip_identity.route_type, true),
           headsign: trip_identity.headsign
         )
@@ -328,14 +328,14 @@ defmodule MobileAppBackend.Alerts.FormattedAlert do
       %AlertSummary.TripShuttle.SingleTrip{} ->
         if trip_identity.from_stop_name != nil do
           gettext("**%{time}** %{vehicle} from **%{from_stop}**",
-            time: Util.datetime_to_string(trip_identity.trip_time, :short_time),
+            time: Util.DateTime.datetime_to_string(trip_identity.trip_time, :short_time),
             vehicle:
               MobileAppBackend.PresentationStrings.route_type(trip_identity.route_type, true),
             from_stop: trip_identity.from_stop_name
           )
         else
           gettext("the **%{time}** %{vehicle}",
-            time: Util.datetime_to_string(trip_identity.trip_time, :short_time),
+            time: Util.DateTime.datetime_to_string(trip_identity.trip_time, :short_time),
             vehicle:
               MobileAppBackend.PresentationStrings.route_type(trip_identity.route_type, true)
           )

--- a/lib/mobile_app_backend/notifications/window.ex
+++ b/lib/mobile_app_backend/notifications/window.ex
@@ -44,8 +44,8 @@ defmodule MobileAppBackend.Notifications.Window do
     period_open_days = Stream.filter(period_days, &(Date.day_of_week(&1) in window.days_of_week))
 
     Enum.find_value(period_open_days, fn date ->
-      window_start = DateTime.new!(date, window.start_time, "America/New_York")
-      window_end = DateTime.new!(date, window.end_time, "America/New_York")
+      window_start = Util.DateTime.new_safe(date, window.start_time)
+      window_end = Util.DateTime.new_safe(date, window.end_time)
 
       cond do
         DateTime.compare(window_end, period_start) == :lt ->

--- a/lib/mobile_app_backend_web/controllers/next_schedule_controller.ex
+++ b/lib/mobile_app_backend_web/controllers/next_schedule_controller.ex
@@ -13,8 +13,8 @@ defmodule MobileAppBackendWeb.NextScheduleController do
 
     service_date =
       date_time
-      |> Util.parse_datetime!()
-      |> Util.datetime_to_gtfs()
+      |> Util.DateTime.parse_datetime!()
+      |> Util.DateTime.datetime_to_gtfs()
 
     # as an optimization, skip loading the services if there is a schedule tomorrow
     next_schedule =

--- a/lib/mobile_app_backend_web/controllers/schedule_controller.ex
+++ b/lib/mobile_app_backend_web/controllers/schedule_controller.ex
@@ -48,7 +48,7 @@ defmodule MobileAppBackendWeb.ScheduleController do
   defp fetch_schedules_and_combine_data(conn, stop_ids_concat, date_time_string, params) do
     stop_ids = String.split(stop_ids_concat, ",")
 
-    date_time = Util.parse_datetime!(date_time_string)
+    date_time = Util.DateTime.parse_datetime!(date_time_string)
     global_stops = GlobalDataCache.get_data().stops
 
     parent_stop_ids =
@@ -91,11 +91,11 @@ defmodule MobileAppBackendWeb.ScheduleController do
 
     yesterdays_filters =
       parent_stop_ids
-      |> Enum.map(&get_filter(&1, Util.datetime_to_gtfs(yesterdays_date_time)))
+      |> Enum.map(&get_filter(&1, Util.DateTime.datetime_to_gtfs(yesterdays_date_time)))
 
     todays_filters =
       parent_stop_ids
-      |> Enum.map(&get_filter(&1, Util.datetime_to_gtfs(date_time)))
+      |> Enum.map(&get_filter(&1, Util.DateTime.datetime_to_gtfs(date_time)))
 
     yesterdays_data =
       case yesterdays_filters do
@@ -140,7 +140,7 @@ defmodule MobileAppBackendWeb.ScheduleController do
        ) do
     filters =
       parent_stop_ids
-      |> Enum.map(&get_filter(&1, Util.datetime_to_gtfs(date_time)))
+      |> Enum.map(&get_filter(&1, Util.DateTime.datetime_to_gtfs(date_time)))
 
     data =
       case filters do

--- a/lib/util.ex
+++ b/lib/util.ex
@@ -235,36 +235,6 @@ defmodule Util do
   end
 
   @doc """
-  Parses a value as an `America/New_York` datetime.
-
-  ## Examples
-
-      iex> Util.parse_datetime!("2024-02-02T10:45:52-05:00")
-      #DateTime<2024-02-02 10:45:52-05:00 EST America/New_York>
-  """
-  @spec parse_datetime!(String.t()) :: DateTime.t()
-  def parse_datetime!(data) do
-    {:ok, datetime, _} = DateTime.from_iso8601(data)
-    DateTime.shift_zone!(datetime, "America/New_York")
-  end
-
-  @doc """
-  Parses an optional value as an `America/New_York` datetime.
-
-  ## Examples
-
-      iex> Util.parse_optional_datetime!(nil)
-      nil
-
-      iex> Util.parse_optional_datetime!("2024-02-02T10:45:52-05:00")
-      #DateTime<2024-02-02 10:45:52-05:00 EST America/New_York>
-  """
-  @spec parse_optional_datetime!(String.t() | nil) :: DateTime.t() | nil
-  def parse_optional_datetime!(data)
-  def parse_optional_datetime!(nil), do: nil
-  def parse_optional_datetime!(data), do: parse_datetime!(data)
-
-  @doc """
   Constructs a union out of a list of types.
 
   ## Examples
@@ -285,76 +255,6 @@ defmodule Util do
     args
     |> Enum.reverse()
     |> Enum.reduce(fn t, acc -> quote(do: unquote(t) | unquote(acc)) end)
-  end
-
-  @doc """
-  Converts a local time into a GTFS {service date, HH:MM}.
-
-  ## Examples
-
-      iex> import Test.Support.Sigils
-      iex> Util.datetime_to_gtfs(~B[2024-03-12 10:55:39])
-      ~D[2024-03-12]
-      iex> Util.datetime_to_gtfs(~B[2024-03-12 00:19:03])
-      ~D[2024-03-11]
-      iex> Util.datetime_to_gtfs(~B[2024-03-12 01:23:45])
-      ~D[2024-03-11]
-      iex> Util.datetime_to_gtfs(~B[2024-03-12 02:11:00])
-      ~D[2024-03-11]
-      iex> Util.datetime_to_gtfs(~B[2024-03-12 03:00:00])
-      ~D[2024-03-12]
-      iex> Util.datetime_to_gtfs(~B[2024-03-12 03:00:00], rounding: :backwards)
-      ~D[2024-03-11]
-  """
-  @spec datetime_to_gtfs(DateTime.t(), rounding: :forwards | :backwards) :: Date.t()
-  def datetime_to_gtfs(
-        %DateTime{hour: hour, time_zone: "America/New_York"} = datetime,
-        opts \\ []
-      ) do
-    date = DateTime.to_date(datetime)
-    rounding = Keyword.get(opts, :rounding, :forwards)
-
-    if hour in [0, 1, 2] or (rounding == :backwards and hour == 3 and datetime.minute == 0) do
-      Date.add(date, -1)
-    else
-      date
-    end
-  end
-
-  @spec datetime_to_string(Cldr.Calendar.any_date_time(), String.t() | atom()) :: String.t()
-
-  @doc """
-  Format the date in a localized string
-
-  ## Examples
-      iex> import Test.Support.Sigils
-      iex> Util.datetime_to_string(~B[2026-04-29 01:23:45], :short_time)
-      "1:23 AM"
-      iex> Util.datetime_to_string(~B[2026-04-29 13:23:45], :short_time)
-      "1:23 PM"
-      iex> Util.datetime_to_string(~B[2026-04-29 01:23:45], :short_month_day)
-      "Apr 29"
-      iex> Util.datetime_to_string(~B[2026-04-29 01:23:45], :wide_weekday)
-      "Wednesday"
-      iex> Util.datetime_to_string(~B[2026-04-29 01:23:45], "h")
-      "1"
-
-  """
-  def datetime_to_string(datetime, :short_time) do
-    datetime_to_string(datetime, "h:mm a")
-  end
-
-  def datetime_to_string(datetime, :short_month_day) do
-    datetime_to_string(datetime, "MMM d")
-  end
-
-  def datetime_to_string(datetime, :wide_weekday) do
-    datetime_to_string(datetime, "EEEE")
-  end
-
-  def datetime_to_string(datetime, format) do
-    {:ok, formatted} = Cldr.DateTime.to_string(datetime, MobileAppBackend.Cldr, format: format)
-    formatted
   end
 
   @spec parse_revenue_status(String.t() | nil) :: boolean()

--- a/lib/util/date_time.ex
+++ b/lib/util/date_time.ex
@@ -98,4 +98,26 @@ defmodule Util.DateTime do
     {:ok, formatted} = Cldr.DateTime.to_string(datetime, MobileAppBackend.Cldr, format: format)
     formatted
   end
+
+  @doc """
+    Make a new date, safely handling daylight savings issues. Always returns the later
+    time at a daylight savings boundary.
+  ## Examples
+
+      iex> Util.DateTime.new_safe(~D[2027-03-14], ~T[02:00:00])
+      #DateTime<2027-03-14 03:00:00-04:00 EDT America/New_York>
+      iex> Util.DateTime.new_safe(~D[2027-11-27], ~T[02:00:00])
+      #DateTime<2027-11-27 02:00:00-05:00 EST America/New_York>
+      iex> Util.DateTime.new_safe(~D[2027-03-15], ~T[02:00:00])
+      #DateTime<2027-03-15 02:00:00-04:00 EDT America/New_York>
+  """
+  @spec new_safe(Date.t(), Time.t()) :: DateTime.t()
+  def new_safe(date, time) do
+    case DateTime.new(date, time, "America/New_York") do
+      {:ok, date_time} -> date_time
+      {:ambiguous, _first_dt, second_dt} -> second_dt
+      {:gap, _first_dt, second_dt} -> second_dt
+      {:error, _error} -> DateTime.new!(date, ~T[23:59:59], "America/New_York")
+    end
+  end
 end

--- a/lib/util/date_time.ex
+++ b/lib/util/date_time.ex
@@ -1,0 +1,101 @@
+defmodule Util.DateTime do
+  @doc """
+  Parses a value as an `America/New_York` datetime.
+
+  ## Examples
+
+      iex> Util.DateTime.parse_datetime!("2024-02-02T10:45:52-05:00")
+      #DateTime<2024-02-02 10:45:52-05:00 EST America/New_York>
+  """
+  @spec parse_datetime!(String.t()) :: DateTime.t()
+  def parse_datetime!(data) do
+    {:ok, datetime, _} = DateTime.from_iso8601(data)
+    DateTime.shift_zone!(datetime, "America/New_York")
+  end
+
+  @doc """
+  Parses an optional value as an `America/New_York` datetime.
+
+  ## Examples
+
+      iex> Util.DateTime.parse_optional_datetime!(nil)
+      nil
+
+      iex> Util.DateTime.parse_optional_datetime!("2024-02-02T10:45:52-05:00")
+      #DateTime<2024-02-02 10:45:52-05:00 EST America/New_York>
+  """
+  @spec parse_optional_datetime!(String.t() | nil) :: DateTime.t() | nil
+  def parse_optional_datetime!(data)
+  def parse_optional_datetime!(nil), do: nil
+  def parse_optional_datetime!(data), do: parse_datetime!(data)
+
+  @doc """
+  Converts a local time into a GTFS {service date, HH:MM}.
+
+  ## Examples
+
+      iex> import Test.Support.Sigils
+      iex> Util.DateTime.datetime_to_gtfs(~B[2024-03-12 10:55:39])
+      ~D[2024-03-12]
+      iex> Util.DateTime.datetime_to_gtfs(~B[2024-03-12 00:19:03])
+      ~D[2024-03-11]
+      iex> Util.DateTime.datetime_to_gtfs(~B[2024-03-12 01:23:45])
+      ~D[2024-03-11]
+      iex> Util.DateTime.datetime_to_gtfs(~B[2024-03-12 02:11:00])
+      ~D[2024-03-11]
+      iex> Util.DateTime.datetime_to_gtfs(~B[2024-03-12 03:00:00])
+      ~D[2024-03-12]
+      iex> Util.DateTime.datetime_to_gtfs(~B[2024-03-12 03:00:00], rounding: :backwards)
+      ~D[2024-03-11]
+  """
+  @spec datetime_to_gtfs(DateTime.t(), rounding: :forwards | :backwards) :: Date.t()
+  def datetime_to_gtfs(
+        %DateTime{hour: hour, time_zone: "America/New_York"} = datetime,
+        opts \\ []
+      ) do
+    date = DateTime.to_date(datetime)
+    rounding = Keyword.get(opts, :rounding, :forwards)
+
+    if hour in [0, 1, 2] or (rounding == :backwards and hour == 3 and datetime.minute == 0) do
+      Date.add(date, -1)
+    else
+      date
+    end
+  end
+
+  @spec datetime_to_string(Cldr.Calendar.any_date_time(), String.t() | atom()) :: String.t()
+
+  @doc """
+  Format the date in a localized string
+
+  ## Examples
+      iex> import Test.Support.Sigils
+      iex> Util.DateTime.datetime_to_string(~B[2026-04-29 01:23:45], :short_time)
+      "1:23 AM"
+      iex> Util.DateTime.datetime_to_string(~B[2026-04-29 13:23:45], :short_time)
+      "1:23 PM"
+      iex> Util.DateTime.datetime_to_string(~B[2026-04-29 01:23:45], :short_month_day)
+      "Apr 29"
+      iex> Util.DateTime.datetime_to_string(~B[2026-04-29 01:23:45], :wide_weekday)
+      "Wednesday"
+      iex> Util.DateTime.datetime_to_string(~B[2026-04-29 01:23:45], "h")
+      "1"
+
+  """
+  def datetime_to_string(datetime, :short_time) do
+    datetime_to_string(datetime, "h:mm a")
+  end
+
+  def datetime_to_string(datetime, :short_month_day) do
+    datetime_to_string(datetime, "MMM d")
+  end
+
+  def datetime_to_string(datetime, :wide_weekday) do
+    datetime_to_string(datetime, "EEEE")
+  end
+
+  def datetime_to_string(datetime, format) do
+    {:ok, formatted} = Cldr.DateTime.to_string(datetime, MobileAppBackend.Cldr, format: format)
+    formatted
+  end
+end

--- a/test/mbta_v3_api/alert_test.exs
+++ b/test/mbta_v3_api/alert_test.exs
@@ -438,7 +438,7 @@ defmodule MBTAV3API.AlertTest do
       today =
         Date.new!(2026, 4, 13)
         |> DateTime.new!(Time.new!(3, 0, 0), "America/New_York")
-        |> Util.datetime_to_gtfs()
+        |> Util.DateTime.datetime_to_gtfs()
 
       nine_pm = ~T[21:00:00]
       end_of_service = ~T[03:00:00]
@@ -473,7 +473,7 @@ defmodule MBTAV3API.AlertTest do
 
     test "selects specific days" do
       selected_days = MapSet.new([1, 2])
-      today = "America/New_York" |> DateTime.now!() |> Util.datetime_to_gtfs()
+      today = "America/New_York" |> DateTime.now!() |> Util.DateTime.datetime_to_gtfs()
       nine_pm = ~T[21:00:00]
       end_of_service = ~T[03:00:00]
 
@@ -512,7 +512,7 @@ defmodule MBTAV3API.AlertTest do
       today =
         Date.new!(2026, 4, 13)
         |> DateTime.new!(Time.new!(3, 0, 0), "America/New_York")
-        |> Util.datetime_to_gtfs()
+        |> Util.DateTime.datetime_to_gtfs()
 
       nine_am = ~T[09:00:00]
       end_of_service = ~T[03:00:00]

--- a/test/mobile_app_backend/alerts/alert_summary_test.exs
+++ b/test/mobile_app_backend/alerts/alert_summary_test.exs
@@ -449,7 +449,7 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
     end
 
     test "summary with end of service timeframe", %{now: now} do
-      tomorrow = Util.datetime_to_gtfs(now) |> Date.add(1)
+      tomorrow = Util.DateTime.datetime_to_gtfs(now) |> Date.add(1)
       end_time = DateTime.new!(tomorrow, ~T[02:59:00], "America/New_York")
 
       alert =
@@ -462,7 +462,7 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
     end
 
     test "summary with alt end of service timeframe", %{now: now} do
-      tomorrow = Util.datetime_to_gtfs(now) |> Date.add(1)
+      tomorrow = Util.DateTime.datetime_to_gtfs(now) |> Date.add(1)
       end_time = DateTime.new!(tomorrow, ~T[03:00:00], "America/New_York")
 
       alert =
@@ -476,7 +476,7 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
 
     test "summary with tomorrow timeframe", %{now: now} do
       # Set to tomorrow's end of service, with a date of 2 days from now
-      tomorrow = Util.datetime_to_gtfs(now) |> Date.add(2)
+      tomorrow = Util.DateTime.datetime_to_gtfs(now) |> Date.add(2)
       end_time = DateTime.new!(tomorrow, ~T[03:00:00], "America/New_York")
 
       alert =
@@ -491,7 +491,7 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
     test "summary with this week timeframe" do
       # Fixed time so we can have a specific day of the week (wed)
       now = ~B[2025-04-02 09:00:00]
-      saturday = Util.datetime_to_gtfs(now) |> Date.add(3)
+      saturday = Util.DateTime.datetime_to_gtfs(now) |> Date.add(3)
       end_time = DateTime.new!(saturday, ~T[05:00:00], "America/New_York")
 
       alert =
@@ -506,7 +506,7 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
     test "summary with later date timeframe" do
       # Fixed time so we can have a specific day of the week (wed)
       now = ~B[2025-04-02 09:00:00]
-      monday = Util.datetime_to_gtfs(now) |> Date.add(5)
+      monday = Util.DateTime.datetime_to_gtfs(now) |> Date.add(5)
       end_time = DateTime.new!(monday, ~T[05:00:00], "America/New_York")
 
       alert =

--- a/test/mobile_app_backend/notifications/scheduler_test.exs
+++ b/test/mobile_app_backend/notifications/scheduler_test.exs
@@ -532,7 +532,7 @@ defmodule MobileAppBackend.Notifications.SchedulerTest do
         "alert_id" => alert.id,
         "title" => "Fitchburg Line",
         "body" =>
-          "Trip cancelled starting #{Util.datetime_to_string(start_time, :short_time)} today",
+          "Trip cancelled starting #{Util.DateTime.datetime_to_string(start_time, :short_time)} today",
         "deep_link_path" => "/s/#{parent_stop.id}/r/#{route.id}/d/1",
         "type" => "reminder",
         "upstream_timestamp" => nil,
@@ -653,7 +653,7 @@ defmodule MobileAppBackend.Notifications.SchedulerTest do
         "alert_id" => alert.id,
         "title" => "Fitchburg Line",
         "body" =>
-          "Trip cancelled starting #{Util.datetime_to_string(start_time, :short_time)} today",
+          "Trip cancelled starting #{Util.DateTime.datetime_to_string(start_time, :short_time)} today",
         "deep_link_path" => "/s/#{parent_stop.id}/r/#{route.id}/d/1",
         "type" => "reminder",
         "upstream_timestamp" => nil,

--- a/test/mobile_app_backend/notifications/window_test.exs
+++ b/test/mobile_app_backend/notifications/window_test.exs
@@ -118,6 +118,19 @@ defmodule MobileAppBackend.Notifications.WindowTest do
       assert Window.next_overlap(period, window, now) == ~B[2026-03-20 16:21:00]
     end
 
+    test "window start when window starts after period starts daylight savings" do
+      period = %Alert.ActivePeriod{start: ~B[2027-03-14 00:00:00], end: nil}
+
+      window = %Window{
+        start_time: ~T[02:00:00],
+        end_time: ~T[17:00:00],
+        days_of_week: Enum.to_list(1..7)
+      }
+
+      now = ~B[2026-03-20 16:10:00]
+      assert Window.next_overlap(period, window, now) == ~B[2027-03-14 03:00:00]
+    end
+
     test "checks all windows and periods" do
       p1 = %Alert.ActivePeriod{start: ~B[2026-03-20 16:23:00], end: ~B[2026-03-20 16:25:00]}
       p2 = %Alert.ActivePeriod{start: ~B[2026-03-20 16:28:00], end: ~B[2026-03-20 16:30:00]}

--- a/test/mobile_app_backend_web/controllers/next_schedule_controller_test.exs
+++ b/test/mobile_app_backend_web/controllers/next_schedule_controller_test.exs
@@ -69,7 +69,7 @@ defmodule MobileAppBackendWeb.NextScheduleControllerTest do
 
   test "checks tomorrow before loading service to find later date", %{conn: conn} do
     now = DateTime.now!("America/New_York")
-    today = Util.datetime_to_gtfs(now)
+    today = Util.DateTime.datetime_to_gtfs(now)
     tomorrow = Date.add(today, 1)
     schedule = build(:schedule)
 
@@ -107,7 +107,7 @@ defmodule MobileAppBackendWeb.NextScheduleControllerTest do
 
   test "returns null if no future service", %{conn: conn} do
     now = DateTime.now!("America/New_York")
-    today = Util.datetime_to_gtfs(now)
+    today = Util.DateTime.datetime_to_gtfs(now)
     tomorrow = Date.add(today, 1)
 
     route = "CR-Foxboro"

--- a/test/util/date_time_test.exs
+++ b/test/util/date_time_test.exs
@@ -1,0 +1,4 @@
+defmodule Util.DateTimeTest do
+  use ExUnit.Case, async: true
+  doctest Util.DateTime
+end


### PR DESCRIPTION
### Summary

_Ticket:_ [Investigate error scheduling notifications](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215500480088770?focus=true)

<!-- What is this PR for? -->

The cause of the failure was a recurring alert that had active periods out into 2027. `Window.next_overlap` was creating date times combining the active period dates & the user's window time, which could result in invalid dates due to DST. This now safely handles those scenarios by using a new function which always chooses the later valid time around the DST boundary.

While adding this new util, I opted to break out a separate `Utils.DateTime` file for organization.

### Testing

<!-- What testing have you done? -->

* Added tests for the new function 