### PR TITLE
ci: attempt to fix Renovate schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":prConcurrentLimit10",
-    "schedule:daily"
+    ":prConcurrentLimit10"
   ],
   "minimumReleaseAge": "7 days",
   "minimumReleaseAgeBehaviour": "timestamp-optional"


### PR DESCRIPTION
### Summary

_Ticket:_ [Try renovate instead of dependabot for backend](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215606746972638)

We haven’t had a Renovate update PR since #536 was merged, and my current hypothesis is that some schedule constraint set by `config:recommended` is being applied alongside `schedule:daily` in a way that doesn’t overlap and so never creates PRs at all.

### Testing

Not realistically testable.