### PR TITLE
fix?(ScheduleController): Cleanly handle missing route for schedule

### DIFF
--- a/lib/mobile_app_backend_web/controllers/schedule_controller.ex
+++ b/lib/mobile_app_backend_web/controllers/schedule_controller.ex
@@ -191,7 +191,15 @@ defmodule MobileAppBackendWeb.ScheduleController do
 
     relevant_schedules =
       Enum.filter(schedules, fn schedule ->
-        global_data.routes[schedule.route_id].type in [:commuter_rail, :ferry] or
+        route = global_data.routes[schedule.route_id]
+
+        if route == nil do
+          Logger.warning(
+            "#{__MODULE__} global data is missing route #{schedule.route_id} for schedule id=#{schedule.id} stop_id=#{schedule.stop_id} trip_id=#{schedule.trip_id}"
+          )
+        end
+
+        is_nil(route) or route.type in [:commuter_rail, :ferry] or
           schedule.id in last_schedule_ids or
           compare_schedule_time(schedule, date_time)
       end)

--- a/test/mobile_app_backend_web/controllers/schedule_controller_test.exs
+++ b/test/mobile_app_backend_web/controllers/schedule_controller_test.exs
@@ -1255,5 +1255,84 @@ defmodule MobileAppBackendWeb.ScheduleControllerTest do
                }
              } = json_response(conn, 200)
     end
+
+    test "logs warning if route is missing for some reason", %{conn: conn} do
+      s1 = %MBTAV3API.Schedule{
+        id: "schedule-60565147-70158-90",
+        arrival_time: ~B[2024-03-13 11:15:00],
+        departure_time: ~B[2024-03-13 11:15:00],
+        drop_off_type: :regular,
+        pick_up_type: :regular,
+        stop_sequence: 90,
+        route_id: "MISSING",
+        stop_id: "70158",
+        trip_id: "60565147"
+      }
+
+      t1 = build(:trip, id: s1.trip_id)
+
+      reassign_env(
+        :mobile_app_backend,
+        MobileAppBackend.GlobalDataCache.Module,
+        GlobalDataCacheMock
+      )
+
+      GlobalDataCacheMock
+      |> expect(:default_key, 2, fn -> :default_key end)
+      |> expect(:get_data, 2, fn _ ->
+        %{
+          lines: %{},
+          pattern_ids_by_stop: %{},
+          routes: %{},
+          route_patterns: %{},
+          stops: %{},
+          trips: %{}
+        }
+      end)
+
+      RepositoryMock
+      |> expect(:schedules, fn params, _opts ->
+        assert [
+                 filter: [
+                   stop: "place-boyls",
+                   date: ~D[2024-03-13]
+                 ],
+                 include: :trip
+               ] = params
+
+        ok_response([s1], [t1])
+      end)
+
+      set_log_level(:warning)
+
+      {conn, log} =
+        with_log(fn ->
+          get(conn, "/api/schedules", %{
+            stop_ids: "place-boyls",
+            date_time: "2024-03-13T11:00:30-04:00"
+          })
+        end)
+
+      assert %{
+               "schedules" => [
+                 %{
+                   "arrival_time" => "2024-03-13T11:15:00-04:00",
+                   "departure_time" => "2024-03-13T11:15:00-04:00",
+                   "drop_off_type" => "regular",
+                   "id" => "schedule-60565147-70158-90",
+                   "pick_up_type" => "regular",
+                   "route_id" => "MISSING",
+                   "stop_id" => "70158",
+                   "stop_sequence" => 90,
+                   "trip_id" => "60565147"
+                 }
+               ],
+               "trips" => %{
+                 "60565147" => %{}
+               }
+             } = json_response(conn, 200)
+
+      assert log =~ "global data is missing route MISSING"
+    end
   end
 end


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket
<!-- What is this PR for? -->
There was an influx of errors yesterday [like this one](https://mbta.slack.com/archives/C08242XU3RR/p1785186127887079). I was able to reproduce it locally in a unit test only by having a schedule that didn't have a corresponding route in the global data. 

It isn't clear to me why this would happen, but it may be related to the ongoing RL shuttle. I've added some logging to help us identify the problematic route to investigate further.

### Testing
<!-- What testing have you done? -->
Added unit test