### PR TITLE
feat: Diff alerts:v3 channel updates

### DIFF
--- a/lib/mobile_app_backend_web/channels/alerts_channel.ex
+++ b/lib/mobile_app_backend_web/channels/alerts_channel.ex
@@ -1,8 +1,21 @@
 defmodule MobileAppBackendWeb.AlertsChannel do
   use MobileAppBackendWeb, :channel
 
+  defmodule AlertUpdate do
+    @type t :: %__MODULE__{
+            remove: [String.t()],
+            update: %{String.t() => Alert.t() | AlertWithSummaries.t()}
+          }
+    @derive Jason.Encoder
+    defstruct [:remove, :update]
+
+    def empty?(update) do
+      Enum.empty?(update.remove) and Enum.empty?(update.update)
+    end
+  end
+
   @impl true
-  def join("alerts" = topic, _payload, socket) do
+  def join("alerts", _payload, socket) do
     pubsub_module =
       Application.get_env(
         :mobile_app_backend,
@@ -10,12 +23,12 @@ defmodule MobileAppBackendWeb.AlertsChannel do
         MobileAppBackend.Alerts.PubSub
       )
 
-    data = pubsub_module.subscribe(get_opts(topic, socket))
+    data = pubsub_module.subscribe(get_opts(socket))
     {:ok, data, socket}
   end
 
   @impl true
-  def join("alerts:v2" = topic, _payload, socket) do
+  def join("alerts:v2", _payload, socket) do
     pubsub_module =
       Application.get_env(
         :mobile_app_backend,
@@ -23,12 +36,12 @@ defmodule MobileAppBackendWeb.AlertsChannel do
         MobileAppBackend.Alerts.PubSub
       )
 
-    data = pubsub_module.subscribe(get_opts(topic, socket))
+    data = pubsub_module.subscribe(get_opts(socket))
     {:ok, data, socket}
   end
 
   @impl true
-  def join("alerts:v3" = topic, _payload, socket) do
+  def join("alerts:v3", _payload, socket) do
     pubsub_module =
       Application.get_env(
         :mobile_app_backend,
@@ -36,12 +49,14 @@ defmodule MobileAppBackendWeb.AlertsChannel do
         MobileAppBackend.Alerts.PubSub
       )
 
-    data = pubsub_module.subscribe(get_opts(topic, socket))
-    {:ok, data, socket}
+    %{alerts: alerts} = pubsub_module.subscribe(get_opts(socket))
+    socket = assign(socket, :last_alerts, alert_hashes(alerts))
+
+    {:ok, %AlertUpdate{remove: [], update: alerts}, socket}
   end
 
-  defp get_opts(topic, socket) do
-    case topic do
+  defp get_opts(socket) do
+    case socket.topic do
       "alerts" ->
         [legacy_compatibility: true, include_summaries: false]
 
@@ -61,7 +76,71 @@ defmodule MobileAppBackendWeb.AlertsChannel do
 
   @impl true
   def handle_info({:new_alerts, data}, socket) do
-    :ok = push(socket, "stream_data", data)
-    {:noreply, socket}
+    case socket.topic do
+      "alerts:v3" ->
+        {:noreply, handle_info_v3({:new_alerts, data}, socket)}
+
+      _ ->
+        :ok = push(socket, "stream_data", data)
+        {:noreply, socket}
+    end
+  end
+
+  defp handle_info_v3({:new_alerts, %{alerts: alerts}}, socket) do
+    current_hashes = alert_hashes(alerts)
+    old_hashes = socket.assigns.last_alerts
+
+    current_ids = MapSet.new(Map.keys(current_hashes))
+    old_ids = MapSet.new(Map.keys(old_hashes))
+
+    removed_ids = MapSet.difference(old_ids, current_ids)
+    new_ids = MapSet.difference(current_ids, old_ids)
+
+    update_ids =
+      current_ids
+      |> MapSet.intersection(old_ids)
+      |> MapSet.filter(fn id -> Map.get(current_hashes, id) != Map.get(old_hashes, id) end)
+      |> MapSet.union(new_ids)
+
+    response =
+      %AlertUpdate{
+        remove: MapSet.to_list(removed_ids),
+        update: Map.filter(alerts, fn {id, _alert} -> Enum.member?(update_ids, id) end)
+      }
+
+    if !AlertUpdate.empty?(response) do
+      :ok = push(socket, "stream_data", response)
+    end
+
+    assign(socket, :last_alerts, current_hashes)
+  end
+
+  defp alert_hashes(alert_map) do
+    Map.new(alert_map, fn {key, val} ->
+      {key,
+       val
+       |> Map.from_struct()
+       |> Enum.sort_by(fn {key, _value} -> key end)
+       |> Enum.map(fn {key, value} ->
+         case key do
+           # Do some hacky sorting of informed entities, since the backend can return them arbitrarily in any order
+           :informed_entity ->
+             {key,
+              Enum.sort_by(value, fn entity ->
+                "#{entity.route}-#{entity.stop}-#{entity.direction_id}-#{entity.route_type}-#{entity.facility}-#{entity.trip}"
+              end)}
+
+           # Summaries can also change order based on the entity order, so sort those too
+           :summaries ->
+             {key, Enum.sort_by(value, fn summary -> summary.summary end)}
+
+           _ ->
+             {key, value}
+         end
+       end)
+       |> :erlang.term_to_binary()
+       |> then(&:crypto.hash(:md5, &1))
+       |> Base.encode16()}
+    end)
   end
 end

--- a/lib/mobile_app_backend_web/channels/alerts_channel.ex
+++ b/lib/mobile_app_backend_web/channels/alerts_channel.ex
@@ -1,10 +1,12 @@
 defmodule MobileAppBackendWeb.AlertsChannel do
   use MobileAppBackendWeb, :channel
+  alias MBTAV3API.Alert
+  alias MobileAppBackend.Alerts.AlertWithSummaries
 
   defmodule AlertUpdate do
     @type t :: %__MODULE__{
             remove: [String.t()],
-            update: %{String.t() => Alert.t() | AlertWithSummaries.t()}
+            update: %{String.t() => AlertWithSummaries.t()}
           }
     @derive Jason.Encoder
     defstruct [:remove, :update]
@@ -115,6 +117,7 @@ defmodule MobileAppBackendWeb.AlertsChannel do
     assign(socket, :last_alerts, current_hashes)
   end
 
+  @spec alert_hashes(%{String.t() => Alert.t()}) :: %{String.t() => String.t()}
   defp alert_hashes(alert_map) do
     Map.new(alert_map, fn {key, val} ->
       {key,

--- a/test/mobile_app_backend_web/channels/alerts_channel_test.exs
+++ b/test/mobile_app_backend_web/channels/alerts_channel_test.exs
@@ -1,10 +1,11 @@
 defmodule MobileAppBackendWeb.AlertsChannelTest do
   use MobileAppBackendWeb.ChannelCase
-  import MBTAV3API.JsonApi.Object, only: [to_full_map: 1]
   import Mox
   import Test.Support.Helpers
   import Test.Support.Sigils
   alias MBTAV3API.Alert
+  alias MobileAppBackend.Alerts.AlertWithSummaries
+  alias MobileAppBackend.Alerts.SummaryEntity
 
   alias MobileAppBackendWeb.AlertsChannel
 
@@ -17,6 +18,12 @@ defmodule MobileAppBackendWeb.AlertsChannelTest do
   end
 
   setup :verify_on_exit!
+
+  defp to_alert_map(alerts),
+    do:
+      alerts
+      |> Enum.map(fn alert -> {alert.id, alert} end)
+      |> Map.new()
 
   test "joins and subscribes correctly", %{socket: socket} do
     alert1 = %Alert{
@@ -54,14 +61,14 @@ defmodule MobileAppBackendWeb.AlertsChannelTest do
       lifecycle: :new
     }
 
-    data1 = to_full_map([alert1, alert2])
+    data1 = %{alerts: to_alert_map([alert1, alert2])}
 
     expect(AlertsPubSubMock, :subscribe, 1, fn _ -> data1 end)
 
     {:ok, ^data1, socket} =
       subscribe_and_join(socket, "alerts")
 
-    data2 = to_full_map([alert1])
+    data2 = %{alerts: to_alert_map([alert1])}
 
     AlertsChannel.handle_info({:new_alerts, data2}, socket)
 
@@ -104,17 +111,152 @@ defmodule MobileAppBackendWeb.AlertsChannelTest do
       lifecycle: :new
     }
 
-    data1 = to_full_map([alert1, alert2])
+    data1 = %{alerts: to_alert_map([alert1, alert2])}
 
     expect(AlertsPubSubMock, :subscribe, 1, fn _ -> data1 end)
 
     {:ok, ^data1, socket} =
       subscribe_and_join(socket, "alerts:v2")
 
-    data2 = to_full_map([alert1])
+    data2 = %{alerts: to_alert_map([alert1])}
 
     AlertsChannel.handle_info({:new_alerts, data2}, socket)
 
     assert_push("stream_data", ^data2)
+  end
+
+  test "joins and subscribes v3 correctly", %{socket: socket} do
+    alert1 = %AlertWithSummaries{
+      id: "501047",
+      active_period: [%Alert.ActivePeriod{start: ~B[2023-05-26 16:46:13]}],
+      effect: :station_issue,
+      effect_name: nil,
+      informed_entity: [
+        %Alert.InformedEntity{
+          activities: [:board],
+          route: "Green-D",
+          route_type: :light_rail,
+          stop: "70511"
+        },
+        %Alert.InformedEntity{
+          activities: [:board],
+          route: "88",
+          route_type: :bus,
+          stop: "place-lech"
+        }
+      ],
+      lifecycle: :ongoing,
+      summaries: [%SummaryEntity{summary: "test summary"}]
+    }
+
+    alert2 = %AlertWithSummaries{
+      id: "559018",
+      active_period: [
+        %Alert.ActivePeriod{start: ~B[2024-03-14 16:12:00], end: ~B[2024-03-14 18:13:39]}
+      ],
+      effect: :delay,
+      effect_name: nil,
+      informed_entity: [
+        %Alert.InformedEntity{activities: [:board, :exit, :ride], route: "120", route_type: :bus}
+      ],
+      lifecycle: :new,
+      summaries: [%SummaryEntity{summary: "test summary"}]
+    }
+
+    alert3 = %AlertWithSummaries{
+      id: "559019",
+      active_period: [
+        %Alert.ActivePeriod{start: ~B[2024-03-14 16:12:00], end: ~B[2024-03-14 18:13:39]}
+      ],
+      effect: :delay,
+      effect_name: nil,
+      informed_entity: [
+        %Alert.InformedEntity{activities: [:board, :exit, :ride], route: "1", route_type: :bus}
+      ],
+      lifecycle: :new,
+      summaries: [%SummaryEntity{summary: "test summary"}]
+    }
+
+    data1 = to_alert_map([alert1, alert2, alert3])
+
+    expect(AlertsPubSubMock, :subscribe, 1, fn _ -> %{alerts: data1} end)
+
+    {:ok,
+     %AlertsChannel.AlertUpdate{
+       remove: [],
+       update: ^data1
+     }, socket} =
+      subscribe_and_join(socket, "alerts:v3")
+
+    data2 = to_alert_map([%{alert1 | description: "different description"}])
+
+    AlertsChannel.handle_info(
+      {:new_alerts, %{alerts: Map.merge(data2, %{alert3.id => alert3})}},
+      socket
+    )
+
+    alert2_id = alert2.id
+
+    assert_push("stream_data", %AlertsChannel.AlertUpdate{
+      remove: [^alert2_id],
+      update: ^data2
+    })
+  end
+
+  test "v3 skips updates if there are no changes", %{socket: socket} do
+    alert1 = %AlertWithSummaries{
+      id: "501047",
+      active_period: [%Alert.ActivePeriod{start: ~B[2023-05-26 16:46:13]}],
+      effect: :station_issue,
+      effect_name: nil,
+      informed_entity: [
+        %Alert.InformedEntity{
+          activities: [:board],
+          route: "Green-D",
+          route_type: :light_rail,
+          stop: "70511"
+        },
+        %Alert.InformedEntity{
+          activities: [:board],
+          route: "88",
+          route_type: :bus,
+          stop: "place-lech"
+        }
+      ],
+      lifecycle: :ongoing,
+      summaries: [%SummaryEntity{summary: "test summary"}]
+    }
+
+    alert2 = %AlertWithSummaries{
+      id: "559018",
+      active_period: [
+        %Alert.ActivePeriod{start: ~B[2024-03-14 16:12:00], end: ~B[2024-03-14 18:13:39]}
+      ],
+      effect: :delay,
+      effect_name: nil,
+      informed_entity: [
+        %Alert.InformedEntity{activities: [:board, :exit, :ride], route: "120", route_type: :bus}
+      ],
+      lifecycle: :new,
+      summaries: [%SummaryEntity{summary: "test summary"}]
+    }
+
+    data1 = to_alert_map([alert1, alert2])
+
+    expect(AlertsPubSubMock, :subscribe, 1, fn _ -> %{alerts: data1} end)
+
+    {:ok,
+     %AlertsChannel.AlertUpdate{
+       remove: [],
+       update: ^data1
+     }, socket} =
+      subscribe_and_join(socket, "alerts:v3")
+
+    AlertsChannel.handle_info(
+      {:new_alerts, %{alerts: data1}},
+      socket
+    )
+
+    refute_push "stream_data", _
   end
 end


### PR DESCRIPTION
### Summary

_Ticket:_ [Alert Summary Consolidation | Send diffs for alert changes](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215637601111265?focus=true)

This uses socket assigns to remember the hashes of the previously sent alerts, which are then compared against incoming alerts. All alerts are always sent on join, then subsequent messages are sent as a list of IDs to remove, and a map of alert data to update the client with.

### Testing

Added tests for the new behavior, also updated https://github.com/mbta/mobile_app/pull/1767 with the frontend changes and verified that updates were sent and received successfully