### PR TITLE
chore: only rebase Renovate PRs when actually conflicted

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,6 @@
     ":prConcurrentLimit10"
   ],
   "minimumReleaseAge": "7 days",
-  "minimumReleaseAgeBehaviour": "timestamp-optional"
+  "minimumReleaseAgeBehaviour": "timestamp-optional",
+  "rebaseWhen": "conflicted"
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Try renovate instead of dependabot for backend](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215606746972638)

Per [the docs](https://docs.renovatebot.com/configuration-options/#rebasewhen), this should cut down substantially on email spam without actually making these PRs any harder to merge.

### Testing

Not realistically testable.