### PR TITLE
Revert "chore(deps): update dependency elixir to v1.20.2 (#595)"

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,8 +5,7 @@ defmodule MobileAppBackend.MixProject do
     [
       app: :mobile_app_backend,
       version: "0.1.0",
-      # renovate: datasource=github-releases depName=elixir-lang/elixir
-      elixir: "1.20.2",
+      elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),

--- a/renovate.json
+++ b/renovate.json
@@ -7,23 +7,15 @@
     {
       "customType": "regex",
       "description": "Renovate can't automatically detect the composed version tag in Dockerfiles, so we use a regex to extract it from comments and ARG lines.",
-      "managerFilePatterns": ["/(^|\\/)Dockerfile$/"],
+      "fileMatch": ["(^|\\/)Dockerfile$"],
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>.*?)\\s+depName=(?<depName>.*?)\\s*\\n(?:ENV|ARG)\\s+.*?_VERSION=(?<currentValue>.*)\\s"
       ]
     },
     {
       "customType": "regex",
-      "description": "Update the Elixir version in mix.exs so compilation fails if it doesn't match the version in asdf/Docker.",
-      "managerFilePatterns": ["/(^|\\/)mix\\.exs$/"],
-      "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>.*?)\\s+depName=(?<depName>.*?)\\s*\\n\\s*elixir:\\s*\"(?<currentValue>.*)\",?"
-      ]
-    },
-    {
-      "customType": "regex",
       "description": "Bump the Elixir version in .tool-versions, leaving the existing -otp-N suffix untouched",
-      "managerFilePatterns": ["/(^|\\/)\\.tool-versions$/"],
+      "managerFilePatterns": ["(^|\\/)\\.tool-versions$"],
       "matchStrings": [
         "elixir (?<currentValue>\\d+\\.\\d+\\.\\d+)-otp-(?<otpSuffix>\\d+)\\n"
       ],
@@ -52,8 +44,5 @@
       "matchDepNames": ["elixir", "erlang"],
       "prBodyNotes": "If the \"Check elixir/erlang OTP version sync\" step is failing in CI, the erlang major version has changed, and the OTP suffix for elixir in `.tool-version` must be updated to match it.\nIf the Docker build step is failing, it's possible that an image does not exist for the combination of elixir, erlang, and alpine versions in the Dockerfile. Check https://hub.docker.com/r/hexpm/elixir/tags for available images, and update versions as necessary."
     }
-  ],
-  "constraints": {
-    "erlang": ">=29.0.0"
-  }
+  ]
 }


### PR DESCRIPTION
This reverts commit bfd7bc6c55a5e4878ec24f601a34f6f3935c1856.

### Summary

_Ticket:_ No ticket 

<!-- What is this PR for? -->

Temporarily reverts https://github.com/mbta/mobile_app_backend/pull/595. On deploying 2026-07-20-1, there were issues with the GlobalDataCache not returning 304s at the rate we would expect and . Since this upgrade touched the GlobalDataCache (though in a seemingly no-op way). 

We also saw tasks fail with the error `ea42114edec0 sys/unix/sys_signal_stack.c:103:sys_sigaltstack(): Internal error: Failed to set alternate signal stack`. 

It looks like there is a fix coming in a future version for this issue: 
https://github.com/erlang/otp/issues/11248

### Testing

<!-- What testing have you done? -->