### PR TITLE
fix: Fix elixir/erlang renovate issues

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,8 @@ defmodule MobileAppBackend.MixProject do
     [
       app: :mobile_app_backend,
       version: "0.1.0",
-      elixir: "~> 1.14",
+      # renovate: datasource=github-releases depName=elixir-lang/elixir
+      elixir: "1.20.2",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),

--- a/renovate.json
+++ b/renovate.json
@@ -44,5 +44,8 @@
       "matchDepNames": ["elixir", "erlang"],
       "prBodyNotes": "If the \"Check elixir/erlang OTP version sync\" step is failing in CI, the erlang major version has changed, and the OTP suffix for elixir in `.tool-version` must be updated to match it.\nIf the Docker build step is failing, it's possible that an image does not exist for the combination of elixir, erlang, and alpine versions in the Dockerfile. Check https://hub.docker.com/r/hexpm/elixir/tags for available images, and update versions as necessary."
     }
-  ]
+  ],
+  "constraints": {
+    "erlang": ">=29.0.0"
+  }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,14 @@
     },
     {
       "customType": "regex",
+      "description": "Update the Elixir version in mix.exs so compilation fails if it doesn't match the version in asdf/Docker.",
+      "managerFilePatterns": ["/(^|\\/)mix\\.exs$/"],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>.*?)\\s+depName=(?<depName>.*?)\\s*\\n\\s*elixir:\\s*\"(?<currentValue>.*)\",?"
+      ]
+    },
+    {
+      "customType": "regex",
       "description": "Bump the Elixir version in .tool-versions, leaving the existing -otp-N suffix untouched",
       "managerFilePatterns": ["/(^|\\/)\\.tool-versions$/"],
       "matchStrings": [

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
     {
       "customType": "regex",
       "description": "Renovate can't automatically detect the composed version tag in Dockerfiles, so we use a regex to extract it from comments and ARG lines.",
-      "fileMatch": ["(^|\\/)Dockerfile$"],
+      "managerFilePatterns": ["/(^|\\/)Dockerfile$/"],
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>.*?)\\s+depName=(?<depName>.*?)\\s*\\n(?:ENV|ARG)\\s+.*?_VERSION=(?<currentValue>.*)\\s"
       ]
@@ -15,7 +15,7 @@
     {
       "customType": "regex",
       "description": "Bump the Elixir version in .tool-versions, leaving the existing -otp-N suffix untouched",
-      "managerFilePatterns": ["(^|\\/)\\.tool-versions$"],
+      "managerFilePatterns": ["/(^|\\/)\\.tool-versions$/"],
       "matchStrings": [
         "elixir (?<currentValue>\\d+\\.\\d+\\.\\d+)-otp-(?<otpSuffix>\\d+)\\n"
       ],


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket, follow up to #595 

This updates a few different renovate issues:
* If no erlang version is specified, the renovate mix manager will default to erlang 26, which is not compatible with elixir 1.20
* For regex managers, `fileMatch` is deprecated, but I was also using `managerFilePatterns` wrong.
* Added a new manager to update the elixir version in the mix project, as far as I can tell, the only thing this will do is prevent `mix compile` from succeeding if you have the wrong elixir version installed

### Testing

Won't know for sure if this works until this is merged and runs on mend