### PR TITLE
perf?: Increase response cache size

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -33,12 +33,14 @@ config :mobile_app_backend, vehicles_broadcast_interval_ms: 500
 config :mobile_app_backend, MBTAV3API.ResponseCache,
   gc_interval: :timer.hours(12),
   allocated_memory: 2_000_000_000,
-  stats: true
+  stats: true,
+  telemetry_prefix: [:mbtav3api, :response_cache]
 
 config :mobile_app_backend, MBTAV3API.RepositoryCache,
   gc_interval: :timer.hours(2),
   allocated_memory: 2_000_000_000,
-  stats: true
+  stats: true,
+  telemetry_prefix: [:mbtav3api, :repository_cache]
 
 config :mobile_app_backend, MobileAppBackend.Search.Algolia.Cache,
   gc_interval: :timer.hours(6),

--- a/config/config.exs
+++ b/config/config.exs
@@ -31,7 +31,8 @@ config :mobile_app_backend, predictions_broadcast_interval_ms: 5_000
 config :mobile_app_backend, vehicles_broadcast_interval_ms: 500
 
 config :mobile_app_backend, MBTAV3API.ResponseCache,
-  allocated_memory: 250_000_000,
+  gc_interval: :timer.hours(12),
+  allocated_memory: 2_000_000_000,
   stats: true
 
 config :mobile_app_backend, MBTAV3API.RepositoryCache,

--- a/lib/mobile_app_backend/application.ex
+++ b/lib/mobile_app_backend/application.ex
@@ -75,6 +75,7 @@ defmodule MobileAppBackend.Application do
           MobileAppBackendWeb.Endpoint
         ]
 
+    :ok = MobileAppBackend.Telemetry.CacheHandler.attach()
     :ok = MobileAppBackend.Telemetry.FinchHandler.attach()
     :ok = MobileAppBackend.Telemetry.HttpResponseHandler.attach()
     :ok = MobileAppBackend.Telemetry.WebsocketEventHandler.attach()

--- a/lib/mobile_app_backend/telemetry/cache_handler.ex
+++ b/lib/mobile_app_backend/telemetry/cache_handler.ex
@@ -1,0 +1,53 @@
+defmodule MobileAppBackend.Telemetry.CacheHandler do
+  require Logger
+
+  def attach do
+    :telemetry.attach_many(
+      "nebulex-cache-handler",
+      [
+        [:mbtav3api, :repository_cache, :command, :stop],
+        [:mbtav3api, :response_cache, :command, :stop]
+      ],
+      &__MODULE__.handle_event/4,
+      []
+    )
+  end
+
+  def handle_event(
+        [:mbtav3api, cache, :command, :stop],
+        measurements,
+        %{command: :fetch} = metadata,
+        _config
+      ) do
+    result =
+      case metadata.result do
+        {:error, error} ->
+          "miss details=#{inspect(error)}"
+
+        {:ok, _} ->
+          "hit"
+
+        other ->
+          "unknown details=#{inspect(other)}"
+      end
+
+    duration =
+      case measurements do
+        %{duration: duration} -> System.convert_time_unit(duration, :native, :millisecond)
+        _ -> ""
+      end
+
+    Logger.info(
+      "#{__MODULE__} cache=#{cache} duration=#{duration} result=#{result} key=#{inspect(List.first(metadata.args))}"
+    )
+  end
+
+  def handle_event(
+        [:mbtav3api, _cache, :command, :stop],
+        _measurements,
+        %{command: _command},
+        _config
+      ) do
+    # Ignore other events
+  end
+end

--- a/test/mobile_app_backend/telemetry/cache_handler_test.exs
+++ b/test/mobile_app_backend/telemetry/cache_handler_test.exs
@@ -1,0 +1,44 @@
+defmodule MobileAppBackend.Telemetry.CacheHandlerTest do
+  use ExUnit.Case
+  import ExUnit.CaptureLog
+
+  import Test.Support.Helpers
+
+  alias MobileAppBackend.Telemetry.CacheHandler
+
+  describe "handle_event/4" do
+    test "logs hit" do
+      set_log_level(:info)
+
+      {_results, log} =
+        with_log([level: :info], fn ->
+          CacheHandler.handle_event(
+            [:mbtav3api, :response_cache, :command, :stop],
+            %{duration: 0},
+            %{command: :fetch, args: ["key", "value", "opts"], result: {:ok, "why"}},
+            %{}
+          )
+        end)
+
+      assert log =~
+               "duration=0 result=hit key=\"key\""
+    end
+
+    test "logs miss" do
+      set_log_level(:info)
+
+      {_results, log} =
+        with_log([level: :info], fn ->
+          CacheHandler.handle_event(
+            [:mbtav3api, :response_cache, :command, :stop],
+            %{duration: 0},
+            %{command: :fetch, args: ["key", "value", "opts"], result: {:error, "why"}},
+            %{}
+          )
+        end)
+
+      assert log =~
+               "duration=0 result=miss details=\"why\" key=\"key\""
+    end
+  end
+end


### PR DESCRIPTION
### Summary

_Ticket:_ [Improve caching](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1216655729859154?focus=true)

<!-- What is this PR for? -->
We observed a high miss & eviction rate in the ResponseCache, which caches responses directly from the V3API and re-uses them to fetch with the `if-modified-since` header. Increasing the cache size should help our hit rate, which we hypothesize will help with some ongoing latency issues. 
<img width="561" height="321" alt="image" src="https://github.com/user-attachments/assets/1fc489cb-df5f-4346-9cfe-553ed510dd6c" />

This additionally adds the gc_interval for the cache. [Per the docs](https://nebulex-local.hexdocs.pm/Nebulex.Adapters.Local.html#module-configuration-options), "Always provide the :gc_interval option so the garbage collector can work appropriately out of the box."

### Testing

* Will continue to monitor the hit rate dashboard.
* Added unit tests for new telemetry events & ran locally to confirm it logged as expected

<!-- What testing have you done? -->