### PR TITLE
build: fix deploy workflows after zizmor

### DIFF
--- a/.github/workflows/deploy-dev-orange.yml
+++ b/.github/workflows/deploy-dev-orange.yml
@@ -43,6 +43,9 @@ jobs:
     needs: check
     if: ${{ needs.check.outputs.should-run == 'true' }}
     uses: ./.github/workflows/deploy.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       env: dev-orange
       deploy-desc: ${{ github.event_name == 'pull_request' && 'PR' || github.ref_type }} ${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref_name }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -13,6 +13,9 @@ jobs:
   deploy:
     name: Deploy ${{ github.ref_type }} ${{ github.ref_name }} to Prod
     uses: ./.github/workflows/deploy.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       env: prod
       deploy-desc: ${{ github.ref_type }} ${{ github.ref_name }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -12,6 +12,9 @@ jobs:
   deploy:
     name: Deploy ${{ github.ref_type }} ${{ github.ref_name }} to Staging
     uses: ./.github/workflows/deploy.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       env: staging
       deploy-desc: ${{ github.ref_type }} ${{ github.ref_name }}


### PR DESCRIPTION
### Summary

_Ticket:_ none

All our deploys appear to be broken after #528 because the deploy workflow is called with insufficient permissions. This fixes it.

### Testing

Deployed this PR to dev-orange, so it definitely works.