### PR TITLE
fix: correctly match on alerts with summaries

### DIFF
--- a/lib/mobile_app_backend_web/channels/alerts_channel.ex
+++ b/lib/mobile_app_backend_web/channels/alerts_channel.ex
@@ -51,7 +51,7 @@ defmodule MobileAppBackendWeb.AlertsChannel do
         MobileAppBackend.Alerts.WithSummaryPubSub
       )
 
-    %{alerts: alerts} = pubsub_module.subscribe(get_opts(socket))
+    %{alerts_with_summaries: alerts} = pubsub_module.subscribe(get_opts(socket))
     socket = assign(socket, :last_alerts, alert_hashes(alerts))
 
     {:ok, %AlertUpdate{remove: [], update: alerts}, socket}
@@ -85,7 +85,7 @@ defmodule MobileAppBackendWeb.AlertsChannel do
     end
   end
 
-  defp handle_info_v3({:new_alerts, %{alerts: alerts}}, socket) do
+  defp handle_info_v3({:new_alerts, %{alerts_with_summaries: alerts}}, socket) do
     current_hashes = alert_hashes(alerts)
     old_hashes = socket.assigns.last_alerts
 

--- a/test/mobile_app_backend_web/channels/alerts_channel_test.exs
+++ b/test/mobile_app_backend_web/channels/alerts_channel_test.exs
@@ -185,7 +185,7 @@ defmodule MobileAppBackendWeb.AlertsChannelTest do
 
     data1 = to_alert_map([alert1, alert2, alert3])
 
-    expect(AlertsWithSummaryPubSubMock, :subscribe, 1, fn _ -> %{alerts: data1} end)
+    expect(AlertsWithSummaryPubSubMock, :subscribe, 1, fn _ -> %{alerts_with_summaries: data1} end)
 
     {:ok,
      %AlertsChannel.AlertUpdate{
@@ -197,7 +197,7 @@ defmodule MobileAppBackendWeb.AlertsChannelTest do
     data2 = to_alert_map([%{alert1 | description: "different description"}])
 
     AlertsChannel.handle_info(
-      {:new_alerts, %{alerts: Map.merge(data2, %{alert3.id => alert3})}},
+      {:new_alerts, %{alerts_with_summaries: Map.merge(data2, %{alert3.id => alert3})}},
       socket
     )
 
@@ -249,7 +249,7 @@ defmodule MobileAppBackendWeb.AlertsChannelTest do
 
     data1 = to_alert_map([alert1, alert2])
 
-    expect(AlertsWithSummaryPubSubMock, :subscribe, 1, fn _ -> %{alerts: data1} end)
+    expect(AlertsWithSummaryPubSubMock, :subscribe, 1, fn _ -> %{alerts_with_summaries: data1} end)
 
     {:ok,
      %AlertsChannel.AlertUpdate{
@@ -259,7 +259,7 @@ defmodule MobileAppBackendWeb.AlertsChannelTest do
       subscribe_and_join(socket, "alerts:v3")
 
     AlertsChannel.handle_info(
-      {:new_alerts, %{alerts: data1}},
+      {:new_alerts, %{alerts_with_summaries: data1}},
       socket
     )
 


### PR DESCRIPTION
### Summary

_Ticket:_ none
[Sentry issue](https://mbtace.sentry.io/issues/7598748809/)

Apparently I did not test #571 as well as I should have.

### Testing

Updated tests to match actual behavior.