### PR TITLE
test: Flaky test roundup

### DIFF
--- a/test/mbta_v3_api/json_api/object_test.exs
+++ b/test/mbta_v3_api/json_api/object_test.exs
@@ -139,6 +139,11 @@ defmodule MBTAV3API.JsonApi.ObjectTest do
                    fn ->
                      Code.compile_quoted(bad_module)
                    end
+
+      on_exit(fn ->
+        :code.purge(BadModule)
+        :code.delete(BadModule)
+      end)
     end
 
     test "accepts renames" do
@@ -158,6 +163,11 @@ defmodule MBTAV3API.JsonApi.ObjectTest do
         end
 
       assert [{GoodModule, _}] = Code.compile_quoted(good_module)
+
+      on_exit(fn ->
+        :code.purge(GoodModule)
+        :code.delete(GoodModule)
+      end)
     end
   end
 

--- a/test/mbta_v3_api/stream/static_instance_test.exs
+++ b/test/mbta_v3_api/stream/static_instance_test.exs
@@ -91,7 +91,7 @@ defmodule MBTAV3API.Stream.StaticInstanceTest do
     end
 
     test "launches new instance if not already running" do
-      topic = "predictions:route:fake-route-that-won't-already-exist"
+      topic = "predictions:route:#{Uniq.UUID.uuid7()}"
       refute Stream.Registry.find_pid(topic)
       assert {:ok, _} = Stream.StaticInstance.subscribe(topic)
       assert Stream.Registry.find_pid(topic)
@@ -113,10 +113,11 @@ defmodule MBTAV3API.Stream.StaticInstanceTest do
     end
 
     test "launches new instance if not already running" do
-      topic = "predictions:route:fake-route"
+      topic = "predictions:route:#{Uniq.UUID.uuid7()}"
       refute Stream.Registry.find_pid(topic)
       assert {:ok, _} = Stream.StaticInstance.ensure_stream_started(topic)
-      assert Stream.Registry.find_pid(topic)
+      pid =  Stream.Registry.find_pid(topic)
+      assert pid
     end
 
     test "when include_current_data is false, skips returning latest data" do

--- a/test/mbta_v3_api/stream/static_instance_test.exs
+++ b/test/mbta_v3_api/stream/static_instance_test.exs
@@ -116,8 +116,7 @@ defmodule MBTAV3API.Stream.StaticInstanceTest do
       topic = "predictions:route:#{Uniq.UUID.uuid7()}"
       refute Stream.Registry.find_pid(topic)
       assert {:ok, _} = Stream.StaticInstance.ensure_stream_started(topic)
-      pid =  Stream.Registry.find_pid(topic)
-      assert pid
+      assert Stream.Registry.find_pid(topic)
     end
 
     test "when include_current_data is false, skips returning latest data" do

--- a/test/mobile_app_backend/alerts/pub_sub_test.exs
+++ b/test/mobile_app_backend/alerts/pub_sub_test.exs
@@ -11,6 +11,8 @@ defmodule MobileAppBackend.Alerts.PubSubTests do
   import MobileAppBackend.Factory
 
   setup do
+    reassign_env(:mobile_app_backend, :alerts_broadcast_interval_ms, 10_000)
+
     verify_on_exit!()
     reassign_env(:mobile_app_backend, Store.Alerts, AlertsStoreMock)
     :ok
@@ -65,7 +67,6 @@ defmodule MobileAppBackend.Alerts.PubSubTests do
     setup do
       _dispatched_table = :ets.new(:test_last_dispatched, [:set, :named_table])
       {:ok, %{last_dispatched_table_name: :test_last_dispatched}}
-      reassign_env(:mobile_app_backend, :alerts_broadcast_interval_ms, 10_000)
     end
 
     test "broadcasts on :reset_event" do

--- a/test/mobile_app_backend/alerts/pub_sub_test.exs
+++ b/test/mobile_app_backend/alerts/pub_sub_test.exs
@@ -65,6 +65,7 @@ defmodule MobileAppBackend.Alerts.PubSubTests do
     setup do
       _dispatched_table = :ets.new(:test_last_dispatched, [:set, :named_table])
       {:ok, %{last_dispatched_table_name: :test_last_dispatched}}
+      reassign_env(:mobile_app_backend, :alerts_broadcast_interval_ms, 10_000)
     end
 
     test "broadcasts on :reset_event" do

--- a/test/mobile_app_backend/health/cache_test.exs
+++ b/test/mobile_app_backend/health/cache_test.exs
@@ -5,13 +5,13 @@ defmodule MobileAppBackend.Health.CacheTest do
   import Test.Support.Helpers
 
   defmodule Cache do
-    def stats do
-      %Nebulex.Stats{measurements: %{hits: 4, misses: 4}}
+    def info do
+      {:ok, %{stats: %{hits: 4, misses: 4}}}
     end
   end
 
   defmodule StatslessCache do
-    def stats, do: nil
+    def info, do: nil
   end
 
   describe "handle_info/1" do

--- a/test/mobile_app_backend/health/cache_test.exs
+++ b/test/mobile_app_backend/health/cache_test.exs
@@ -4,12 +4,18 @@ defmodule MobileAppBackend.Health.CacheTest do
   import ExUnit.CaptureLog
   import Test.Support.Helpers
 
+  defmodule Cache do
+    def stats do
+      %Nebulex.Stats{measurements: %{hits: 4, misses: 4}}
+    end
+  end
+
+  defmodule StatslessCache do
+    def stats, do: nil
+  end
+
   describe "handle_info/1" do
     test "when stats disabled, logs" do
-      defmodule StatslessCache do
-        def info, do: nil
-      end
-
       set_log_level(:info)
 
       msg =
@@ -21,12 +27,6 @@ defmodule MobileAppBackend.Health.CacheTest do
     end
 
     test "when stats found, logs stats" do
-      defmodule Cache do
-        def info do
-          {:ok, %{stats: %{hits: 4, misses: 4}}}
-        end
-      end
-
       set_log_level(:info)
 
       msg =


### PR DESCRIPTION
### Summary

_Ticket:_ [Flaky test roundup](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214097786423207?focus=true)

<!-- What is this PR for? -->

I was not able to reproduce the specific failure mentioned in the test. But these changes make it so that we can reliably run tests with `--repeat-until-failure` so that we have an easier time chasing down flaky tests in the future. 

### Testing

<!-- What testing have you done? -->
* Ran locally with `--repeat-until-failure` on for 100 runs without failure *sometimes* (running for a higher number of repetitions I get memory errors). I still get misc errors including the ones described in the comments sometimes... but this is a start