### PR TITLE
feat: calculate summaries as their own PubSub

### DIFF
--- a/lib/mobile_app_backend/alerts/pub_sub.ex
+++ b/lib/mobile_app_backend/alerts/pub_sub.ex
@@ -1,17 +1,10 @@
 defmodule MobileAppBackend.Alerts.PubSub.Behaviour do
   alias MBTAV3API.Alert
-  alias MobileAppBackend.Alerts.AlertWithSummaries
 
   @doc """
   Subscribe to updates for all alerts
   """
-  @callback subscribe(
-              legacy_compatibility: boolean(),
-              include_summaries: boolean(),
-              locale: String.t()
-            ) :: %{
-              alerts: %{String.t() => Alert.t() | AlertWithSummaries.t()}
-            }
+  @callback subscribe(legacy_compatibility: boolean()) :: %{alerts: %{Alert.id() => Alert.t()}}
 end
 
 defmodule MobileAppBackend.Alerts.PubSub do
@@ -30,13 +23,10 @@ defmodule MobileAppBackend.Alerts.PubSub do
   alias MBTAV3API.Alert
   alias MBTAV3API.Store
   alias MBTAV3API.Stream
-  alias MobileAppBackend.Alerts.AlertWithSummaries
   alias MobileAppBackend.Alerts.PubSub
-  alias MobileAppBackend.Alerts.SummaryEntityBuilder
 
   @behaviour PubSub.Behaviour
 
-  @default_locale MobileAppBackend.Application.default_locale()
   @fetch_registry_key :fetch_registry_key
 
   @type state :: %{last_dispatched_table_name: atom()}
@@ -57,33 +47,23 @@ defmodule MobileAppBackend.Alerts.PubSub do
   The legacy alert channel needs to filter out any references to new alert causes,
   they will break old versions of the app entirely if they're sent to the frontend.
   """
-  @spec map_data([Alert.t()], boolean(), boolean(), String.t()) :: %{
-          String.t() => Alert.t() | AlertWithSummaries.t()
-        }
+  @spec map_data([Alert.t()], boolean()) :: %{Alert.id() => Alert.t()}
   # https://github.com/elixir-lang/elixir/issues/14837#issuecomment-3419664245
   # can be removed after elixir 1.20.1
-  @dialyzer {:no_opaque, map_data: 4}
-  def map_data(data, legacy_compatibility, include_summaries, locale) do
-    summaries_by_alert =
-      if include_summaries, do: SummaryEntityBuilder.build_all(data, locale, :card), else: nil
-
+  @dialyzer {:no_opaque, map_data: 2}
+  def map_data(data, legacy_compatibility) do
     legacy_map = fn %Alert{} = alert ->
       if MapSet.member?(Alert.v2_causes(), alert.cause),
         do: %Alert{alert | cause: :unknown_cause},
         else: alert
     end
 
-    summary_map = fn alert ->
-      AlertWithSummaries.from_alert(alert, Map.get(summaries_by_alert, alert.id, []))
+    if legacy_compatibility do
+      data |> Enum.map(legacy_map)
+    else
+      data
     end
-
-    cond do
-      legacy_compatibility -> data |> Enum.map(legacy_map)
-      include_summaries -> data |> Enum.map(summary_map)
-      true -> data
-    end
-    |> Enum.map(fn alert -> {alert.id, alert} end)
-    |> Map.new()
+    |> Map.new(fn alert -> {alert.id, alert} end)
   end
 
   @impl true
@@ -94,11 +74,7 @@ defmodule MobileAppBackend.Alerts.PubSub do
       %{
         alerts:
           data
-          |> map_data(
-            Keyword.get(opts, :legacy_compatibility, true),
-            Keyword.get(opts, :include_summaries, false),
-            Keyword.get(opts, :locale, @default_locale)
-          )
+          |> map_data(Keyword.get(opts, :legacy_compatibility, true))
           |> filter_upcoming_single_tracking_alerts()
       }
     end

--- a/lib/mobile_app_backend/alerts/pub_sub.ex
+++ b/lib/mobile_app_backend/alerts/pub_sub.ex
@@ -102,7 +102,7 @@ defmodule MobileAppBackend.Alerts.PubSub do
   @impl GenServer
   def init(opts \\ []) do
     Stream.StaticInstance.subscribe("alerts:to_store")
-    broadcast_timer(50)
+    broadcast_initial_timer()
 
     create_table_fn =
       Keyword.get(opts, :create_table_fn, fn ->

--- a/lib/mobile_app_backend/alerts/summary_entity_builder.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity_builder.ex
@@ -256,7 +256,7 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
 
           _ ->
             # If a trip ID is provided, we can pull a stop ID from the trip's stop list
-            trips[trip_id].stop_ids |> List.first()
+            Map.get(trips, trip_id, %{stop_ids: []}).stop_ids |> List.first()
         end,
         stops
       )

--- a/lib/mobile_app_backend/alerts/with_summary_pub_sub.ex
+++ b/lib/mobile_app_backend/alerts/with_summary_pub_sub.ex
@@ -96,7 +96,7 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSub do
     upstream = Application.get_env(:mobile_app_backend, Alerts.PubSub, Alerts.PubSub)
 
     upstream.subscribe(legacy_compatibility: false)
-    broadcast_timer(50)
+    broadcast_initial_timer()
 
     create_table_fn =
       Keyword.get(opts, :create_table_fn, fn ->

--- a/lib/mobile_app_backend/alerts/with_summary_pub_sub.ex
+++ b/lib/mobile_app_backend/alerts/with_summary_pub_sub.ex
@@ -58,7 +58,7 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSub do
       %{
         alerts_with_summaries:
           data
-          |> Map.get({locale, :card}, %{})
+          |> Map.get(locale, %{})
           |> filter_upcoming_single_tracking_alerts()
       }
     end
@@ -143,7 +143,7 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSub do
   end
 
   @typep alerts_with_summaries :: %{Alert.id() => AlertWithSummaries.t()}
-  @typep summary_key :: {locale :: String.t(), :notification | :card}
+  @typep summary_key :: locale :: String.t()
   @typep all_summaries :: %{summary_key() => alerts_with_summaries()}
 
   defp recalculate(ets_table, all_alerts \\ nil) do
@@ -158,17 +158,16 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSub do
     alerts_by_id = Map.new(alerts, &{&1.id, &1})
 
     for locale <- Application.get_env(:mobile_app_backend, :locale_codes),
-        context <- [:notification, :card],
         into: %{} do
       alerts_with_summaries =
-        SummaryEntityBuilder.build_all(alerts, locale, context)
+        SummaryEntityBuilder.build_all(alerts, locale, :card)
         |> Map.new(fn {alert_id, summary_entities} ->
           alert = alerts_by_id[alert_id]
           value = AlertWithSummaries.from_alert(alert, summary_entities)
           {alert_id, value}
         end)
 
-      {{locale, context}, alerts_with_summaries}
+      {locale, alerts_with_summaries}
     end
   end
 end

--- a/lib/mobile_app_backend/alerts/with_summary_pub_sub.ex
+++ b/lib/mobile_app_backend/alerts/with_summary_pub_sub.ex
@@ -1,0 +1,174 @@
+defmodule MobileAppBackend.Alerts.WithSummaryPubSub.Behaviour do
+  alias MBTAV3API.Alert
+  alias MobileAppBackend.Alerts.AlertWithSummaries
+
+  @doc """
+  Subscribe to updates for all alerts
+  """
+  @callback subscribe(locale: String.t()) ::
+              %{alerts_with_summaries: %{Alert.id() => AlertWithSummaries.t()}}
+end
+
+defmodule MobileAppBackend.Alerts.WithSummaryPubSub do
+  @moduledoc """
+  Allows channels to subscribe to alerts data and receive updates as the data changes.
+
+  This broadcasts the latest state of the world (if it has changed) to
+  registered consumers in two circumstances:
+  1. Regularly scheduled interval - configured by `:alerts_broadcast_interval_ms`
+  2. When there is a reset event of the underlying alert stream.
+  """
+  use MobileAppBackend.PubSub,
+    broadcast_interval_ms:
+      Application.compile_env(:mobile_app_backend, :alerts_broadcast_interval_ms, 500)
+
+  alias MBTAV3API.Alert
+  alias MBTAV3API.Store
+  alias MobileAppBackend.Alerts
+  alias MobileAppBackend.Alerts.AlertWithSummaries
+  alias MobileAppBackend.Alerts.SummaryEntityBuilder
+
+  @behaviour __MODULE__.Behaviour
+
+  @default_locale MobileAppBackend.Application.default_locale()
+  @default_ets_table :last_dispatched_alerts_with_summary
+  @fetch_registry_key :fetch_registry_key_with_summary
+
+  @type state :: %{last_dispatched_table_name: atom()}
+
+  @spec start_link(Keyword.t()) :: GenServer.on_start()
+  @spec start_link() :: :ignore | {:error, any()} | {:ok, pid()}
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+
+    GenServer.start_link(
+      __MODULE__,
+      opts,
+      name: name
+    )
+  end
+
+  @impl true
+  def subscribe(opts \\ []) do
+    locale = Keyword.get(opts, :locale, @default_locale)
+
+    fetch_keys = []
+
+    format_fn = fn data ->
+      %{
+        alerts_with_summaries:
+          data
+          |> Map.get({locale, :card}, %{})
+          |> filter_upcoming_single_tracking_alerts()
+      }
+    end
+
+    Registry.register(
+      MobileAppBackend.Alerts.Registry,
+      @fetch_registry_key,
+      {fetch_keys, format_fn}
+    )
+
+    # we don’t want to bottleneck subscribe/1 calls in the server process,
+    # so we can’t read this from the state. conveniently it’s only overridden in tests
+    ets_table = Keyword.get(opts, :ets_table, @default_ets_table)
+
+    all_summaries =
+      case :ets.lookup(ets_table, :all_summaries) do
+        [{:all_summaries, all_summaries}] -> all_summaries
+        [] -> %{}
+      end
+
+    format_fn.(all_summaries)
+  end
+
+  # Temporary patch because upcoming single tracking alerts are displayed
+  # incorrectly in the app. Remove any single tracking alerts that aren't happening
+  # right now.
+  defp filter_upcoming_single_tracking_alerts(alerts) do
+    Map.filter(alerts, fn {_key, alert} ->
+      !(alert.cause == :single_tracking && !Alert.active?(alert))
+    end)
+  end
+
+  @impl GenServer
+  def init(opts \\ []) do
+    upstream = Application.get_env(:mobile_app_backend, Alerts.PubSub, Alerts.PubSub)
+
+    upstream.subscribe(legacy_compatibility: false)
+    broadcast_timer(50)
+
+    create_table_fn =
+      Keyword.get(opts, :create_table_fn, fn ->
+        :ets.new(@default_ets_table, [:set, :named_table])
+        {:ok, %{last_dispatched_table_name: @default_ets_table}}
+      end)
+
+    create_table_fn.()
+  end
+
+  @impl GenServer
+  def handle_info(:broadcast, %{last_dispatched_table_name: last_dispatched} = state) do
+    all_summaries = recalculate(last_dispatched)
+
+    perform_broadcast(last_dispatched, all_summaries)
+
+    {:noreply, state, :hibernate}
+  end
+
+  def handle_info(
+        {:new_alerts, %{alerts: all_alerts}},
+        %{last_dispatched_table_name: last_dispatched} = state
+      ) do
+    all_summaries = recalculate(last_dispatched, Map.values(all_alerts))
+    perform_broadcast(last_dispatched, all_summaries)
+    {:noreply, state}
+  end
+
+  defp perform_broadcast(last_dispatched, all_summaries) do
+    Registry.dispatch(MobileAppBackend.Alerts.Registry, @fetch_registry_key, fn entries ->
+      entries
+      |> MobileAppBackend.PubSub.group_pids_by_target_data()
+      |> Enum.each(fn {{_fetch_keys, format_fn} = registry_value, pids} ->
+        all_summaries
+        |> format_fn.()
+        |> MobileAppBackend.PubSub.broadcast_latest_data(
+          :new_alerts,
+          registry_value,
+          pids,
+          last_dispatched
+        )
+      end)
+    end)
+  end
+
+  @typep alerts_with_summaries :: %{Alert.id() => AlertWithSummaries.t()}
+  @typep summary_key :: {locale :: String.t(), :notification | :card}
+  @typep all_summaries :: %{summary_key() => alerts_with_summaries()}
+
+  defp recalculate(ets_table, all_alerts \\ nil) do
+    all_alerts = all_alerts || Store.Alerts.fetch([])
+    all_summaries = build_all_summaries(all_alerts)
+    :ets.insert(ets_table, {:all_summaries, all_summaries})
+    all_summaries
+  end
+
+  @spec build_all_summaries([Alert.t()]) :: all_summaries()
+  defp build_all_summaries(alerts) do
+    alerts_by_id = Map.new(alerts, &{&1.id, &1})
+
+    for locale <- Application.get_env(:mobile_app_backend, :locale_codes),
+        context <- [:notification, :card],
+        into: %{} do
+      alerts_with_summaries =
+        SummaryEntityBuilder.build_all(alerts, locale, context)
+        |> Map.new(fn {alert_id, summary_entities} ->
+          alert = alerts_by_id[alert_id]
+          value = AlertWithSummaries.from_alert(alert, summary_entities)
+          {alert_id, value}
+        end)
+
+      {{locale, context}, alerts_with_summaries}
+    end
+  end
+end

--- a/lib/mobile_app_backend/application.ex
+++ b/lib/mobile_app_backend/application.ex
@@ -45,6 +45,7 @@ defmodule MobileAppBackend.Application do
         if Application.get_env(:mobile_app_backend, :start_pub_subs?, true) do
           [
             MobileAppBackend.Alerts.PubSub,
+            MobileAppBackend.Alerts.WithSummaryPubSub,
             MobileAppBackend.Vehicles.PubSub,
             MobileAppBackend.Predictions.PubSub
           ]

--- a/lib/mobile_app_backend/predictions/pub_sub.ex
+++ b/lib/mobile_app_backend/predictions/pub_sub.ex
@@ -247,7 +247,7 @@ defmodule MobileAppBackend.Predictions.PubSub do
     Stream.PubSub.subscribe("predictions:all:events")
     Stream.PubSub.subscribe("vehicles:to_store")
 
-    broadcast_timer(50)
+    broadcast_initial_timer()
 
     create_table_fn =
       Keyword.get(opts, :create_table_fn, fn ->

--- a/lib/mobile_app_backend/pub_sub.ex
+++ b/lib/mobile_app_backend/pub_sub.ex
@@ -111,6 +111,8 @@ defmodule MobileAppBackend.PubSub do
         {:noreply, state, :hibernate}
       end
 
+      defp broadcast_initial_timer, do: broadcast_timer(50)
+
       defp broadcast_timer(interval) do
         Process.send_after(self(), :timed_broadcast, interval)
       end

--- a/lib/mobile_app_backend/vehicles/pub_sub.ex
+++ b/lib/mobile_app_backend/vehicles/pub_sub.ex
@@ -86,7 +86,7 @@ defmodule MobileAppBackend.Vehicles.PubSub do
   def init(opts \\ []) do
     Stream.StaticInstance.subscribe("vehicles:to_store")
 
-    broadcast_timer(50)
+    broadcast_initial_timer()
 
     create_table_fn =
       Keyword.get(opts, :create_table_fn, fn ->

--- a/lib/mobile_app_backend_web/channels/alerts_channel.ex
+++ b/lib/mobile_app_backend_web/channels/alerts_channel.ex
@@ -47,8 +47,8 @@ defmodule MobileAppBackendWeb.AlertsChannel do
     pubsub_module =
       Application.get_env(
         :mobile_app_backend,
-        MobileAppBackend.Alerts.PubSub,
-        MobileAppBackend.Alerts.PubSub
+        MobileAppBackend.Alerts.WithSummaryPubSub,
+        MobileAppBackend.Alerts.WithSummaryPubSub
       )
 
     %{alerts: alerts} = pubsub_module.subscribe(get_opts(socket))
@@ -60,19 +60,16 @@ defmodule MobileAppBackendWeb.AlertsChannel do
   defp get_opts(socket) do
     case socket.topic do
       "alerts" ->
-        [legacy_compatibility: true, include_summaries: false]
+        [legacy_compatibility: true]
 
       "alerts:v2" ->
-        [legacy_compatibility: false, include_summaries: false]
+        [legacy_compatibility: false]
 
       "alerts:v3" ->
-        Keyword.merge(
-          [legacy_compatibility: false, include_summaries: true],
-          case Map.get(socket.assigns, :locale) do
-            nil -> []
-            locale -> [locale: locale]
-          end
-        )
+        case Map.get(socket.assigns, :locale) do
+          nil -> []
+          locale -> [locale: locale]
+        end
     end
   end
 

--- a/test/mobile_app_backend/alerts/with_summary_pub_sub_test.exs
+++ b/test/mobile_app_backend/alerts/with_summary_pub_sub_test.exs
@@ -53,14 +53,14 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSubTest do
       alert_1 = build(:alert, id: "a_1")
 
       ets_table = :ets.new(nil, [:set])
-      :ets.insert(ets_table, {:all_summaries, %{{"en", :card} => %{alert_1.id => alert_1}}})
+      :ets.insert(ets_table, {:all_summaries, %{"en" => %{alert_1.id => alert_1}}})
 
       assert to_alert_map([alert_1]) == WithSummaryPubSub.subscribe(ets_table: ets_table)
     end
 
     test "returns empty list when no alerts" do
       ets_table = :ets.new(nil, [:set])
-      :ets.insert(ets_table, {:all_summaries, %{{"en", :card} => %{}}})
+      :ets.insert(ets_table, {:all_summaries, %{"en" => %{}}})
 
       assert to_alert_map([]) == WithSummaryPubSub.subscribe(ets_table: ets_table)
     end

--- a/test/mobile_app_backend/alerts/with_summary_pub_sub_test.exs
+++ b/test/mobile_app_backend/alerts/with_summary_pub_sub_test.exs
@@ -1,0 +1,181 @@
+defmodule MobileAppBackend.Alerts.WithSummaryPubSubTest do
+  use ExUnit.Case
+
+  alias MBTAV3API.Alert
+  alias MBTAV3API.Store
+  alias MobileAppBackend.Alerts
+  alias MobileAppBackend.Alerts.AlertWithSummaries
+  alias MobileAppBackend.Alerts.WithSummaryPubSub
+  import Mox
+  import Test.Support.Helpers
+  import Test.Support.Sigils
+  import MobileAppBackend.Factory
+
+  setup do
+    reassign_env(:mobile_app_backend, :alerts_broadcast_interval_ms, 10_000)
+    reassign_env(:mobile_app_backend, Alerts.PubSub, AlertsPubSubMock)
+
+    reassign_env(
+      :mobile_app_backend,
+      MobileAppBackend.GlobalDataCache.Module,
+      GlobalDataCacheMock
+    )
+
+    reassign_env(:mobile_app_backend, Store.Alerts, AlertsStoreMock)
+    reassign_env(:mobile_app_backend, MBTAV3API.Repository, RepositoryMock)
+
+    verify_on_exit!()
+    :ok
+  end
+
+  # make sure mocks are globally accessible, including from the PubSub genserver
+  setup :set_mox_from_context
+
+  defp to_alert_map(alerts_with_summaries) do
+    %{
+      alerts_with_summaries:
+        alerts_with_summaries
+        |> Map.new(&{&1.id, &1})
+    }
+  end
+
+  describe "init/1" do
+    test "subscribes to alert events" do
+      AlertsPubSubMock
+      |> expect(:subscribe, fn _ -> %{alerts: %{}} end)
+
+      WithSummaryPubSub.init(create_table_fn: fn -> :no_op end)
+    end
+  end
+
+  describe "subscribe/1" do
+    test "returns initial data" do
+      alert_1 = build(:alert, id: "a_1")
+
+      ets_table = :ets.new(nil, [:set])
+      :ets.insert(ets_table, {:all_summaries, %{{"en", :card} => %{alert_1.id => alert_1}}})
+
+      assert to_alert_map([alert_1]) == WithSummaryPubSub.subscribe(ets_table: ets_table)
+    end
+
+    test "returns empty list when no alerts" do
+      ets_table = :ets.new(nil, [:set])
+      :ets.insert(ets_table, {:all_summaries, %{{"en", :card} => %{}}})
+
+      assert to_alert_map([]) == WithSummaryPubSub.subscribe(ets_table: ets_table)
+    end
+  end
+
+  describe "handle_info" do
+    setup do
+      _dispatched_table = :ets.new(:test_last_dispatched, [:set, :named_table])
+      {:ok, %{last_dispatched_table_name: :test_last_dispatched}}
+    end
+
+    test "broadcasts on :reset_event", state do
+      WithSummaryPubSub.handle_info(:reset_event, state)
+
+      assert_receive :broadcast
+    end
+
+    test ":broadcast sends message to subscribed pid", state do
+      alert_1 =
+        build(:alert,
+          id: "a_1",
+          cause: :single_tracking,
+          active_period: [
+            %Alert.ActivePeriod{
+              start: ~B[2024-02-12 09:44:04],
+              end: nil
+            }
+          ]
+        )
+
+      alert_2 = build(:alert, id: "a_2", cause: :rail_defect)
+
+      AlertsStoreMock
+      # 1st and 2nd broadcast
+      |> expect(:fetch, 2, fn _ -> [alert_1] end)
+      # 3rd broadcast
+      |> expect(:fetch, fn _ -> [alert_2] end)
+
+      GlobalDataCacheMock
+      |> stub(:default_key, fn -> :default_key end)
+      |> stub(:get_data, fn _ ->
+        %{route_patterns: %{}}
+      end)
+
+      RepositoryMock |> stub(:stops, fn _, _ -> {:ok, %{data: []}} end)
+
+      WithSummaryPubSub.subscribe(ets_table: state.last_dispatched_table_name)
+
+      WithSummaryPubSub.handle_info(:broadcast, state)
+
+      assert_receive {:new_alerts, new_alerts}
+
+      assert to_alert_map([AlertWithSummaries.from_alert(alert_1, [])]) == new_alerts
+
+      # Doesn't re-send the same alerts that have already been seen
+      WithSummaryPubSub.handle_info(:broadcast, state)
+
+      refute_receive _
+
+      # Sends new alerts
+      WithSummaryPubSub.handle_info(:broadcast, state)
+
+      assert_receive {:new_alerts, new_alerts}
+
+      assert to_alert_map([AlertWithSummaries.from_alert(alert_2, [])]) == new_alerts
+    end
+
+    test ":broadcast filters out upcoming single tracking alerts", state do
+      single_tracking_future =
+        build(:alert,
+          id: "a_1",
+          cause: :single_tracking,
+          active_period: [
+            %Alert.ActivePeriod{
+              start: DateTime.add(DateTime.now!("America/New_York"), 10, :minute),
+              end: nil
+            }
+          ]
+        )
+
+      single_tracking_now =
+        build(:alert,
+          id: "a_2",
+          cause: :single_tracking,
+          active_period: [
+            %Alert.ActivePeriod{
+              start: DateTime.add(DateTime.now!("America/New_York"), -10, :minute),
+              end: nil
+            }
+          ]
+        )
+
+      AlertsStoreMock
+      # Subscribe & first broadcast
+      |> expect(:fetch, fn _ -> [single_tracking_future, single_tracking_now] end)
+      |> expect(:fetch, fn _ -> [single_tracking_future] end)
+
+      GlobalDataCacheMock
+      |> stub(:default_key, fn -> :default_key end)
+      |> stub(:get_data, fn _ ->
+        %{route_patterns: %{}}
+      end)
+
+      RepositoryMock |> stub(:stops, fn _, _ -> {:ok, %{data: []}} end)
+
+      WithSummaryPubSub.handle_info(:broadcast, state)
+
+      assert to_alert_map([AlertWithSummaries.from_alert(single_tracking_now, [])]) ==
+               WithSummaryPubSub.subscribe(ets_table: state.last_dispatched_table_name)
+
+      WithSummaryPubSub.handle_info(:broadcast, state)
+
+      assert_receive {:new_alerts, new_alerts}
+
+      assert to_alert_map([]) == new_alerts
+    end
+  end
+end

--- a/test/mobile_app_backend_web/channels/alerts_channel_test.exs
+++ b/test/mobile_app_backend_web/channels/alerts_channel_test.exs
@@ -12,6 +12,12 @@ defmodule MobileAppBackendWeb.AlertsChannelTest do
   setup do
     reassign_env(:mobile_app_backend, MobileAppBackend.Alerts.PubSub, AlertsPubSubMock)
 
+    reassign_env(
+      :mobile_app_backend,
+      MobileAppBackend.Alerts.WithSummaryPubSub,
+      AlertsWithSummaryPubSubMock
+    )
+
     {:ok, socket} = connect(MobileAppBackendWeb.UserSocket, %{})
 
     %{socket: socket}
@@ -179,7 +185,7 @@ defmodule MobileAppBackendWeb.AlertsChannelTest do
 
     data1 = to_alert_map([alert1, alert2, alert3])
 
-    expect(AlertsPubSubMock, :subscribe, 1, fn _ -> %{alerts: data1} end)
+    expect(AlertsWithSummaryPubSubMock, :subscribe, 1, fn _ -> %{alerts: data1} end)
 
     {:ok,
      %AlertsChannel.AlertUpdate{
@@ -243,7 +249,7 @@ defmodule MobileAppBackendWeb.AlertsChannelTest do
 
     data1 = to_alert_map([alert1, alert2])
 
-    expect(AlertsPubSubMock, :subscribe, 1, fn _ -> %{alerts: data1} end)
+    expect(AlertsWithSummaryPubSubMock, :subscribe, 1, fn _ -> %{alerts: data1} end)
 
     {:ok,
      %AlertsChannel.AlertUpdate{

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,6 @@
 Mox.defmock(AlertsCheckerMock, for: MobileAppBackend.Health.Checker)
 Mox.defmock(AlertsPubSubMock, for: MobileAppBackend.Alerts.PubSub.Behaviour)
+Mox.defmock(AlertsWithSummaryPubSubMock, for: MobileAppBackend.Alerts.WithSummaryPubSub.Behaviour)
 Mox.defmock(AlertsStoreMock, for: MBTAV3API.Store)
 Mox.defmock(GlobalDataCacheCheckerMock, for: MobileAppBackend.Health.Checker)
 Mox.defmock(GlobalDataCacheMock, for: MobileAppBackend.GlobalDataCache)


### PR DESCRIPTION
### Summary

_Ticket:_ [Alert Summary Consolidation | Cache Generated Summaries](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215452720852110)

This architecture seems like the most straightforward way to make sure the channels always get up to date summaries.

### Testing

Copied over unit tests from the existing `Alerts.PubSub` and updated as needed.