### PR TITLE
perf: increase alerts_with_summaries broadcast interval

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -26,6 +26,7 @@ config :ex_cldr,
   default_backend: MobileAppBackend.Cldr
 
 config :mobile_app_backend, alerts_broadcast_interval_ms: 500
+config :mobile_app_backend, alerts_with_summaries_broadcast_interval_ms: 60_000
 config :mobile_app_backend, predictions_broadcast_interval_ms: 5_000
 config :mobile_app_backend, vehicles_broadcast_interval_ms: 500
 

--- a/lib/mobile_app_backend/alerts/with_summary_pub_sub.ex
+++ b/lib/mobile_app_backend/alerts/with_summary_pub_sub.ex
@@ -15,12 +15,17 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSub do
 
   This broadcasts the latest state of the world (if it has changed) to
   registered consumers in two circumstances:
-  1. Regularly scheduled interval - configured by `:alerts_broadcast_interval_ms`
+  1. Regularly scheduled interval - configured by
+  `:alerts_with_summaries_broadcast_interval_ms`
   2. When there is a reset event of the underlying alert stream.
   """
   use MobileAppBackend.PubSub,
     broadcast_interval_ms:
-      Application.compile_env(:mobile_app_backend, :alerts_broadcast_interval_ms, 500)
+      Application.compile_env(
+        :mobile_app_backend,
+        :alerts_with_summaries_broadcast_interval_ms,
+        60_000
+      )
 
   alias MBTAV3API.Alert
   alias MBTAV3API.Store

--- a/test/mobile_app_backend/alerts/with_summary_pub_sub_test.exs
+++ b/test/mobile_app_backend/alerts/with_summary_pub_sub_test.exs
@@ -12,7 +12,7 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSubTest do
   import MobileAppBackend.Factory
 
   setup do
-    reassign_env(:mobile_app_backend, :alerts_broadcast_interval_ms, 10_000)
+    reassign_env(:mobile_app_backend, :alerts_with_summaries_broadcast_interval_ms, 10_000)
     reassign_env(:mobile_app_backend, Alerts.PubSub, AlertsPubSubMock)
 
     reassign_env(


### PR DESCRIPTION
### Summary

_Ticket:_ No Ticket

<!-- What is this PR for? -->
Noticed CPU spike after last deploy. This pub sub currently has no subscribers, so no user impact of making this change. 
This may eventually be a reasonable value for users, but we can verify that later.

### Testing

<!-- What testing have you done? -->