### PR TITLE
fix: Make upcoming stop closures use AffectedStops

### DIFF
--- a/lib/mobile_app_backend/alerts/alert_summary.ex
+++ b/lib/mobile_app_backend/alerts/alert_summary.ex
@@ -190,9 +190,9 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
     end
   end
 
-  defp alert_location_closure(alert, affected_stops) do
-    alert.effect in [:station_closure, :stop_closure] and
-      affected_stops != [] and Alert.active?(alert)
+  defp alert_location_is_closure?(alert, affected_stops) do
+    alert.effect in [:dock_closure, :station_closure, :stop_closure] and
+      affected_stops != [] and (Alert.active?(alert) or Alert.active_soon?(alert))
   end
 
   @spec alert_location(Alert.t(), Stop.id(), 0 | 1, [RoutePattern.t()], GlobalDataCache.data()) ::
@@ -224,7 +224,7 @@ defmodule MobileAppBackend.Alerts.AlertSummary do
       downstream = Enum.all?(affected_stops, &(&1.id != stop_id))
 
       cond do
-        alert_location_closure(alert, affected_stops) ->
+        alert_location_is_closure?(alert, affected_stops) ->
           %Location.AffectedStops{
             stops: Enum.map(affected_stops, fn stop -> stop.name end)
           }

--- a/lib/mobile_app_backend/alerts/alert_summary/trip_specific.ex
+++ b/lib/mobile_app_backend/alerts/alert_summary/trip_specific.ex
@@ -94,7 +94,7 @@ defmodule MobileAppBackend.Alerts.AlertSummary.TripSpecific do
           context
         )
 
-      effect when effect in [:station_closure, :stop_closure, :dock_closure] ->
+      effect when effect in [:dock_closure, :station_closure, :stop_closure] ->
         trip_stop_bypass_summary(
           alert,
           stop_id,

--- a/lib/mobile_app_backend/alerts/formatted_alert.ex
+++ b/lib/mobile_app_backend/alerts/formatted_alert.ex
@@ -37,7 +37,7 @@ defmodule MobileAppBackend.Alerts.FormattedAlert do
             summary_mode = summary_affected_mode(alert_summary.effect)
 
             cond do
-              alert_summary.effect in [:station_closure, :stop_closure] ->
+              alert_summary.effect in [:dock_closure, :station_closure, :stop_closure] ->
                 gettext(
                   "%{mode} %{skipped_effect}",
                   mode: summary_mode,
@@ -401,7 +401,7 @@ defmodule MobileAppBackend.Alerts.FormattedAlert do
       effect == :cancellation ->
         gettext("is cancelled %{day}", day: day)
 
-      effect in [:station_closure, :stop_closure, :dock_closure] && effect_stops != nil ->
+      effect in [:dock_closure, :station_closure, :stop_closure] && effect_stops != nil ->
         summary_skipped_effect(summary_affected_stops(effect_stops), day)
 
       effect == :suspension ->
@@ -455,6 +455,7 @@ defmodule MobileAppBackend.Alerts.FormattedAlert do
 
   defp summary_affected_mode(effect) do
     case effect do
+      :dock_closure -> gettext("Ferries")
       :station_closure -> gettext("Trains")
       :stop_closure -> gettext("Buses")
       _ -> ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1193,22 +1193,27 @@ msgstr ""
 msgid "%{mode} %{skipped_effect}"
 msgstr ""
 
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:460
+#, elixir-autogen, elixir-format
+msgid "Buses"
+msgstr ""
+
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:459
+#, elixir-autogen, elixir-format
+msgid "Trains"
+msgstr ""
+
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:458
+#, elixir-autogen, elixir-format
+msgid "Ferries"
+msgstr ""
+
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:446
 #, elixir-autogen, elixir-format
 msgid "**multiple stops**"
 msgstr ""
 
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:459
-#, elixir-autogen, elixir-format
-msgid "Buses"
-msgstr ""
-
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:458
-#, elixir-autogen, elixir-format
-msgid "Trains"
-msgstr ""
-
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:465
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:466
 #, elixir-autogen, elixir-format
 msgid "will not stop at %{stop_list} %{timeframe}"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1193,22 +1193,27 @@ msgstr ""
 msgid "%{mode} %{skipped_effect}"
 msgstr "%{mode} %{skipped_effect}"
 
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:460
+#, elixir-autogen, elixir-format
+msgid "Buses"
+msgstr "Buses"
+
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:459
+#, elixir-autogen, elixir-format
+msgid "Trains"
+msgstr "Trains"
+
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:458
+#, elixir-autogen, elixir-format
+msgid "Ferries"
+msgstr "Ferries"
+
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:446
 #, elixir-autogen, elixir-format
 msgid "**multiple stops**"
 msgstr "**multiple stops**"
 
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:459
-#, elixir-autogen, elixir-format
-msgid "Buses"
-msgstr "Buses"
-
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:458
-#, elixir-autogen, elixir-format
-msgid "Trains"
-msgstr "Trains"
-
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:465
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:466
 #, elixir-autogen, elixir-format
 msgid "will not stop at %{stop_list} %{timeframe}"
 msgstr "will not stop at %{stop_list} %{timeframe}"

--- a/priv/gettext/es/LC_MESSAGES/default.po
+++ b/priv/gettext/es/LC_MESSAGES/default.po
@@ -1193,22 +1193,27 @@ msgstr ""
 msgid "%{mode} %{skipped_effect}"
 msgstr "%{mode} %{skipped_effect}"
 
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:460
+#, elixir-autogen, elixir-format
+msgid "Buses"
+msgstr "Autobuses"
+
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:459
+#, elixir-autogen, elixir-format
+msgid "Trains"
+msgstr "Trenes"
+
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:458
+#, elixir-autogen, elixir-format
+msgid "Ferries"
+msgstr "Transbordadores"
+
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:446
 #, elixir-autogen, elixir-format
 msgid "**multiple stops**"
 msgstr "**varias paradas**"
 
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:459
-#, elixir-autogen, elixir-format
-msgid "Buses"
-msgstr "Autobuses"
-
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:458
-#, elixir-autogen, elixir-format
-msgid "Trains"
-msgstr "Trenes"
-
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:465
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:466
 #, elixir-autogen, elixir-format
 msgid "will not stop at %{stop_list} %{timeframe}"
 msgstr "no se detendrá en %{stop_list} %{timeframe}"

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -1193,22 +1193,27 @@ msgstr ""
 msgid "%{mode} %{skipped_effect}"
 msgstr "%{skipped_effect} %{mode}"
 
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:460
+#, elixir-autogen, elixir-format
+msgid "Buses"
+msgstr "Les autobus"
+
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:459
+#, elixir-autogen, elixir-format
+msgid "Trains"
+msgstr "Trains"
+
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:458
+#, elixir-autogen, elixir-format
+msgid "Ferries"
+msgstr "Ferries"
+
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:446
 #, elixir-autogen, elixir-format
 msgid "**multiple stops**"
 msgstr "**plusieurs arrêts**"
 
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:459
-#, elixir-autogen, elixir-format
-msgid "Buses"
-msgstr "Les autobus"
-
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:458
-#, elixir-autogen, elixir-format
-msgid "Trains"
-msgstr "Trains"
-
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:465
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:466
 #, elixir-autogen, elixir-format
 msgid "will not stop at %{stop_list} %{timeframe}"
 msgstr "ne s’arrêtera pas à %{stop_list} %{timeframe}"

--- a/priv/gettext/ht/LC_MESSAGES/default.po
+++ b/priv/gettext/ht/LC_MESSAGES/default.po
@@ -1193,22 +1193,27 @@ msgstr ""
 msgid "%{mode} %{skipped_effect}"
 msgstr "%{mode} %{skipped_effect}"
 
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:460
+#, elixir-autogen, elixir-format
+msgid "Buses"
+msgstr "Bis"
+
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:459
+#, elixir-autogen, elixir-format
+msgid "Trains"
+msgstr "Tren yo"
+
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:458
+#, elixir-autogen, elixir-format
+msgid "Ferries"
+msgstr "Ferry"
+
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:446
 #, elixir-autogen, elixir-format
 msgid "**multiple stops**"
 msgstr "**plizyè arè**"
 
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:459
-#, elixir-autogen, elixir-format
-msgid "Buses"
-msgstr "Bis"
-
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:458
-#, elixir-autogen, elixir-format
-msgid "Trains"
-msgstr "Tren yo"
-
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:465
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:466
 #, elixir-autogen, elixir-format
 msgid "will not stop at %{stop_list} %{timeframe}"
 msgstr "p ap rete nan %{stop_list} %{timeframe}"

--- a/priv/gettext/pt-BR/LC_MESSAGES/default.po
+++ b/priv/gettext/pt-BR/LC_MESSAGES/default.po
@@ -1193,22 +1193,27 @@ msgstr ""
 msgid "%{mode} %{skipped_effect}"
 msgstr "%{mode} %{skipped_effect}"
 
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:460
+#, elixir-autogen, elixir-format
+msgid "Buses"
+msgstr "Ônibus"
+
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:459
+#, elixir-autogen, elixir-format
+msgid "Trains"
+msgstr "Trens"
+
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:458
+#, elixir-autogen, elixir-format
+msgid "Ferries"
+msgstr "Balsas"
+
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:446
 #, elixir-autogen, elixir-format
 msgid "**multiple stops**"
 msgstr "**várias paradas**"
 
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:459
-#, elixir-autogen, elixir-format
-msgid "Buses"
-msgstr "Ônibus"
-
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:458
-#, elixir-autogen, elixir-format
-msgid "Trains"
-msgstr "Trens"
-
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:465
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:466
 #, elixir-autogen, elixir-format
 msgid "will not stop at %{stop_list} %{timeframe}"
 msgstr "não vai parar em %{stop_list} %{timeframe}"

--- a/priv/gettext/vi/LC_MESSAGES/default.po
+++ b/priv/gettext/vi/LC_MESSAGES/default.po
@@ -1193,22 +1193,27 @@ msgstr ""
 msgid "%{mode} %{skipped_effect}"
 msgstr "%{mode} %{skipped_effect}"
 
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:460
+#, elixir-autogen, elixir-format
+msgid "Buses"
+msgstr "Xe buýt"
+
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:459
+#, elixir-autogen, elixir-format
+msgid "Trains"
+msgstr "Tàu hỏa"
+
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:458
+#, elixir-autogen, elixir-format
+msgid "Ferries"
+msgstr "Phà"
+
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:446
 #, elixir-autogen, elixir-format
 msgid "**multiple stops**"
 msgstr "**nhiều điểm dừng**"
 
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:459
-#, elixir-autogen, elixir-format
-msgid "Buses"
-msgstr "Xe buýt"
-
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:458
-#, elixir-autogen, elixir-format
-msgid "Trains"
-msgstr "Tàu hỏa"
-
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:465
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:466
 #, elixir-autogen, elixir-format
 msgid "will not stop at %{stop_list} %{timeframe}"
 msgstr "sẽ không dừng lại ở %{stop_list} %{timeframe}"

--- a/priv/gettext/zh-Hans-CN/LC_MESSAGES/default.po
+++ b/priv/gettext/zh-Hans-CN/LC_MESSAGES/default.po
@@ -1193,22 +1193,27 @@ msgstr ""
 msgid "%{mode} %{skipped_effect}"
 msgstr "%{mode} %{skipped_effect}"
 
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:460
+#, elixir-autogen, elixir-format
+msgid "Buses"
+msgstr "公交车"
+
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:459
+#, elixir-autogen, elixir-format
+msgid "Trains"
+msgstr "火车"
+
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:458
+#, elixir-autogen, elixir-format
+msgid "Ferries"
+msgstr "渡轮"
+
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:446
 #, elixir-autogen, elixir-format
 msgid "**multiple stops**"
 msgstr "**多站停靠**"
 
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:459
-#, elixir-autogen, elixir-format
-msgid "Buses"
-msgstr "公交车"
-
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:458
-#, elixir-autogen, elixir-format
-msgid "Trains"
-msgstr "火车"
-
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:465
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:466
 #, elixir-autogen, elixir-format
 msgid "will not stop at %{stop_list} %{timeframe}"
 msgstr "不会止步于 %{stop_list} %{timeframe}"

--- a/priv/gettext/zh-Hant-TW/LC_MESSAGES/default.po
+++ b/priv/gettext/zh-Hant-TW/LC_MESSAGES/default.po
@@ -1193,22 +1193,27 @@ msgstr ""
 msgid "%{mode} %{skipped_effect}"
 msgstr "%{mode} %{skipped_effect}"
 
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:460
+#, elixir-autogen, elixir-format
+msgid "Buses"
+msgstr "公車"
+
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:459
+#, elixir-autogen, elixir-format
+msgid "Trains"
+msgstr "火車"
+
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:458
+#, elixir-autogen, elixir-format
+msgid "Ferries"
+msgstr "渡輪"
+
 #: lib/mobile_app_backend/alerts/formatted_alert.ex:446
 #, elixir-autogen, elixir-format
 msgid "**multiple stops**"
 msgstr "**多站停靠**"
 
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:459
-#, elixir-autogen, elixir-format
-msgid "Buses"
-msgstr "公車"
-
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:458
-#, elixir-autogen, elixir-format
-msgid "Trains"
-msgstr "火車"
-
-#: lib/mobile_app_backend/alerts/formatted_alert.ex:465
+#: lib/mobile_app_backend/alerts/formatted_alert.ex:466
 #, elixir-autogen, elixir-format
 msgid "will not stop at %{stop_list} %{timeframe}"
 msgstr "不會止步於 %{stop_list} %{timeframe}"

--- a/test/mobile_app_backend/alerts/alert_summary_test.exs
+++ b/test/mobile_app_backend/alerts/alert_summary_test.exs
@@ -2481,6 +2481,50 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                )
     end
 
+    test "stop closure returns affected stops when upcoming", %{now: now} do
+      stop = build(:stop, name: "Parent Name")
+      child_stop = build(:stop, parent_station_id: stop.id)
+      stop = put_in(stop.child_stop_ids, [child_stop.id])
+
+      route = build(:route)
+      pattern = build(:route_pattern, route_id: route.id, direction_id: 0)
+
+      later_today = DateTime.add(now, 1)
+
+      alert =
+        build(:alert,
+          active_period: [%Alert.ActivePeriod{start: later_today, end: nil}],
+          effect: :stop_closure,
+          informed_entity: [
+            %Alert.InformedEntity{
+              activities: ~w(board exit ride)a,
+              route: route.id,
+              stop: child_stop.id
+            }
+          ]
+        )
+
+      assert %AlertSummary.Standard{
+               location: %AlertSummary.Location.AffectedStops{
+                 stops: ["Parent Name"]
+               },
+               timeframe: %AlertSummary.Timeframe.StartingLaterToday{time: ^later_today}
+             } =
+               AlertSummary.summarizing(
+                 alert,
+                 "",
+                 0,
+                 [pattern],
+                 now,
+                 nil,
+                 %{
+                   routes: %{route.id => route},
+                   stops: %{stop.id => stop, child_stop.id => child_stop}
+                 },
+                 :notification
+               )
+    end
+
     test "trip specific - same trip and stops" do
       now = DateTime.now!("America/New_York")
 

--- a/test/mobile_app_backend/alerts/formatted_alert_test.exs
+++ b/test/mobile_app_backend/alerts/formatted_alert_test.exs
@@ -699,4 +699,22 @@ defmodule MobileAppBackend.Alerts.FormattedAlertTest do
                )
     end
   end
+
+  test "one stops skipped upcoming" do
+    alert = build(:alert, effect: :dock_closure)
+
+    alert_summary = %AlertSummary.Standard{
+      effect: :dock_closure,
+      location: %Location.AffectedStops{
+        stops: ["Long Wharf"]
+      },
+      timeframe: %Timeframe.StartingTomorrow{}
+    }
+
+    assert "Ferries will not stop at Long Wharf starting tomorrow" ==
+             FormattedAlert.summary(
+               %FormattedAlert{alert: alert, alert_summary: alert_summary},
+               "en"
+             )
+  end
 end


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix template for downstream stop closure](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215459184849991?focus=true)

I spent too much time rearranging the template strings to not include the "at" and only include the "at" in the location fragment, but then I realized that it was only happening for upcoming alerts because instead of correctly using `AffectedStops` it was falling back to the standard `SingleStop`, `SuccessiveStops`, etc logic. The check for closure alerts was only returning true for alerts that were active now, so I made it also return true for upcoming alerts. We can't remove the timeframe entirely because all clear summaries still need to use the standard location.

While I was in here, I also added support for ferry closure summaries.

### Testing

Added tests for broken logic, also checked running locally that the frontend was receiving the correct summaries