### PR TITLE
fix(Schedule): Don't expand added routes for shuttles

### DIFF
--- a/lib/mbta_v3_api/route.ex
+++ b/lib/mbta_v3_api/route.ex
@@ -99,4 +99,8 @@ defmodule MBTAV3API.Route do
   end
 
   def label(%__MODULE__{long_name: long_name}), do: long_name
+
+  @spec is_shuttle(t() | String.t()) :: boolean()
+  def is_shuttle(%__MODULE__{id: id}), do: is_shuttle(id)
+  def is_shuttle(id), do: String.starts_with?(id, "Shuttle")
 end

--- a/lib/mbta_v3_api/route.ex
+++ b/lib/mbta_v3_api/route.ex
@@ -100,7 +100,7 @@ defmodule MBTAV3API.Route do
 
   def label(%__MODULE__{long_name: long_name}), do: long_name
 
-  @spec is_shuttle(t() | String.t()) :: boolean()
-  def is_shuttle(%__MODULE__{id: id}), do: is_shuttle(id)
-  def is_shuttle(id), do: String.starts_with?(id, "Shuttle")
+  @spec shuttle?(t() | String.t()) :: boolean()
+  def shuttle?(%__MODULE__{id: id}), do: shuttle?(id)
+  def shuttle?(id), do: String.starts_with?(id, "Shuttle")
 end

--- a/lib/mbta_v3_api/schedule.ex
+++ b/lib/mbta_v3_api/schedule.ex
@@ -1,5 +1,6 @@
 defmodule MBTAV3API.Schedule do
   use MBTAV3API.JsonApi.Object, renames: %{pickup_type: :pick_up_type}
+  alias MBTAV3API.Route
   require Util
 
   @type t :: %__MODULE__{
@@ -77,14 +78,20 @@ defmodule MBTAV3API.Schedule do
 
   @spec expand_added_routes(t()) :: [t()]
   def expand_added_routes(%__MODULE__{} = schedule) do
-    [schedule] ++
-      for added_route_id <- schedule.added_route_ids || [] do
-        %__MODULE__{
-          schedule
-          | id: "#{schedule.id}+r#{added_route_id}",
-            route_id: added_route_id,
-            added_route_ids: []
-        }
-      end
+    # Don't expand shuttle schedules onto the routes they cover so that we don't attempt
+    # to show them on subway stop pages
+    if Route.is_shuttle(schedule.route_id) do
+      [schedule]
+    else
+      [schedule] ++
+        for added_route_id <- schedule.added_route_ids || [] do
+          %__MODULE__{
+            schedule
+            | id: "#{schedule.id}+r#{added_route_id}",
+              route_id: added_route_id,
+              added_route_ids: []
+          }
+        end
+    end
   end
 end

--- a/lib/mbta_v3_api/schedule.ex
+++ b/lib/mbta_v3_api/schedule.ex
@@ -80,7 +80,7 @@ defmodule MBTAV3API.Schedule do
   def expand_added_routes(%__MODULE__{} = schedule) do
     # Don't expand shuttle schedules onto the routes they cover so that we don't attempt
     # to show them on subway stop pages
-    if Route.is_shuttle(schedule.route_id) do
+    if Route.shuttle?(schedule.route_id) do
       [schedule]
     else
       [schedule] ++

--- a/test/mbta_v3_api/schedule_test.exs
+++ b/test/mbta_v3_api/schedule_test.exs
@@ -36,4 +36,44 @@ defmodule MBTAV3API.ScheduleTest do
              trip_id: "60565179"
            }
   end
+
+  describe "expand_added_routes" do
+    test "expands for regular route" do
+      sched = %Schedule{
+        id: "schedule-60565179-70159-90",
+        arrival_time: ~B[2024-03-13 01:07:00],
+        departure_time: ~B[2024-03-13 01:07:00],
+        drop_off_type: :regular,
+        pick_up_type: :regular,
+        stop_headsign: "abc",
+        stop_sequence: 90,
+        added_route_ids: ["1"],
+        route_id: "Green-D",
+        stop_id: "70159",
+        trip_id: "60565179"
+      }
+
+      expanded = %Schedule{sched | id: "#{sched.id}+r1", route_id: "1", added_route_ids: []}
+
+      assert [sched, expanded] == Schedule.expand_added_routes(sched)
+    end
+
+    test "doesn't expand for shuttle route" do
+      sched = %Schedule{
+        id: "schedule-60565179-70159-90",
+        arrival_time: ~B[2024-03-13 01:07:00],
+        departure_time: ~B[2024-03-13 01:07:00],
+        drop_off_type: :regular,
+        pick_up_type: :regular,
+        stop_headsign: "abc",
+        stop_sequence: 90,
+        added_route_ids: ["Green-D"],
+        route_id: "Shuttle-Green-D",
+        stop_id: "70159",
+        trip_id: "60565179"
+      }
+
+      assert [sched] == Schedule.expand_added_routes(sched)
+    end
+  end
 end


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix: Red Line NB @ Davis thinks there's still service](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1216857119900223?focus=true)

<!-- What is this PR for? -->

There is ongoing discussion about whether rail routes should be included in `added_routes` for their shuttles. In the meantime, adding this filtering on our side so that we correctly show a full takeover shuttle alert at Davis. 

### Testing

<!-- What testing have you done? -->
* Added unit test
* Ran locally and confirmed I now see a takeover without an infinitely loading trip at davis 
<img width="45%" height="1500" alt="image" src="https://github.com/user-attachments/assets/dd64b2c4-04f5-49f6-8aec-82bf464a85db" />
