### PR TITLE
Add logging when trip subscription fails

### DIFF
--- a/lib/mbta_v3_api.ex
+++ b/lib/mbta_v3_api.ex
@@ -185,7 +185,11 @@ defmodule MBTAV3API do
   end
 
   defp log_body({:ok, response}) do
-    "status=#{response.status} content_length=#{byte_size(response.body)}"
+    if byte_size(response.body) > 100 do
+      ~s(status=#{response.status} content_length=#{byte_size(response.body)})
+    else
+      ~s(status=#{response.status} content_length=#{byte_size(response.body)} body=#{String.slice(response.body, 0, 100)})
+    end
   end
 
   defp log_body({:error, error}) do

--- a/lib/mobile_app_backend/predictions/stream_subscriber.ex
+++ b/lib/mobile_app_backend/predictions/stream_subscriber.ex
@@ -66,7 +66,8 @@ defmodule MobileAppBackend.Predictions.StreamSubscriber.Impl do
   @impl true
   def subscribe_for_trip(trip_id) do
     with {:ok, %{data: [trip]}} <- MBTAV3API.Repository.trips(filter: [id: trip_id]),
-         route_id <- trip.route_id,
+         {:ok, route_id} <-
+           if(trip.route_id, do: {:ok, trip.route_id}, else: {:error, :missing_route_id}),
          {:ok, _data} <-
            StaticInstance.ensure_stream_started("predictions:route:to_store:#{route_id}",
              include_current_data: false
@@ -75,8 +76,29 @@ defmodule MobileAppBackend.Predictions.StreamSubscriber.Impl do
            StaticInstance.ensure_stream_started("vehicles:to_store", include_current_data: false) do
       :ok
     else
+      {:ok, %{data: []}} ->
+        Logger.warning(
+          "#{__MODULE__} failed to fetch trip from repository for trip=#{trip_id} not found."
+        )
+
+        :error
+
+      {:error, :missing_route_id} ->
+        Logger.warning(
+          "#{__MODULE__} failed to fetch trip from repository for trip=#{trip_id} is missing route_id."
+        )
+
+        :error
+
+      {:error, reason} ->
+        Logger.warning(
+          "#{__MODULE__} failed to fetch trip from repository for trip=#{trip_id}. Reason: #{inspect(reason)}"
+        )
+
+        :error
+
       _ ->
-        Logger.warning("#{__MODULE__} failed to fetch trip from repository for #{trip_id}")
+        Logger.warning("#{__MODULE__} failed to fetch trip from repository for trip=#{trip_id}")
         :error
     end
   end

--- a/lib/mobile_app_backend/predictions/stream_subscriber.ex
+++ b/lib/mobile_app_backend/predictions/stream_subscriber.ex
@@ -77,29 +77,29 @@ defmodule MobileAppBackend.Predictions.StreamSubscriber.Impl do
       :ok
     else
       {:ok, %{data: []}} ->
-        Logger.warning(
-          "#{__MODULE__} failed to fetch trip from repository for trip=#{trip_id} not found."
-        )
+        log_failed_trip_fetch(trip_id, :trip_not_found)
 
         :error
 
       {:error, :missing_route_id} ->
-        Logger.warning(
-          "#{__MODULE__} failed to fetch trip from repository for trip=#{trip_id} is missing route_id."
-        )
+        log_failed_trip_fetch(trip_id, :missing_route_id)
 
         :error
 
       {:error, reason} ->
-        Logger.warning(
-          "#{__MODULE__} failed to fetch trip from repository for trip=#{trip_id}. Reason: #{inspect(reason)}"
-        )
+        log_failed_trip_fetch(trip_id, reason)
 
         :error
 
       _ ->
-        Logger.warning("#{__MODULE__} failed to fetch trip from repository for trip=#{trip_id}")
+        log_failed_trip_fetch(trip_id, :unknown_error)
         :error
     end
+  end
+
+  defp log_failed_trip_fetch(trip_id, reason) do
+    Logger.warning(
+      "#{__MODULE__} failed to fetch trip from repository for trip=#{trip_id}. Reason: #{inspect(reason)}"
+    )
   end
 end

--- a/lib/mobile_app_backend_web/channels/predictions_for_trip_channel.ex
+++ b/lib/mobile_app_backend_web/channels/predictions_for_trip_channel.ex
@@ -21,11 +21,14 @@ defmodule MobileAppBackendWeb.PredictionsForTripChannel do
 
     case :timer.tc(fn -> pubsub_module.subscribe_for_trip(trip_id) end) do
       {time_micros, :error} ->
-        Logger.warning("#{__MODULE__} failed join duration=#{time_micros / 1000}")
+        Logger.warning(
+          "#{__MODULE__} failed join trip_id=#{trip_id} duration=#{time_micros / 1000}"
+        )
+
         {:error, %{code: :subscribe_failed}}
 
       {time_micros, initial_data} ->
-        Logger.info("#{__MODULE__} join duration=#{time_micros / 1000}")
+        Logger.info("#{__MODULE__} join trip_id=#{trip_id} duration=#{time_micros / 1000}")
 
         {:ok, initial_data, socket}
     end


### PR DESCRIPTION
### Summary

_Ticket:_ [Investigate Adam's report of GL-C weirdness](https://app.asana.com/1/15492006741476/project/1215456342910576/task/1215638932339487?focus=true)

<!-- What is this PR for? -->
Add more details logging to be able to spot why REFUSED join is happening

### Testing

<!-- What testing have you done? -->
Deployed to dev orange and check that the logs existed


[Splunk logs](https://mbta.splunkcloud.com/en-US/app/search/show_source?sid=1784128001.49472&offset=0&latest_time=)
```
94fdb785c6f1 13:17:22.921 [warning] Elixir.MobileAppBackend.Predictions.StreamSubscriber.Impl failed to fetch trip from repository for trip=ADDED-1748030133 not found.
```