### PR TITLE
fix: Assorted test issues and type warnings

### DIFF
--- a/test/mobile_app_backend/alerts/pub_sub_test.exs
+++ b/test/mobile_app_backend/alerts/pub_sub_test.exs
@@ -157,9 +157,9 @@ defmodule MobileAppBackend.Alerts.PubSubTests do
     end
 
     test "legacy compatibility converts v2 alert causes", state do
-      alert_1 = build(:alert, id: "a_1", cause: :single_tracking)
-      alert_2 = build(:alert, id: "a_2", cause: :rail_defect)
-      alert_3 = build(:alert, id: "a_3", cause: :shuttle)
+      %MBTAV3API.Alert{} = alert_1 = build(:alert, id: "a_1", cause: :single_tracking)
+      %MBTAV3API.Alert{} = alert_2 = build(:alert, id: "a_2", cause: :rail_defect)
+      %MBTAV3API.Alert{} = alert_3 = build(:alert, id: "a_3", cause: :shuttle)
 
       AlertsStoreMock
       # Subscribe
@@ -168,12 +168,12 @@ defmodule MobileAppBackend.Alerts.PubSubTests do
       |> expect(:fetch, fn _ -> [alert_2, alert_3] end)
 
       initial_alerts = PubSub.subscribe(legacy_compatibility: true)
-      assert to_alert_map([%Alert{alert_1 | cause: :unknown_cause}]) == initial_alerts
+      assert to_alert_map([%{alert_1 | cause: :unknown_cause}]) == initial_alerts
 
       PubSub.handle_info(:broadcast, state)
 
       assert_receive {:new_alerts, new_alerts}
-      assert to_alert_map([%Alert{alert_2 | cause: :unknown_cause}, alert_3]) == new_alerts
+      assert to_alert_map([%{alert_2 | cause: :unknown_cause}, alert_3]) == new_alerts
     end
   end
 end

--- a/test/mobile_app_backend/notifications/delivered_notification_pruner_test.exs
+++ b/test/mobile_app_backend/notifications/delivered_notification_pruner_test.exs
@@ -36,6 +36,7 @@ defmodule MobileAppBackend.Notifications.DeliveredNotificationPrunerTest do
       capture_log([level: :info], fn ->
         :ok = perform_job(DeliveredNotificationPruner, %{})
       end)
+      |> String.replace(~r/\e\[[0-9;]*[mK]/, "")
 
     assert Repo.all(DeliveredNotification) == []
     assert log =~ "[info] #{DeliveredNotificationPruner} pruned=1 remaining=0\n"
@@ -61,6 +62,7 @@ defmodule MobileAppBackend.Notifications.DeliveredNotificationPrunerTest do
       capture_log([level: :info], fn ->
         :ok = perform_job(DeliveredNotificationPruner, %{})
       end)
+      |> String.replace(~r/\e\[[0-9;]*[mK]/, "")
 
     assert Repo.all(DeliveredNotification) == [dn]
     assert log =~ "[info] #{DeliveredNotificationPruner} pruned=0 remaining=1\n"
@@ -84,6 +86,7 @@ defmodule MobileAppBackend.Notifications.DeliveredNotificationPrunerTest do
       capture_log([level: :info], fn ->
         :ok = perform_job(DeliveredNotificationPruner, %{})
       end)
+      |> String.replace(~r/\e\[[0-9;]*[mK]/, "")
 
     assert Repo.all(DeliveredNotification) == [dn]
     assert log =~ "[info] #{DeliveredNotificationPruner} pruned=0 remaining=1\n"

--- a/test/mobile_app_backend/notifications/stats_reporter_test.exs
+++ b/test/mobile_app_backend/notifications/stats_reporter_test.exs
@@ -67,6 +67,7 @@ defmodule MobileAppBackend.Notifications.StatsReporterTest do
       capture_log([level: :info], fn ->
         :ok = perform_job(StatsReporter, %{})
       end)
+      |> String.replace(~r/\e\[[0-9;]*[mK]/, "")
 
     assert log =~ "[info] #{StatsReporter} users_by_route route_id=66 count=1\n"
     assert log =~ "[info] #{StatsReporter} users_by_route route_id=Red count=2\n"

--- a/test/mobile_app_backend/throttler_test.exs
+++ b/test/mobile_app_backend/throttler_test.exs
@@ -12,8 +12,8 @@ defmodule MobileAppBackend.ThrottlerTest do
     throttler = start_link_supervised!({Throttler, target: self(), cast: :message, ms: @timeout})
 
     if last_cast_ms_ago = ctx[:last_cast_ms_ago] do
-      :sys.replace_state(throttler, fn state ->
-        %Throttler.State{
+      :sys.replace_state(throttler, fn %Throttler.State{} = state ->
+        %{
           state
           | last_cast: System.monotonic_time(:millisecond) - last_cast_ms_ago
         }

--- a/test/support/data.ex
+++ b/test/support/data.ex
@@ -154,8 +154,8 @@ defmodule Test.Support.Data do
       nil ->
         {:reply, nil, state}
 
-      result ->
-        result = %Response{result | touched: true}
+      %Response{} = result ->
+        result = %{result | touched: true}
         state = put_in(state.data[request], result)
         {:reply, result, state}
     end
@@ -165,7 +165,7 @@ defmodule Test.Support.Data do
     state =
       update_in(state.data[request], fn
         nil -> %Response{id: Uniq.UUID.uuid7(), new_data: data, touched: true}
-        resp -> %Response{resp | new_data: data, touched: true}
+        %Response{} = resp -> %{resp | new_data: data, touched: true}
       end)
 
     {:reply, :ok, state}


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket

I was hitting these while running tests on the alert diff changes, my local logging was adding ANSI terminal escape codes, which were causing log tests to fail, so I added a regex to strip them out. I was also getting some warnings about type checks, so I fixed those too.

### Testing

Tests pass