### PR TITLE
perf: Improve API query retry behavior

### DIFF
--- a/lib/mbta_v3_api.ex
+++ b/lib/mbta_v3_api.ex
@@ -196,7 +196,7 @@ defmodule MBTAV3API do
     [
       base_url: Application.get_env(:mobile_app_backend, :base_url),
       api_key: Application.get_env(:mobile_app_backend, :api_key),
-      timeout: 10_000
+      timeout: 7_000
     ]
   end
 

--- a/lib/mbta_v3_api.ex
+++ b/lib/mbta_v3_api.ex
@@ -137,6 +137,8 @@ defmodule MBTAV3API do
           params: params,
           compressed: true,
           decode_body: false,
+          retry_delay: fn _ -> 300 end,
+          max_retries: 2,
           pool_timeout: timeout,
           receive_timeout: timeout
         )

--- a/lib/mbta_v3_api/store.ex
+++ b/lib/mbta_v3_api/store.ex
@@ -53,7 +53,7 @@ defmodule MBTAV3API.Store do
 
     time_ms = time_micros / 1000
 
-    Logger.info(
+    Logger.debug(
       "#{__MODULE__} fetch table_name=#{table_name} #{log_metadata} duration=#{time_ms}"
     )
 

--- a/lib/mbta_v3_api/store/predictions.ex
+++ b/lib/mbta_v3_api/store/predictions.ex
@@ -194,7 +194,7 @@ defmodule MBTAV3API.Store.Predictions.Impl do
   end
 
   defp process_one_remove(%{type: "prediction", id: id}) do
-    Logger.info("#{__MODULE__} process_remove type=prediction id=#{id}")
+    Logger.debug("#{__MODULE__} process_remove type=prediction id=#{id}")
     :ets.delete(@predictions_table_name, id)
   end
 
@@ -202,10 +202,10 @@ defmodule MBTAV3API.Store.Predictions.Impl do
     existing_predictions_for_trip = fetch(trip_id: id)
 
     if Enum.empty?(existing_predictions_for_trip) do
-      Logger.info("#{__MODULE__} process_remove type=trip id=#{id}")
+      Logger.debug("#{__MODULE__} process_remove type=trip id=#{id}")
       :ets.delete(@trips_table_name, id)
     else
-      Logger.info(
+      Logger.debug(
         "#{__MODULE__} process_remove skipping removal type=trip id=#{id} remaining_prediction_count=#{length(existing_predictions_for_trip)}"
       )
     end

--- a/lib/mobile_app_backend/predictions/pub_sub.ex
+++ b/lib/mobile_app_backend/predictions/pub_sub.ex
@@ -97,7 +97,7 @@ defmodule MobileAppBackend.Predictions.PubSub do
         stop_ids ++ child_stop_ids
       ])
 
-    Logger.info(
+    Logger.debug(
       "#{__MODULE__} subscribe_for_stops stop_id=#{inspect(stop_ids)} duration=#{time_micros / 1000} "
     )
 
@@ -129,7 +129,7 @@ defmodule MobileAppBackend.Predictions.PubSub do
   def subscribe_for_trip(trip_id) do
     case :timer.tc(MobileAppBackend.Predictions.StreamSubscriber, :subscribe_for_trip, [trip_id]) do
       {time_micros, :ok} ->
-        Logger.info(
+        Logger.debug(
           "#{__MODULE__} subscribe_for_trip trip_id=#{trip_id} duration=#{time_micros / 1000} "
         )
 

--- a/lib/mobile_app_backend/pub_sub.ex
+++ b/lib/mobile_app_backend/pub_sub.ex
@@ -64,7 +64,7 @@ defmodule MobileAppBackend.PubSub do
          {fetch_keys, _format_fn} = registry_value,
          last_dispatched_table_name
        ) do
-    Logger.info("#{__MODULE__} broadcasting to pids len=#{length(pids)}")
+    Logger.debug("#{__MODULE__} broadcasting to pids len=#{length(pids)}")
 
     {time_micros, _result} =
       :timer.tc(__MODULE__, :broadcast_to_pids, [
@@ -73,7 +73,7 @@ defmodule MobileAppBackend.PubSub do
         broadcast_message_name
       ])
 
-    Logger.info(
+    Logger.debug(
       "#{__MODULE__} broadcast_to_pids fetch_keys=#{inspect(fetch_keys)} duration=#{time_micros / 1000}"
     )
 

--- a/test/mbta_v3_api/store/alerts_test.exs
+++ b/test/mbta_v3_api/store/alerts_test.exs
@@ -75,10 +75,10 @@ defmodule MBTAV3API.Store.AlertsTest do
     end
 
     test "logs duration", %{alert_1: alert_1} do
-      set_log_level(:info)
+      set_log_level(:debug)
 
       Store.Alerts.process_upsert(:add, [alert_1])
-      msg = capture_log([level: :info], fn -> Store.Alerts.fetch(id: "a_1") end)
+      msg = capture_log([level: :debug], fn -> Store.Alerts.fetch(id: "a_1") end)
 
       assert msg =~
                "fetch table_name=alerts_from_stream fetch_keys=[id: \"a_1\"] duration="

--- a/test/mbta_v3_api/store/predictions_test.exs
+++ b/test/mbta_v3_api/store/predictions_test.exs
@@ -71,12 +71,12 @@ defmodule MBTAV3API.Store.PredictionsTest do
       trip_1: trip_1,
       trip_2: trip_2
     } do
-      set_log_level(:info)
+      set_log_level(:debug)
 
       Store.Predictions.process_upsert(:add, [prediction_1, prediction_2, trip_1, trip_2])
 
       msg =
-        capture_log([level: :info], fn ->
+        capture_log([level: :debug], fn ->
           Store.Predictions.process_remove([
             %Reference{type: "prediction", id: prediction_1.id},
             %Reference{type: "trip", id: trip_1.id}
@@ -97,7 +97,7 @@ defmodule MBTAV3API.Store.PredictionsTest do
       trip_1: trip_1,
       trip_2: trip_2
     } do
-      set_log_level(:info)
+      set_log_level(:debug)
 
       trip_1_prediction_other_route = %{
         prediction_1
@@ -114,7 +114,7 @@ defmodule MBTAV3API.Store.PredictionsTest do
       ])
 
       msg =
-        capture_log([level: :info], fn ->
+        capture_log([level: :debug], fn ->
           Store.Predictions.process_remove([
             %Reference{type: "prediction", id: prediction_1.id},
             %Reference{type: "trip", id: trip_1.id}
@@ -208,11 +208,11 @@ defmodule MBTAV3API.Store.PredictionsTest do
     end
 
     test "logs duration" do
-      set_log_level(:info)
+      set_log_level(:debug)
       prediction_1 = build(:prediction, id: "1", stop_id: "12345")
 
       Store.Predictions.process_upsert(:add, [prediction_1])
-      msg = capture_log([level: :info], fn -> Store.Predictions.fetch(stop_id: "12345") end)
+      msg = capture_log([level: :debug], fn -> Store.Predictions.fetch(stop_id: "12345") end)
 
       assert msg =~
                "fetch table_name=predictions_from_streams fetch_keys=[stop_id: \"12345\"] duration="

--- a/test/mbta_v3_api/store/vehicles_test.exs
+++ b/test/mbta_v3_api/store/vehicles_test.exs
@@ -96,10 +96,10 @@ defmodule MBTAV3API.Store.VehiclesTest do
     end
 
     test "logs duration", %{vehicle_1: vehicle_1} do
-      set_log_level(:info)
+      set_log_level(:debug)
 
       Store.Vehicles.process_upsert(:add, [vehicle_1])
-      msg = capture_log([level: :info], fn -> Store.Vehicles.fetch(id: "v_1") end)
+      msg = capture_log([level: :debug], fn -> Store.Vehicles.fetch(id: "v_1") end)
 
       assert msg =~
                "fetch table_name=vehicles_from_stream fetch_keys=[id: \"v_1\"] duration="

--- a/test/mbta_v3_api/store_test.exs
+++ b/test/mbta_v3_api/store_test.exs
@@ -27,11 +27,11 @@ defmodule MBTAV3API.StoreTest do
 
   describe "timed_fetch/3" do
     test "returns matches & logs duration" do
-      set_log_level(:info)
+      set_log_level(:debug)
       :ets.insert(:test_table, [{"key", "value"}, {"other", "other_value"}])
 
       {results, log} =
-        with_log([level: :info], fn ->
+        with_log([level: :debug], fn ->
           Store.timed_fetch(:test_table, [{{"key", :"$1"}, [], [:"$1"]}], "other_field=true")
         end)
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Investigate 7/7 increased latency & timeouts](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1216357676564476?focus=true)

<!-- What is this PR for? -->

We received a 74 logs with the message `retry: got exception, will retry in 1000ms, 3 attempts left`. It seems that the API was potentially having some issues around this timeframe, but we can at least shorten the retry loop to fail faster. 

There were also a number of `Handler :default switched from :sync to :drop mode`, indicating that logs were being dropped. This also turns off some noisy logs that we don't often need to reduce the log volume

### Testing

<!-- What testing have you done? -->
* Ran app locally, confirmed fetching data still works