### PR TITLE
feat: context for trip-specific alerts to use this trip

### DIFF
--- a/lib/mobile_app_backend/alerts/alert_summary.ex
+++ b/lib/mobile_app_backend/alerts/alert_summary.ex
@@ -421,6 +421,8 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
 
   @type t :: Standard.t() | AllClear.t() | TripSpecific.t() | TripShuttle.t()
 
+  @type context :: :notification | :card
+
   @spec summarizing(
           Alert.t(),
           Stop.id(),
@@ -428,9 +430,10 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
           [RoutePattern.t()],
           DateTime.t(),
           [Schedule.t()] | nil,
-          GlobalDataCache.data()
+          GlobalDataCache.data(),
+          context()
         ) :: t()
-  def summarizing(alert, stop_id, direction_id, patterns, at_time, schedules, global) do
+  def summarizing(alert, stop_id, direction_id, patterns, at_time, schedules, global, context) do
     with nil <- all_clear_summary(alert, stop_id, direction_id, patterns, global),
          nil <-
            TripSpecific.summary(
@@ -440,7 +443,8 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
              patterns,
              at_time,
              schedules,
-             global
+             global,
+             context
            ) do
       recurrence = alert_recurrence(alert, at_time)
 

--- a/lib/mobile_app_backend/alerts/alert_summary/trip_shuttle.ex
+++ b/lib/mobile_app_backend/alerts/alert_summary/trip_shuttle.ex
@@ -54,7 +54,8 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripShuttle do
           [RoutePattern.t()],
           DateTime.t(),
           [Schedule.t()] | nil,
-          GlobalDataCache.data()
+          GlobalDataCache.data(),
+          AlertSummary.context()
         ) :: t() | nil
   def summary(
         alert,
@@ -63,7 +64,8 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripShuttle do
         patterns,
         at_time,
         informed_schedules,
-        global
+        global,
+        context
       ) do
     with %AlertSummary.Location.SuccessiveStops{
            start_stop_name: location_start_stop_name,
@@ -76,7 +78,7 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripShuttle do
            resolve_start_stop_name(downstream, location_start_stop_name, current_stop_name),
          identity_stop_name <- resolve_trip_identity_stop_name(downstream, current_stop_name),
          trip_identity when not is_nil(trip_identity) <-
-           trip_identity(identity_stop_name, patterns, informed_schedules, global) do
+           trip_identity(identity_stop_name, patterns, informed_schedules, global, context) do
       %__MODULE__{
         trip_identity: trip_identity,
         start_stop_name: start_stop_name,
@@ -146,26 +148,30 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripShuttle do
          current_stop_name,
          patterns,
          informed_schedules,
-         global
+         global,
+         context
        ) do
+    route_type = Enum.find_value(patterns, &global.routes[&1.route_id].type)
+
     case informed_schedules do
       [] ->
         nil
+
+      _ when context == :card ->
+        if route_type do
+          %ThisTrip{route_type: route_type}
+        end
 
       [%Schedule{} = informed_trip]
       when not is_nil(informed_trip.departure_time) or not is_nil(informed_trip.arrival_time) ->
         trip_time = informed_trip.departure_time || informed_trip.arrival_time
 
-        case Enum.find_value(patterns, &global.routes[&1.route_id]) do
-          %Route{type: route_type} ->
-            %SingleTrip{
-              trip_time: trip_time,
-              route_type: route_type,
-              from_stop_name: current_stop_name
-            }
-
-          _ ->
-            nil
+        if route_type do
+          %SingleTrip{
+            trip_time: trip_time,
+            route_type: route_type,
+            from_stop_name: current_stop_name
+          }
         end
 
       _ ->

--- a/lib/mobile_app_backend/alerts/alert_summary/trip_specific.ex
+++ b/lib/mobile_app_backend/alerts/alert_summary/trip_specific.ex
@@ -63,7 +63,8 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripSpecific do
           [RoutePattern.t()],
           DateTime.t(),
           [Schedule.t()] | nil,
-          GlobalDataCache.data()
+          GlobalDataCache.data(),
+          AlertSummary.context()
         ) :: t() | AlertSummary.TripShuttle.t() | nil
   def summary(
         alert,
@@ -72,7 +73,8 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripSpecific do
         patterns,
         at_time,
         schedules,
-        global
+        global,
+        context
       ) do
     informed_schedules =
       Enum.filter(schedules || [], fn schedule ->
@@ -88,11 +90,20 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripSpecific do
           patterns,
           at_time,
           informed_schedules,
-          global
+          global,
+          context
         )
 
       effect when effect in [:station_closure, :stop_closure, :dock_closure] ->
-        trip_stop_bypass_summary(alert, stop_id, patterns, at_time, informed_schedules, global)
+        trip_stop_bypass_summary(
+          alert,
+          stop_id,
+          patterns,
+          at_time,
+          informed_schedules,
+          global,
+          context
+        )
 
       _ ->
         trip_specific_other_summary(
@@ -102,7 +113,8 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripSpecific do
           patterns,
           at_time,
           informed_schedules,
-          global
+          global,
+          context
         )
     end
   end
@@ -164,11 +176,26 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripSpecific do
     end)
   end
 
-  defp trip_stop_bypass_summary(alert, stop_id, patterns, at_time, informed_schedules, global) do
+  defp trip_stop_bypass_summary(
+         alert,
+         stop_id,
+         patterns,
+         at_time,
+         informed_schedules,
+         global,
+         context
+       ) do
     route_type = route_type_from_patterns(patterns, global)
 
     {trip_identity, is_today} =
-      case trip_identity_is_today(stop_id, at_time, route_type, informed_schedules, global) do
+      case trip_identity_is_today(
+             stop_id,
+             at_time,
+             route_type,
+             informed_schedules,
+             global,
+             context
+           ) do
         {%TripFrom{trip_time: trip_time}, is_today} when route_type != nil ->
           # must be a single trip since there weren’t multiple trips
           [informed_schedule] = informed_schedules
@@ -213,12 +240,13 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripSpecific do
          patterns,
          at_time,
          informed_schedules,
-         global
+         global,
+         context
        ) do
     route_type = route_type_from_patterns(patterns, global)
 
     {trip_identity, is_today} =
-      trip_identity_is_today(stop_id, at_time, route_type, informed_schedules, global)
+      trip_identity_is_today(stop_id, at_time, route_type, informed_schedules, global, context)
 
     effect_stops =
       trip_specific_effect_stops(alert, stop_id, direction_id, patterns, global)
@@ -268,7 +296,7 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripSpecific do
 
   defp trip_specific_effect_stops(_, _, _, _, _), do: nil
 
-  defp trip_identity_is_today(stop_id, at_time, route_type, informed_schedules, global) do
+  defp trip_identity_is_today(stop_id, at_time, route_type, informed_schedules, global, context) do
     case informed_schedules do
       [] ->
         {nil, nil}
@@ -278,21 +306,46 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripSpecific do
 
       [%Schedule{} = informed_trip]
       when not is_nil(informed_trip.departure_time) or not is_nil(informed_trip.arrival_time) ->
-        trip_time = informed_trip.departure_time || informed_trip.arrival_time
+        trip_time = trip_time(informed_trip)
 
-        {%TripFrom{
-           trip_time: trip_time,
-           route_type: route_type,
-           stop_name: global.stops[stop_id].name
-         }, Util.DateTime.datetime_to_gtfs(trip_time) == Util.DateTime.datetime_to_gtfs(at_time)}
+        is_today? =
+          Util.DateTime.datetime_to_gtfs(trip_time) == Util.DateTime.datetime_to_gtfs(at_time)
+
+        trip_identity = single_trip_identity(trip_time, stop_id, route_type, global, context)
+
+        {trip_identity, is_today?}
 
       _ ->
-        {%MultipleTrips{},
-         Enum.any?(
-           informed_schedules,
-           &(Util.DateTime.datetime_to_gtfs(&1.departure_time || &1.arrival_time) ==
-               Util.DateTime.datetime_to_gtfs(at_time))
-         )}
+        trip_identity =
+          case context do
+            :notification -> %MultipleTrips{}
+            :card -> %ThisTrip{route_type: route_type}
+          end
+
+        is_today? =
+          Enum.any?(
+            informed_schedules,
+            &(Util.DateTime.datetime_to_gtfs(trip_time(&1)) ==
+                Util.DateTime.datetime_to_gtfs(at_time))
+          )
+
+        {trip_identity, is_today?}
+    end
+  end
+
+  defp trip_time(%Schedule{} = s), do: s.departure_time || s.arrival_time
+
+  defp single_trip_identity(trip_time, stop_id, route_type, global, context) do
+    case context do
+      :notification ->
+        %TripFrom{
+          trip_time: trip_time,
+          route_type: route_type,
+          stop_name: global.stops[stop_id].name
+        }
+
+      :card ->
+        %ThisTrip{route_type: route_type}
     end
   end
 end

--- a/lib/mobile_app_backend/alerts/pub_sub.ex
+++ b/lib/mobile_app_backend/alerts/pub_sub.ex
@@ -65,7 +65,7 @@ defmodule MobileAppBackend.Alerts.PubSub do
   @dialyzer {:no_opaque, map_data: 4}
   def map_data(data, legacy_compatibility, include_summaries, locale) do
     summaries_by_alert =
-      if include_summaries, do: SummaryEntityBuilder.build_all(data, locale), else: nil
+      if include_summaries, do: SummaryEntityBuilder.build_all(data, locale, :card), else: nil
 
     legacy_map = fn %Alert{} = alert ->
       if MapSet.member?(Alert.v2_causes(), alert.cause),

--- a/lib/mobile_app_backend/alerts/summary_entity_builder.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity_builder.ex
@@ -24,27 +24,38 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
   @doc """
   Given a list of alerts and global data, produces a list of summary entites keyed by alert id
   """
-  @spec build_all([Alert.t()], DateTime.t(), String.t(), GlobalDataCache.data()) :: %{
-          String.t() => [SummaryEntity.t()]
-        }
-  def build_all(alerts, at_time, locale, global) do
+  @spec build_all(
+          [Alert.t()],
+          DateTime.t(),
+          String.t(),
+          GlobalDataCache.data(),
+          AlertSummary.context()
+        ) :: %{String.t() => [SummaryEntity.t()]}
+  def build_all(alerts, at_time, locale, global, context) do
     Map.new(
-      Enum.map(alerts, fn alert -> {alert.id, build_for_alert(alert, at_time, locale, global)} end)
+      Enum.map(alerts, fn alert ->
+        {alert.id, build_for_alert(alert, at_time, locale, global, context)}
+      end)
     )
   end
 
-  @spec build_all([Alert.t()], String.t()) :: %{String.t() => [SummaryEntity.t()]}
-  def build_all(alerts, locale) do
+  @spec build_all([Alert.t()], String.t(), AlertSummary.context()) ::
+          %{String.t() => [SummaryEntity.t()]}
+  def build_all(alerts, locale, context) do
     at_time = DateTime.now!("America/New_York")
     global = GlobalDataCache.get_data()
 
-    build_all(alerts, at_time, locale, global)
+    build_all(alerts, at_time, locale, global, context)
   end
 
-  @spec build_for_alert(Alert.t(), DateTime.t(), String.t(), GlobalDataCache.data()) :: [
-          SummaryEntity.t()
-        ]
-  defp build_for_alert(alert, at_time, locale, global) do
+  @spec build_for_alert(
+          Alert.t(),
+          DateTime.t(),
+          String.t(),
+          GlobalDataCache.data(),
+          AlertSummary.context()
+        ) :: [SummaryEntity.t()]
+  defp build_for_alert(alert, at_time, locale, global, context) do
     # Fetch schedules once for the whole alert for any trips included in the informed entities
     {schedules, trips} = fetch_schedules_for_alert(alert)
 
@@ -55,7 +66,15 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
 
     Enum.flat_map(
       combinations,
-      &combination_to_summaries(&1, alert, at_time, locale, schedules, trips, stops, global)
+      &combination_to_summaries(
+        &1,
+        alert,
+        at_time,
+        locale,
+        {schedules, trips, stops},
+        global,
+        context
+      )
     )
     |> dedup_summaries()
   end
@@ -70,10 +89,9 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
          alert,
          at_time,
          locale,
-         schedules,
-         trips,
-         stops,
-         global
+         {schedules, trips, stops},
+         global,
+         context
        ) do
     RoutePattern.get_relevant_patterns(route_id, stop_id, direction_id, global)
     |> Enum.group_by(&{&1.route_id, &1.direction_id})
@@ -99,7 +117,8 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
           patterns,
           at_time,
           resolved_schedules,
-          global
+          global,
+          context
         )
 
       formatted =

--- a/lib/mobile_app_backend/notifications/engine.ex
+++ b/lib/mobile_app_backend/notifications/engine.ex
@@ -252,7 +252,8 @@ defmodule MobileAppBackend.Notifications.Engine do
       patterns,
       now,
       schedules,
-      global_data
+      global_data,
+      :notification
     )
   end
 

--- a/test/mobile_app_backend/alerts/alert_summary_test.exs
+++ b/test/mobile_app_backend/alerts/alert_summary_test.exs
@@ -433,7 +433,7 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
         )
 
       assert %AlertSummary.Standard{timeframe: %AlertSummary.Timeframe.UntilFurtherNotice{}} =
-               AlertSummary.summarizing(alert, "", 0, [], now, nil, %{})
+               AlertSummary.summarizing(alert, "", 0, [], now, nil, %{}, :notification)
     end
 
     test "summary with later today timeframe", %{now: now} do
@@ -445,7 +445,7 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
         )
 
       assert %AlertSummary.Standard{timeframe: %AlertSummary.Timeframe.Time{time: ^end_time}} =
-               AlertSummary.summarizing(alert, "", 0, [], now, nil, %{})
+               AlertSummary.summarizing(alert, "", 0, [], now, nil, %{}, :notification)
     end
 
     test "summary with end of service timeframe", %{now: now} do
@@ -458,7 +458,7 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
         )
 
       assert %AlertSummary.Standard{timeframe: %AlertSummary.Timeframe.EndOfService{}} =
-               AlertSummary.summarizing(alert, "", 0, [], now, nil, %{})
+               AlertSummary.summarizing(alert, "", 0, [], now, nil, %{}, :notification)
     end
 
     test "summary with alt end of service timeframe", %{now: now} do
@@ -471,7 +471,7 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
         )
 
       assert %AlertSummary.Standard{timeframe: %AlertSummary.Timeframe.EndOfService{}} =
-               AlertSummary.summarizing(alert, "", 0, [], now, nil, %{})
+               AlertSummary.summarizing(alert, "", 0, [], now, nil, %{}, :notification)
     end
 
     test "summary with tomorrow timeframe", %{now: now} do
@@ -485,7 +485,7 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
         )
 
       assert %AlertSummary.Standard{timeframe: %AlertSummary.Timeframe.Tomorrow{}} =
-               AlertSummary.summarizing(alert, "", 0, [], now, nil, %{})
+               AlertSummary.summarizing(alert, "", 0, [], now, nil, %{}, :notification)
     end
 
     test "summary with this week timeframe" do
@@ -500,7 +500,7 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
         )
 
       assert %AlertSummary.Standard{timeframe: %AlertSummary.Timeframe.ThisWeek{time: ^end_time}} =
-               AlertSummary.summarizing(alert, "", 0, [], now, nil, %{})
+               AlertSummary.summarizing(alert, "", 0, [], now, nil, %{}, :notification)
     end
 
     test "summary with later date timeframe" do
@@ -515,7 +515,7 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
         )
 
       assert %AlertSummary.Standard{timeframe: %AlertSummary.Timeframe.LaterDate{time: ^end_time}} =
-               AlertSummary.summarizing(alert, "", 0, [], now, nil, %{})
+               AlertSummary.summarizing(alert, "", 0, [], now, nil, %{}, :notification)
     end
 
     test "summary with starting tomorrow timeframe" do
@@ -527,7 +527,7 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
         )
 
       assert %AlertSummary.Standard{timeframe: %AlertSummary.Timeframe.StartingTomorrow{}} =
-               AlertSummary.summarizing(alert, "", 0, [], now, nil, %{})
+               AlertSummary.summarizing(alert, "", 0, [], now, nil, %{}, :notification)
     end
 
     test "summary with starting later today timeframe" do
@@ -537,7 +537,7 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
 
       assert %AlertSummary.Standard{
                timeframe: %AlertSummary.Timeframe.StartingLaterToday{time: ^later_today}
-             } = AlertSummary.summarizing(alert, "", 0, [], now, nil, %{})
+             } = AlertSummary.summarizing(alert, "", 0, [], now, nil, %{}, :notification)
     end
 
     test "summary with single stop", %{now: now} do
@@ -566,10 +566,19 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                  downstream: true
                }
              } =
-               AlertSummary.summarizing(alert, "", 0, [pattern], now, nil, %{
-                 routes: %{route.id => route},
-                 stops: %{stop.id => stop, child_stop.id => child_stop}
-               })
+               AlertSummary.summarizing(
+                 alert,
+                 "",
+                 0,
+                 [pattern],
+                 now,
+                 nil,
+                 %{
+                   routes: %{route.id => route},
+                   stops: %{stop.id => stop, child_stop.id => child_stop}
+                 },
+                 :notification
+               )
     end
 
     test "summary with successive stops", %{now: now} do
@@ -621,7 +630,8 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                    routes: %{route.id => route},
                    stops: Map.new(stops, &{&1.id, &1}),
                    trips: %{trip.id => trip}
-                 }
+                 },
+                 :notification
                )
     end
 
@@ -657,11 +667,20 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
         )
 
       assert %AlertSummary.Standard{location: nil} =
-               AlertSummary.summarizing(alert, "", 0, [pattern], now, nil, %{
-                 routes: %{route.id => route},
-                 stops: Map.new(stops, &{&1.id, &1}),
-                 trips: %{trip.id => trip}
-               })
+               AlertSummary.summarizing(
+                 alert,
+                 "",
+                 0,
+                 [pattern],
+                 now,
+                 nil,
+                 %{
+                   routes: %{route.id => route},
+                   stops: Map.new(stops, &{&1.id, &1}),
+                   trips: %{trip.id => trip}
+                 },
+                 :notification
+               )
     end
 
     test "summary with branching stops ahead", %{now: now} do
@@ -741,7 +760,8 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                        &{&1.id, &1}
                      ),
                    trips: %{trip1.id => trip1, trip2.id => trip2}
-                 }
+                 },
+                 :notification
                )
     end
 
@@ -822,7 +842,8 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                        &{&1.id, &1}
                      ),
                    trips: %{trip1.id => trip1, trip2.id => trip2}
-                 }
+                 },
+                 :notification
                )
     end
 
@@ -884,11 +905,20 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                  downstream: false
                }
              } =
-               AlertSummary.summarizing(alert, kenmore.id, 0, [b_branch, c_branch], now, nil, %{
-                 routes: %{route.id => route},
-                 stops: Map.new([kenmore, blandford, saint_marys | child_stops], &{&1.id, &1}),
-                 trips: %{b_branch_trip.id => b_branch_trip, c_branch_trip.id => c_branch_trip}
-               })
+               AlertSummary.summarizing(
+                 alert,
+                 kenmore.id,
+                 0,
+                 [b_branch, c_branch],
+                 now,
+                 nil,
+                 %{
+                   routes: %{route.id => route},
+                   stops: Map.new([kenmore, blandford, saint_marys | child_stops], &{&1.id, &1}),
+                   trips: %{b_branch_trip.id => b_branch_trip, c_branch_trip.id => c_branch_trip}
+                 },
+                 :notification
+               )
     end
 
     test "summary with branching GL on branch", %{now: now} do
@@ -942,15 +972,24 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                  end_stop_name: "Kenmore"
                }
              } =
-               AlertSummary.summarizing(alert, saint_marys.id, 1, [c_branch], now, nil, %{
-                 routes: %{route.id => route},
-                 stops:
-                   Map.new(
-                     [kenmore, blandford, saint_marys, c_branch_terminal | child_stops],
-                     &{&1.id, &1}
-                   ),
-                 trips: %{c_branch_trip.id => c_branch_trip}
-               })
+               AlertSummary.summarizing(
+                 alert,
+                 saint_marys.id,
+                 1,
+                 [c_branch],
+                 now,
+                 nil,
+                 %{
+                   routes: %{route.id => route},
+                   stops:
+                     Map.new(
+                       [kenmore, blandford, saint_marys, c_branch_terminal | child_stops],
+                       &{&1.id, &1}
+                     ),
+                   trips: %{c_branch_trip.id => c_branch_trip}
+                 },
+                 :notification
+               )
     end
 
     test "summary with branching GL on opposite and disconnected branch", %{now: now} do
@@ -1005,11 +1044,20 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                  direction: %Direction{name: "Westbound", destination: "Copley & West", id: 0}
                }
              } =
-               AlertSummary.summarizing(alert, medford_tufts.id, 0, [e_branch], now, nil, %{
-                 routes: %{route.id => route},
-                 stops: Map.new(parent_stations ++ child_stops, &{&1.id, &1}),
-                 trips: %{e_branch_trip.id => e_branch_trip}
-               })
+               AlertSummary.summarizing(
+                 alert,
+                 medford_tufts.id,
+                 0,
+                 [e_branch],
+                 now,
+                 nil,
+                 %{
+                   routes: %{route.id => route},
+                   stops: Map.new(parent_stations ++ child_stops, &{&1.id, &1}),
+                   trips: %{e_branch_trip.id => e_branch_trip}
+                 },
+                 :notification
+               )
     end
 
     test "summary with daily recurrence ending on a later date", %{now: now} do
@@ -1043,7 +1091,7 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                recurrence: %AlertSummary.Recurrence.Daily{
                  ending: %AlertSummary.Timeframe.LaterDate{time: ^end_time}
                }
-             } = AlertSummary.summarizing(alert, "", 0, [], now, nil, %{})
+             } = AlertSummary.summarizing(alert, "", 0, [], now, nil, %{}, :notification)
     end
 
     test "summary with daily recurrence until further notice", %{now: now} do
@@ -1076,7 +1124,7 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                recurrence: %AlertSummary.Recurrence.Daily{
                  ending: %AlertSummary.Timeframe.UntilFurtherNotice{}
                }
-             } = AlertSummary.summarizing(alert, "", 0, [], now, nil, %{})
+             } = AlertSummary.summarizing(alert, "", 0, [], now, nil, %{}, :notification)
     end
 
     test "summary with MWF recurrence ending later this week" do
@@ -1129,7 +1177,8 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                  [],
                  DateTime.new!(monday, noon, "America/New_York"),
                  nil,
-                 %{}
+                 %{},
+                 :notification
                )
 
       assert %AlertSummary.Standard{
@@ -1143,7 +1192,8 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                  [],
                  DateTime.new!(tuesday, noon, "America/New_York"),
                  nil,
-                 %{}
+                 %{},
+                 :notification
                )
     end
 
@@ -1159,7 +1209,7 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
       assert %AlertSummary.Standard{
                timeframe: %AlertSummary.Timeframe.Time{time: ^end_time},
                is_update: true
-             } = AlertSummary.summarizing(alert, "", 0, [], now, nil, %{})
+             } = AlertSummary.summarizing(alert, "", 0, [], now, nil, %{}, :notification)
     end
 
     test "summary with all_clear update", %{now: now} do
@@ -1174,7 +1224,7 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
         )
 
       assert %AlertSummary.AllClear{location: nil} =
-               AlertSummary.summarizing(alert, "", 0, [], now, nil, %{})
+               AlertSummary.summarizing(alert, "", 0, [], now, nil, %{}, :notification)
     end
 
     test "summary with whole route entity", %{now: now} do
@@ -1201,9 +1251,16 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                },
                timeframe: %AlertSummary.Timeframe.UntilFurtherNotice{}
              } =
-               AlertSummary.summarizing(alert, "", 0, [pattern], now, nil, %{
-                 routes: %{route.id => route}
-               })
+               AlertSummary.summarizing(
+                 alert,
+                 "",
+                 0,
+                 [pattern],
+                 now,
+                 nil,
+                 %{routes: %{route.id => route}},
+                 :notification
+               )
     end
 
     test "summary with stop entities for every stop on a route", %{now: now} do
@@ -1243,11 +1300,20 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                },
                timeframe: %AlertSummary.Timeframe.UntilFurtherNotice{}
              } =
-               AlertSummary.summarizing(alert, "", 0, [pattern], now, nil, %{
-                 routes: %{route.id => route},
-                 stops: stops,
-                 trips: %{trip.id => trip}
-               })
+               AlertSummary.summarizing(
+                 alert,
+                 "",
+                 0,
+                 [pattern],
+                 now,
+                 nil,
+                 %{
+                   routes: %{route.id => route},
+                   stops: stops,
+                   trips: %{trip.id => trip}
+                 },
+                 :notification
+               )
     end
 
     test "summary with whole green line alert", %{now: now} do
@@ -1292,9 +1358,18 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                },
                timeframe: %AlertSummary.Timeframe.UntilFurtherNotice{}
              } =
-               AlertSummary.summarizing(alert, "stopId", 0, e_patterns, now, nil, %{
-                 routes: routes
-               })
+               AlertSummary.summarizing(
+                 alert,
+                 "stopId",
+                 0,
+                 e_patterns,
+                 now,
+                 nil,
+                 %{
+                   routes: routes
+                 },
+                 :notification
+               )
     end
 
     test "summary with stop entities for every stop on the green line", %{now: now} do
@@ -1367,12 +1442,21 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                },
                timeframe: %AlertSummary.Timeframe.UntilFurtherNotice{}
              } =
-               AlertSummary.summarizing(alert, "stopId", 0, e_patterns, now, nil, %{
-                 routes: routes,
-                 stops: all_stops,
-                 trips: trips,
-                 route_patterns: Map.new(patterns, &{&1.id, &1})
-               })
+               AlertSummary.summarizing(
+                 alert,
+                 "stopId",
+                 0,
+                 e_patterns,
+                 now,
+                 nil,
+                 %{
+                   routes: routes,
+                   stops: all_stops,
+                   trips: trips,
+                   route_patterns: Map.new(patterns, &{&1.id, &1})
+                 },
+                 :notification
+               )
     end
 
     test "summary for whole other green line branch", %{now: now} do
@@ -1430,12 +1514,21 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                },
                timeframe: %AlertSummary.Timeframe.UntilFurtherNotice{}
              } =
-               AlertSummary.summarizing(alert, "stopId", 0, e_pattern, now, nil, %{
-                 routes: routes,
-                 route_patterns: Map.new(patterns, &{&1.id, &1}),
-                 trips: trips,
-                 stops: stops
-               })
+               AlertSummary.summarizing(
+                 alert,
+                 "stopId",
+                 0,
+                 e_pattern,
+                 now,
+                 nil,
+                 %{
+                   routes: routes,
+                   route_patterns: Map.new(patterns, &{&1.id, &1}),
+                   trips: trips,
+                   stops: stops
+                 },
+                 :notification
+               )
     end
 
     test "trip specific suspension" do
@@ -1479,10 +1572,19 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                cause: :weather,
                recurrence: nil
              } =
-               AlertSummary.summarizing(alert, stop.id, 0, [pattern], now, [schedule], %{
-                 stops: %{stop.id => stop},
-                 routes: %{route.id => route}
-               })
+               AlertSummary.summarizing(
+                 alert,
+                 stop.id,
+                 0,
+                 [pattern],
+                 now,
+                 [schedule],
+                 %{
+                   stops: %{stop.id => stop},
+                   routes: %{route.id => route}
+                 },
+                 :notification
+               )
     end
 
     test "trip specific suspension single stop downstream" do
@@ -1527,10 +1629,19 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                cause: :weather,
                recurrence: nil
              } =
-               AlertSummary.summarizing(alert, stop1.id, 0, [pattern], now, [schedule], %{
-                 stops: %{stop1.id => stop1, stop2.id => stop2},
-                 routes: %{route.id => route}
-               })
+               AlertSummary.summarizing(
+                 alert,
+                 stop1.id,
+                 0,
+                 [pattern],
+                 now,
+                 [schedule],
+                 %{
+                   stops: %{stop1.id => stop1, stop2.id => stop2},
+                   routes: %{route.id => route}
+                 },
+                 :notification
+               )
     end
 
     test "trip specific suspension multi stop downstream" do
@@ -1589,12 +1700,21 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                cause: :weather,
                recurrence: nil
              } =
-               AlertSummary.summarizing(alert, stop1.id, 0, [pattern], now, [schedule], %{
-                 stops: %{stop1.id => stop1, stop2.id => stop2, stop3.id => stop3},
-                 routes: %{route.id => route},
-                 route_patterns: %{pattern.id => pattern},
-                 trips: %{representative_trip.id => representative_trip}
-               })
+               AlertSummary.summarizing(
+                 alert,
+                 stop1.id,
+                 0,
+                 [pattern],
+                 now,
+                 [schedule],
+                 %{
+                   stops: %{stop1.id => stop1, stop2.id => stop2, stop3.id => stop3},
+                   routes: %{route.id => route},
+                   route_patterns: %{pattern.id => pattern},
+                   trips: %{representative_trip.id => representative_trip}
+                 },
+                 :notification
+               )
     end
 
     test "trip specific station closure" do
@@ -1667,10 +1787,19 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                cause: :weather,
                recurrence: nil
              } =
-               AlertSummary.summarizing(alert, stop1.id, 0, [pattern], now, [schedule], %{
-                 stops: %{stop1.id => stop1, stop2.id => stop2, stop3.id => stop3},
-                 routes: %{route.id => route}
-               })
+               AlertSummary.summarizing(
+                 alert,
+                 stop1.id,
+                 0,
+                 [pattern],
+                 now,
+                 [schedule],
+                 %{
+                   stops: %{stop1.id => stop1, stop2.id => stop2, stop3.id => stop3},
+                   routes: %{route.id => route}
+                 },
+                 :notification
+               )
     end
 
     test "trip specific dock closure" do
@@ -1739,10 +1868,19 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                cause: :weather,
                recurrence: nil
              } =
-               AlertSummary.summarizing(alert, stop1.id, 0, [pattern], now, [schedule], %{
-                 stops: %{stop1.id => stop1, stop2.id => stop2, stop3.id => stop3},
-                 routes: %{route.id => route}
-               })
+               AlertSummary.summarizing(
+                 alert,
+                 stop1.id,
+                 0,
+                 [pattern],
+                 now,
+                 [schedule],
+                 %{
+                   stops: %{stop1.id => stop1, stop2.id => stop2, stop3.id => stop3},
+                   routes: %{route.id => route}
+                 },
+                 :notification
+               )
     end
 
     test "multiple trip cancellation" do
@@ -1795,7 +1933,8 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                  [pattern],
                  now,
                  [schedule1, schedule2],
-                 %{routes: %{route.id => route}}
+                 %{routes: %{route.id => route}},
+                 :notification
                )
     end
 
@@ -1844,11 +1983,20 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                end_stop_name: "Forest Hills",
                recurrence: nil
              } =
-               AlertSummary.summarizing(alert, stop1.id, 0, [pattern], now, [schedule], %{
-                 routes: %{route.id => route},
-                 stops: %{stop1.id => stop1, stop2.id => stop2},
-                 trips: %{representative_trip.id => representative_trip}
-               })
+               AlertSummary.summarizing(
+                 alert,
+                 stop1.id,
+                 0,
+                 [pattern],
+                 now,
+                 [schedule],
+                 %{
+                   routes: %{route.id => route},
+                   stops: %{stop1.id => stop1, stop2.id => stop2},
+                   trips: %{representative_trip.id => representative_trip}
+                 },
+                 :notification
+               )
     end
 
     test "trip specific station bypass" do
@@ -1900,10 +2048,19 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                effect: :station_closure,
                effect_stops: ["Back Bay", "Ruggles"]
              } =
-               AlertSummary.summarizing(alert, stop1.id, 0, [pattern], now, [schedule], %{
-                 stops: %{stop1.id => stop1, stop2.id => stop2},
-                 routes: %{route.id => route}
-               })
+               AlertSummary.summarizing(
+                 alert,
+                 stop1.id,
+                 0,
+                 [pattern],
+                 now,
+                 [schedule],
+                 %{
+                   stops: %{stop1.id => stop1, stop2.id => stop2},
+                   routes: %{route.id => route}
+                 },
+                 :notification
+               )
     end
 
     test "trip specific reminder" do
@@ -1943,10 +2100,19 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                effect: :suspension,
                is_today: false
              } =
-               AlertSummary.summarizing(alert, stop.id, 0, [pattern], now, [schedule], %{
-                 stops: %{stop.id => stop},
-                 routes: %{route.id => route}
-               })
+               AlertSummary.summarizing(
+                 alert,
+                 stop.id,
+                 0,
+                 [pattern],
+                 now,
+                 [schedule],
+                 %{
+                   stops: %{stop.id => stop},
+                   routes: %{route.id => route}
+                 },
+                 :notification
+               )
     end
 
     test "trip shuttle recurrence" do
@@ -1999,11 +2165,20 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                  ending: %AlertSummary.Timeframe.ThisWeek{time: ^end_time}
                }
              } =
-               AlertSummary.summarizing(alert, stop1.id, 0, [pattern], now, [schedule], %{
-                 routes: %{route.id => route},
-                 stops: %{stop1.id => stop1, stop2.id => stop2},
-                 trips: %{representative_trip.id => representative_trip}
-               })
+               AlertSummary.summarizing(
+                 alert,
+                 stop1.id,
+                 0,
+                 [pattern],
+                 now,
+                 [schedule],
+                 %{
+                   routes: %{route.id => route},
+                   stops: %{stop1.id => stop1, stop2.id => stop2},
+                   trips: %{representative_trip.id => representative_trip}
+                 },
+                 :notification
+               )
     end
   end
 
@@ -2260,7 +2435,8 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                    routes: %{route.id => route},
                    stops: Map.new(stops, &{&1.id, &1}),
                    trips: %{trip.id => trip}
-                 }
+                 },
+                 :notification
                )
     end
 
@@ -2290,10 +2466,19 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                  stops: ["Parent Name"]
                }
              } =
-               AlertSummary.summarizing(alert, "", 0, [pattern], now, nil, %{
-                 routes: %{route.id => route},
-                 stops: %{stop.id => stop, child_stop.id => child_stop}
-               })
+               AlertSummary.summarizing(
+                 alert,
+                 "",
+                 0,
+                 [pattern],
+                 now,
+                 nil,
+                 %{
+                   routes: %{route.id => route},
+                   stops: %{stop.id => stop, child_stop.id => child_stop}
+                 },
+                 :notification
+               )
     end
 
     test "trip specific - same trip and stops" do

--- a/test/mobile_app_backend/alerts/summary_entity_builder_test.exs
+++ b/test/mobile_app_backend/alerts/summary_entity_builder_test.exs
@@ -227,7 +227,20 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
                    summary: "Service suspended on Red Line"
                  }
                ]
-             } = SummaryEntityBuilder.build_all([alert], now, "en", global)
+             } = SummaryEntityBuilder.build_all([alert], now, "en", global, :notification)
+
+      assert %{
+               ^alert_id => [
+                 %SummaryEntity{
+                   alert_id: ^alert_id,
+                   route_id: ^route_id,
+                   stop_id: nil,
+                   trip_id: nil,
+                   direction_id: 0,
+                   summary: "Service suspended on Red Line"
+                 }
+               ]
+             } = SummaryEntityBuilder.build_all([alert], now, "en", global, :card)
     end
 
     test "build trip alert" do
@@ -301,7 +314,20 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
                      "4:41 PM train from Harvard Sq @ Garden St - Dawes Island is suspended tomorrow due to maintenance"
                  }
                ]
-             } = SummaryEntityBuilder.build_all([alert], now, "en", global)
+             } = SummaryEntityBuilder.build_all([alert], now, "en", global, :notification)
+
+      assert %{
+               ^alert_id => [
+                 %SummaryEntity{
+                   alert_id: ^alert_id,
+                   route_id: ^route_id,
+                   stop_id: nil,
+                   trip_id: ^trip_id,
+                   direction_id: 0,
+                   summary: "This train is suspended tomorrow due to maintenance"
+                 }
+               ]
+             } = SummaryEntityBuilder.build_all([alert], now, "en", global, :card)
     end
 
     test "build stop alert" do
@@ -363,7 +389,20 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
                    summary: "Service suspended at Harvard Sq @ Garden St - Dawes Island"
                  }
                ]
-             } = SummaryEntityBuilder.build_all([alert], now, "en", global)
+             } = SummaryEntityBuilder.build_all([alert], now, "en", global, :notification)
+
+      assert %{
+               ^alert_id => [
+                 %SummaryEntity{
+                   alert_id: ^alert_id,
+                   route_id: ^route_id,
+                   stop_id: ^stop_id,
+                   trip_id: nil,
+                   direction_id: 0,
+                   summary: "Service suspended at Harvard Sq @ Garden St - Dawes Island"
+                 }
+               ]
+             } = SummaryEntityBuilder.build_all([alert], now, "en", global, :card)
     end
 
     test "build route type alert" do
@@ -431,7 +470,7 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
 
       assert %{
                ^alert_id => summary_entities
-             } = SummaryEntityBuilder.build_all([alert], now, "en", global)
+             } = SummaryEntityBuilder.build_all([alert], now, "en", global, :notification)
 
       assert [
                %SummaryEntity{


### PR DESCRIPTION
### Summary

_Ticket:_ [Alert Summary Consolidation | Generate trip specific summaries differently for displaying on the frontend](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215637601111269)

The only hard part here wound up being appeasing Credo as our complexity and number of parameters increases.

### Testing

Updated some unit tests to specifically confirm trip-specific alerts vary and other alerts do not.