### PR TITLE
perf?: further adjust parallel schedule fetching

### DIFF
--- a/lib/mobile_app_backend/application.ex
+++ b/lib/mobile_app_backend/application.ex
@@ -26,7 +26,7 @@ defmodule MobileAppBackend.Application do
         {Finch,
          name: Finch.CustomPool,
          pools: %{
-           :default => [size: 100, count: 5, start_pool_metrics?: true]
+           :default => [size: 50, count: 4, start_pool_metrics?: true]
          }},
         {MBTAV3API.ResponseCache, []},
         {MBTAV3API.RepositoryCache, []},

--- a/lib/mobile_app_backend_web/controllers/schedule_controller.ex
+++ b/lib/mobile_app_backend_web/controllers/schedule_controller.ex
@@ -177,7 +177,7 @@ defmodule MobileAppBackendWeb.ScheduleController do
           {filter_params, fetch_schedules(filter_params, date_time)}
         end,
         ordered: false,
-        max_concurrency: 25,
+        max_concurrency: 10,
         timeout: timeout
       )
       |> Enum.reduce_while(%{schedules: [], trips: %{}}, fn result, acc ->


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket

<!-- What is this PR for? -->
In response to performance issues yesterday. 
In https://github.com/mbta/mobile_app_backend/pull/446 I increased the max_concurrency to 25 thinking that it was limited by the HTTP pool size. The default value for max_concurrency is [System.schedulers_online](https://elixir.hexdocs.pm/1.12/Task.html#async_stream/5-options). Since fetching schedules does do other work besides the HTTP request (reading from potentially 2 layers of caches, parsing responses, post-processing & filtering data), something closer to `schedulers_online` is probably more appropriate. 

Potentially this should just be reverted entirely back down to `schedulers_online`. The avg # of stops we fetch parallel schedules for has decreased from 17 down to 10. 

This also tunes the connection pool down. Over the last 30 days, the max of `in_use_connections` was 23, and that was during downtime. Typically it is more like ~5.[ From the docs](https://finch.hexdocs.pm/Finch.html#start_link/1-pool-configuration-options): "Prefer the lowest :count that still meets latency and throughput; raise count when you see checkout queue timeouts or heavy load on one shard"
### Testing

<!-- What testing have you done? -->

Will observe in staging before deploying to prod. Since max_concurrency wasn't set until April 2026, I feel comfortable re-lowering that value.