### PR TITLE
feat: build downstream alert summaries

### DIFF
--- a/lib/mobile_app_backend/alerts/summary_entity.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity.ex
@@ -1,6 +1,5 @@
 defmodule MobileAppBackend.Alerts.SummaryEntity do
   @type t :: %__MODULE__{
-          alert_id: String.t(),
           route_id: String.t() | nil,
           stop_id: String.t() | nil,
           trip_id: String.t() | nil,
@@ -9,5 +8,5 @@ defmodule MobileAppBackend.Alerts.SummaryEntity do
         }
 
   @derive Jason.Encoder
-  defstruct [:alert_id, :route_id, :stop_id, :trip_id, :direction_id, :summary]
+  defstruct [:route_id, :stop_id, :trip_id, :direction_id, :summary]
 end

--- a/lib/mobile_app_backend/alerts/summary_entity_builder.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity_builder.ex
@@ -1,4 +1,5 @@
 defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
+  require Logger
   alias MBTAV3API.Alert
   alias MBTAV3API.Repository
   alias MBTAV3API.Route
@@ -10,17 +11,6 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
   alias MobileAppBackend.Alerts.FormattedAlert
   alias MobileAppBackend.Alerts.SummaryEntity
   alias MobileAppBackend.GlobalDataCache
-
-  defmodule BroadCombination do
-    @moduledoc "a route, direction, and optional trip that an InformedEntity applies to"
-    @type t :: %__MODULE__{
-            route: Route.id(),
-            direction: 0 | 1,
-            trip: Trip.id() | nil
-          }
-    @enforce_keys [:route, :direction, :trip]
-    defstruct [:route, :direction, :trip]
-  end
 
   defmodule Combination do
     @moduledoc "specific parameters for an individual summary"
@@ -165,103 +155,98 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
           [Combination.t()]
   def relevant_combinations(alert, {all_child_stops, trips, global}) do
     alert.informed_entity
-    |> Enum.flat_map(&combination_from_entity(&1, {all_child_stops, trips, global}))
+    |> Enum.flat_map(&expand_entity(&1, {all_child_stops, trips, global}))
     |> Enum.uniq()
-    |> Enum.flat_map(&expand_combination(&1, global))
+    |> Enum.flat_map(&combinations_from_entity(&1, global))
+    |> Enum.uniq()
   end
 
-  @spec combination_from_entity(
+  @spec expand_entity(
           Alert.InformedEntity.t(),
           {all_child_stops :: %{Stop.id() => Stop.t()}, trips :: %{Trip.id() => Trip.t()},
            global :: GlobalDataCache.data()}
         ) ::
-          [BroadCombination.t()]
-  defp combination_from_entity(entity, extra_context)
+          [Alert.InformedEntity.t()]
+  defp expand_entity(ie, extra_context)
 
-  defp combination_from_entity(
-         %Alert.InformedEntity{
-           route_type: route_type,
-           route: nil,
-           direction_id: nil
-         },
-         {_all_child_stops, _trips, global}
+  defp expand_entity(
+         %Alert.InformedEntity{route: nil, route_type: route_type} = ie,
+         {all_child_stops, trips, global}
        )
        when not is_nil(route_type) do
-    # Expand route type entities into a combination for each route of that type,
-    # since each route will have a different summary
     global.routes
     |> Enum.filter(fn {_id, route} -> route.type == route_type end)
     |> Enum.flat_map(fn {route_id, _} ->
-      [
-        %BroadCombination{route: route_id, direction: 0, trip: nil},
-        %BroadCombination{route: route_id, direction: 1, trip: nil}
-      ]
+      expand_entity(%Alert.InformedEntity{ie | route: route_id}, {all_child_stops, trips, global})
     end)
   end
 
-  defp combination_from_entity(
-         %Alert.InformedEntity{route: route_id, trip: trip_id, direction_id: direction_id},
-         _extra_context
+  defp expand_entity(
+         %Alert.InformedEntity{route: nil, stop: stop} = ie,
+         {all_child_stops, trips, global}
        )
-       when not is_nil(trip_id) and not is_nil(direction_id) do
-    [%BroadCombination{route: route_id, direction: direction_id, trip: trip_id}]
-  end
-
-  defp combination_from_entity(
-         %Alert.InformedEntity{route: route_id, trip: trip_id, direction_id: nil},
-         {_all_child_stops, trips, _global}
-       )
-       when not is_nil(trip_id) do
-    direction = trips[trip_id].direction_id
-    [%BroadCombination{route: route_id, direction: direction, trip: trip_id}]
-  end
-
-  defp combination_from_entity(
-         %Alert.InformedEntity{route: route_id, direction_id: nil},
-         _extra_context
-       )
-       when not is_nil(route_id) do
-    [
-      %BroadCombination{route: route_id, direction: 0, trip: nil},
-      %BroadCombination{route: route_id, direction: 1, trip: nil}
-    ]
-  end
-
-  defp combination_from_entity(
-         %Alert.InformedEntity{route: route_id, direction_id: direction_id},
-         _extra_context
-       )
-       when not is_nil(route_id) do
-    [%BroadCombination{route: route_id, direction: direction_id, trip: nil}]
-  end
-
-  defp combination_from_entity(
-         %Alert.InformedEntity{stop: stop_id},
-         {all_child_stops, _trips, global}
-       )
-       when not is_nil(stop_id) do
+       when not is_nil(stop) do
     # check all the patterns at this stop to find their routes and directions
-    parent_stop = global.stops[stop_parent_id(stop_id, all_child_stops)]
+    parent_stop = global.stops[stop_parent_id(stop, all_child_stops)]
     all_stop_ids = [parent_stop | parent_stop.child_stop_ids || []]
 
     all_stop_ids
     |> Enum.flat_map(&(global.pattern_ids_by_stop[&1] || []))
     |> Enum.map(fn pattern_id ->
       pattern = global.route_patterns[pattern_id]
-      %BroadCombination{route: pattern.route_id, direction: pattern.direction_id, trip: nil}
+
+      %Alert.InformedEntity{
+        ie
+        | direction_id: pattern.direction_id,
+          route: pattern.route_id,
+          stop: nil
+      }
     end)
     |> Enum.uniq()
+    |> Enum.flat_map(&expand_entity(&1, {all_child_stops, trips, global}))
   end
 
-  defp combination_from_entity(entity, _extra_context) do
-    raise "uhhh what is a #{inspect(entity)}"
+  defp expand_entity(
+         %Alert.InformedEntity{direction_id: nil} = ie,
+         {all_child_stops, trips, global}
+       ) do
+    directions =
+      if is_nil(ie.trip) do
+        [0, 1]
+      else
+        [trips[ie.trip].direction_id]
+      end
+
+    Enum.flat_map(
+      directions,
+      &expand_entity(
+        %Alert.InformedEntity{ie | direction_id: &1},
+        {all_child_stops, trips, global}
+      )
+    )
+  end
+
+  defp expand_entity(
+         %Alert.InformedEntity{direction_id: direction_id, route: route} = ie,
+         _extra_context
+       )
+       when not is_nil(direction_id) and not is_nil(route) do
+    [ie]
+  end
+
+  defp expand_entity(ie, _extra_context) do
+    Logger.warning("expand_entity/2 unknown entity #{inspect(ie)}")
+    Sentry.capture_message("expand_entity/2 unknown entity #{inspect(ie)}")
     []
   end
 
-  @spec expand_combination(BroadCombination.t(), GlobalDataCache.data()) ::
+  @spec combinations_from_entity(
+          Alert.InformedEntity.t(),
+          GlobalDataCache.data()
+        ) ::
           [Combination.t()]
-  defp expand_combination(
-         %BroadCombination{route: route, direction: direction, trip: trip},
+  defp combinations_from_entity(
+         %Alert.InformedEntity{direction_id: direction, route: route, trip: trip},
          global
        ) do
     patterns = RoutePattern.get_relevant_patterns(route, nil, direction, global)

--- a/lib/mobile_app_backend/alerts/summary_entity_builder.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity_builder.ex
@@ -11,14 +11,28 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
   alias MobileAppBackend.Alerts.SummaryEntity
   alias MobileAppBackend.GlobalDataCache
 
-  defmodule Combination do
+  defmodule BroadCombination do
+    @moduledoc "a route, direction, and optional trip that an InformedEntity applies to"
     @type t :: %__MODULE__{
-            route: String.t() | nil,
-            stop: String.t() | nil,
-            trip: String.t() | nil,
-            direction: 0 | 1 | nil
+            route: Route.id(),
+            direction: 0 | 1,
+            trip: Trip.id() | nil
           }
-    defstruct [:route, :stop, :trip, :direction]
+    @enforce_keys [:route, :direction, :trip]
+    defstruct [:route, :direction, :trip]
+  end
+
+  defmodule Combination do
+    @moduledoc "specific parameters for an individual summary"
+    @type t :: %__MODULE__{
+            route: Route.id(),
+            stop: Stop.id() | nil,
+            direction: 0 | 1,
+            trip: Trip.id() | nil,
+            patterns: [RoutePattern.t()]
+          }
+    @enforce_keys [:route, :stop, :direction, :trip, :patterns]
+    defstruct [:route, :stop, :direction, :trip, :patterns]
   end
 
   @doc """
@@ -62,11 +76,11 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
     # The global stops don't include all child stops, so we need to fetch them separately
     stops = fetch_all_stops()
 
-    combinations = relevant_combinations(alert, stops, global)
+    combinations = relevant_combinations(alert, {stops, trips, global})
 
-    Enum.flat_map(
+    Enum.map(
       combinations,
-      &combination_to_summaries(
+      &combination_to_summary(
         &1,
         alert,
         at_time,
@@ -79,12 +93,22 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
     |> dedup_summaries()
   end
 
-  defp combination_to_summaries(
+  @spec combination_to_summary(
+          Combination.t(),
+          Alert.t(),
+          DateTime.t(),
+          String.t(),
+          {[Schedule.t()] | nil, %{Trip.id() => Trip.t()} | nil, %{Stop.id() => Stop.t()}},
+          GlobalDataCache.data(),
+          AlertSummary.context()
+        ) :: SummaryEntity.t()
+  defp combination_to_summary(
          %Combination{
            route: route_id,
            stop: stop_id,
+           direction: direction_id,
            trip: trip_id,
-           direction: direction_id
+           patterns: patterns
          },
          alert,
          at_time,
@@ -93,130 +117,191 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
          global,
          context
        ) do
-    RoutePattern.get_relevant_patterns(route_id, stop_id, direction_id, global)
-    |> Enum.group_by(&{&1.route_id, &1.direction_id})
-    |> Enum.map(fn {{resolved_route_id, resolved_direction_id}, patterns} ->
-      resolved_stop_id = resolve_stop_id(stop_id, trip_id, patterns, trips, stops, global)
+    resolved_stop_id = resolve_stop_id(stop_id, trip_id, patterns, trips, stops, global)
 
-      resolved_schedules =
-        filter_schedules(
-          schedules,
-          trips,
-          resolved_route_id,
-          resolved_stop_id,
-          resolved_direction_id,
-          stops,
-          global
-        )
+    resolved_schedules =
+      filter_schedules(
+        schedules,
+        trips,
+        route_id,
+        resolved_stop_id,
+        direction_id,
+        stops,
+        global
+      )
 
-      summary =
-        AlertSummary.summarizing(
-          alert,
-          resolved_stop_id,
-          resolved_direction_id,
-          patterns,
-          at_time,
-          resolved_schedules,
-          global,
-          context
-        )
+    summary =
+      AlertSummary.summarizing(
+        alert,
+        resolved_stop_id,
+        direction_id,
+        patterns,
+        at_time,
+        resolved_schedules,
+        global,
+        context
+      )
 
-      formatted =
-        FormattedAlert.summary(
-          %FormattedAlert{alert: alert, alert_summary: summary},
-          locale
-        )
+    formatted =
+      FormattedAlert.summary(
+        %FormattedAlert{alert: alert, alert_summary: summary},
+        locale
+      )
 
-      %SummaryEntity{
-        alert_id: alert.id,
-        route_id: resolved_route_id,
-        stop_id: stop_id,
-        trip_id: trip_id,
-        direction_id: resolved_direction_id,
-        summary: formatted
-      }
-    end)
+    %SummaryEntity{
+      route_id: route_id,
+      stop_id: stop_id,
+      trip_id: trip_id,
+      direction_id: direction_id,
+      summary: formatted
+    }
   end
 
   # Get the route, stop, trip, and direction combinations relevant to the alert based on its informed_entity list
-  @spec relevant_combinations(Alert.t(), %{String.t() => Stop.t()}, GlobalDataCache.data()) :: [
-          Combination.t()
-        ]
-  def relevant_combinations(alert, stops, global) do
-    combinations =
-      alert.informed_entity
-      |> Enum.flat_map(&combination_from_entity(&1, global))
-      |> Enum.map(fn %Combination{route: route, stop: stop, trip: trip, direction: direction} ->
+  @spec relevant_combinations(
+          Alert.t(),
+          {%{Stop.id() => Stop.t()}, %{Trip.id() => Trip.t()}, GlobalDataCache.data()}
+        ) ::
+          [Combination.t()]
+  def relevant_combinations(alert, {all_child_stops, trips, global}) do
+    alert.informed_entity
+    |> Enum.flat_map(&combination_from_entity(&1, {all_child_stops, trips, global}))
+    |> Enum.uniq()
+    |> Enum.flat_map(&expand_combination(&1, global))
+  end
+
+  @spec combination_from_entity(
+          Alert.InformedEntity.t(),
+          {all_child_stops :: %{Stop.id() => Stop.t()}, trips :: %{Trip.id() => Trip.t()},
+           global :: GlobalDataCache.data()}
+        ) ::
+          [BroadCombination.t()]
+  defp combination_from_entity(entity, extra_context)
+
+  defp combination_from_entity(
+         %Alert.InformedEntity{
+           route_type: route_type,
+           route: nil,
+           direction_id: nil
+         },
+         {_all_child_stops, _trips, global}
+       )
+       when not is_nil(route_type) do
+    # Expand route type entities into a combination for each route of that type,
+    # since each route will have a different summary
+    global.routes
+    |> Enum.filter(fn {_id, route} -> route.type == route_type end)
+    |> Enum.flat_map(fn {route_id, _} ->
+      [
+        %BroadCombination{route: route_id, direction: 0, trip: nil},
+        %BroadCombination{route: route_id, direction: 1, trip: nil}
+      ]
+    end)
+  end
+
+  defp combination_from_entity(
+         %Alert.InformedEntity{route: route_id, trip: trip_id, direction_id: direction_id},
+         _extra_context
+       )
+       when not is_nil(trip_id) and not is_nil(direction_id) do
+    [%BroadCombination{route: route_id, direction: direction_id, trip: trip_id}]
+  end
+
+  defp combination_from_entity(
+         %Alert.InformedEntity{route: route_id, trip: trip_id, direction_id: nil},
+         {_all_child_stops, trips, _global}
+       )
+       when not is_nil(trip_id) do
+    direction = trips[trip_id].direction_id
+    [%BroadCombination{route: route_id, direction: direction, trip: trip_id}]
+  end
+
+  defp combination_from_entity(
+         %Alert.InformedEntity{route: route_id, direction_id: nil},
+         _extra_context
+       )
+       when not is_nil(route_id) do
+    [
+      %BroadCombination{route: route_id, direction: 0, trip: nil},
+      %BroadCombination{route: route_id, direction: 1, trip: nil}
+    ]
+  end
+
+  defp combination_from_entity(
+         %Alert.InformedEntity{route: route_id, direction_id: direction_id},
+         _extra_context
+       )
+       when not is_nil(route_id) do
+    [%BroadCombination{route: route_id, direction: direction_id, trip: nil}]
+  end
+
+  defp combination_from_entity(
+         %Alert.InformedEntity{stop: stop_id},
+         {all_child_stops, _trips, global}
+       )
+       when not is_nil(stop_id) do
+    # check all the patterns at this stop to find their routes and directions
+    parent_stop = global.stops[stop_parent_id(stop_id, all_child_stops)]
+    all_stop_ids = [parent_stop | parent_stop.child_stop_ids || []]
+
+    all_stop_ids
+    |> Enum.flat_map(&(global.pattern_ids_by_stop[&1] || []))
+    |> Enum.map(fn pattern_id ->
+      pattern = global.route_patterns[pattern_id]
+      %BroadCombination{route: pattern.route_id, direction: pattern.direction_id, trip: nil}
+    end)
+    |> Enum.uniq()
+  end
+
+  defp combination_from_entity(entity, _extra_context) do
+    raise "uhhh what is a #{inspect(entity)}"
+    []
+  end
+
+  @spec expand_combination(BroadCombination.t(), GlobalDataCache.data()) ::
+          [Combination.t()]
+  defp expand_combination(
+         %BroadCombination{route: route, direction: direction, trip: trip},
+         global
+       ) do
+    patterns = RoutePattern.get_relevant_patterns(route, nil, direction, global)
+
+    # we don’t actually need to look at each stop separately if
+    # 1. this isn’t a trip-specific alert
+    # 2. this isn’t on the Green Line
+    # 3. there’s only one pattern in this direction, so all the stops are on it
+    should_expand_stops? =
+      not is_nil(trip) or String.starts_with?(route, "Green-") or length(patterns) > 1
+
+    if should_expand_stops? do
+      patterns
+      |> Enum.flat_map(fn pattern ->
+        pattern_stop_ids = global.trips[pattern.representative_trip_id].stop_ids
+        Enum.map(pattern_stop_ids, &{Stop.parent_id_if_exists(&1, global.stops), pattern})
+      end)
+      |> Enum.group_by(fn {stop_id, _pattern} -> stop_id end, fn {_stop_id, pattern} ->
+        pattern
+      end)
+      |> Enum.map(fn {stop_id, patterns} ->
         %Combination{
           route: route,
-          stop: stop_parent_id(stop, stops),
+          stop: stop_id,
+          direction: direction,
           trip: trip,
-          direction: direction
+          patterns: patterns
         }
       end)
-      |> Enum.uniq()
-
-    # Filter out any combinations that are already covered by another wildcard in the list
-    Enum.reject(combinations, fn combination ->
-      redundant_combination?(combination, combinations)
-    end)
-  end
-
-  @spec combination_from_entity(Alert.InformedEntity.t(), GlobalDataCache.data()) :: [
-          {String.t() | nil, String.t() | nil, String.t() | nil, 0 | 1 | nil}
-        ]
-  defp combination_from_entity(entity, global) do
-    case entity do
-      # Expand route type entities into a combination for each route of that type,
-      # since each route will have a different summary
-      %Alert.InformedEntity{route_type: route_type, route: nil, stop: nil, direction_id: nil}
-      when not is_nil(route_type) ->
-        global.routes
-        |> Enum.filter(fn {_id, route} -> route.type == Route.parse_type!(route_type) end)
-        |> Enum.map(fn {route_id, _} -> %Combination{route: route_id} end)
-
-      %Alert.InformedEntity{
-        route: route_id,
-        stop: stop_id,
-        trip: trip_id,
-        direction_id: direction_id
-      }
-      when not is_nil(trip_id) ->
-        [%Combination{route: route_id, stop: stop_id, trip: trip_id, direction: direction_id}]
-
-      %Alert.InformedEntity{route: route_id, stop: stop_id, direction_id: nil}
-      when not is_nil(stop_id) or not is_nil(route_id) ->
-        [
-          %Combination{route: route_id, stop: stop_id, direction: 0},
-          %Combination{route: route_id, stop: stop_id, direction: 1}
-        ]
-
-      %Alert.InformedEntity{route: route_id, stop: stop_id, direction_id: direction_id}
-      when not is_nil(stop_id) or not is_nil(route_id) ->
-        [%Combination{route: route_id, stop: stop_id, direction: direction_id}]
-
-      _ ->
-        []
+    else
+      [
+        %Combination{
+          route: route,
+          stop: nil,
+          direction: direction,
+          trip: trip,
+          patterns: patterns
+        }
+      ]
     end
-  end
-
-  # A combination is redundant if there exists another combination in the list where
-  # all fields are either nil if a non-nil field exists in the redundant one or equal
-  @spec redundant_combination?(
-          Combination.t(),
-          [Combination.t()]
-        ) :: boolean()
-  defp redundant_combination?(combination, combinations) do
-    keys = %Combination{} |> Map.from_struct() |> Map.keys()
-
-    Enum.any?(combinations, fn other ->
-      combination != other and
-        Enum.all?(
-          keys,
-          &((not is_nil(Map.get(combination, &1)) and is_nil(Map.get(other, &1))) or
-              Map.get(combination, &1) == Map.get(other, &1))
-        )
-    end)
   end
 
   defp fetch_all_stops do
@@ -337,16 +422,28 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
   # Collapse entities where both directions produce identical summaries
   @spec dedup_summaries([SummaryEntity.t()]) :: [SummaryEntity.t()]
   def dedup_summaries(entities) do
-    entities
-    |> Enum.group_by(&{&1.alert_id, &1.route_id, &1.stop_id, &1.trip_id})
-    |> Enum.flat_map(fn {_key, grouped} ->
-      case grouped do
-        [a, b] when a.summary == b.summary ->
-          [%{a | direction_id: nil}]
+    # sorted from least desirable to split by to most desirable to split by
+    all_keys = [:stop_id, :trip_id, :direction_id, :route_id]
 
-        _ ->
-          grouped
-      end
-    end)
+    for split_key <- all_keys, reduce: entities do
+      entities ->
+        other_keys = all_keys -- [split_key]
+        # we can drop this key if the other keys are sufficient to uniquely determine the summary
+        summaries_by_other_keys =
+          Enum.group_by(
+            entities,
+            fn entity -> Map.take(entity, other_keys) end,
+            fn entity -> entity.summary end
+          )
+
+        can_drop_split_key? =
+          summaries_by_other_keys |> Map.values() |> Enum.all?(&(length(Enum.uniq(&1)) == 1))
+
+        if can_drop_split_key? do
+          entities |> Enum.map(&Map.put(&1, split_key, nil)) |> Enum.uniq()
+        else
+          entities
+        end
+    end
   end
 end

--- a/lib/mobile_app_backend/alerts/summary_entity_builder.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity_builder.ex
@@ -163,7 +163,7 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
     alert.informed_entity
     |> Enum.flat_map(&expand_entity(&1, {all_child_stops, trips, global}))
     |> Enum.uniq()
-    |> Enum.flat_map(&combinations_from_entity(&1, global))
+    |> Enum.flat_map(&combinations_from_entity(&1, trips, global))
     |> Enum.uniq()
   end
 
@@ -248,50 +248,68 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
 
   @spec combinations_from_entity(
           Alert.InformedEntity.t(),
+          %{Trip.id() => Trip.t()},
           GlobalDataCache.data()
         ) ::
           [Combination.t()]
   defp combinations_from_entity(
-         %Alert.InformedEntity{direction_id: direction, route: route, trip: trip},
+         %Alert.InformedEntity{direction_id: direction_id, route: route_id, trip: trip_id},
+         trips,
          global
        ) do
-    patterns = RoutePattern.get_relevant_patterns(route, nil, direction, global)
+    patterns = RoutePattern.get_relevant_patterns(route_id, nil, direction_id, global)
 
-    # we don’t actually need to look at each stop separately if
-    # 1. this isn’t a trip-specific alert
-    # 2. this isn’t on the Green Line
-    # 3. there’s only one pattern in this direction, so all the stops are on it
-    should_expand_stops? =
-      not is_nil(trip) or String.starts_with?(route, "Green-") or length(patterns) > 1
+    cond do
+      not is_nil(trip_id) ->
+        # for trip-specific alerts, we usually need the stop id for trip identity,
+        # and we only want the stops the trip will actually visit
+        trip = trips[trip_id]
+        pattern = Enum.find(patterns, &(&1.id == trip.route_pattern_id))
+        stop_ids = trip.stop_ids
 
-    if should_expand_stops? do
-      patterns
-      |> Enum.flat_map(fn pattern ->
-        pattern_stop_ids = global.trips[pattern.representative_trip_id].stop_ids
-        Enum.map(pattern_stop_ids, &{Stop.parent_id_if_exists(&1, global.stops), pattern})
-      end)
-      |> Enum.group_by(fn {stop_id, _pattern} -> stop_id end, fn {_stop_id, pattern} ->
-        pattern
-      end)
-      |> Enum.map(fn {stop_id, patterns} ->
-        %Combination{
-          route: route,
-          stop: stop_id,
-          direction: direction,
-          trip: trip,
-          patterns: patterns
-        }
-      end)
-    else
-      [
-        %Combination{
-          route: route,
-          stop: nil,
-          direction: direction,
-          trip: trip,
-          patterns: patterns
-        }
-      ]
+        Enum.map(stop_ids, fn stop_id ->
+          stop_id = Stop.parent_id_if_exists(stop_id, global.stops)
+
+          %Combination{
+            route: route_id,
+            stop: stop_id,
+            direction: direction_id,
+            trip: trip_id,
+            patterns: [pattern]
+          }
+        end)
+
+      String.starts_with?(route_id, "Green-") or length(patterns) > 1 ->
+        # for branching routes or the Green Line, the summary may differ by stop id
+        patterns
+        |> Enum.flat_map(fn pattern ->
+          pattern_stop_ids = global.trips[pattern.representative_trip_id].stop_ids
+          Enum.map(pattern_stop_ids, &{Stop.parent_id_if_exists(&1, global.stops), pattern})
+        end)
+        |> Enum.group_by(fn {stop_id, _pattern} -> stop_id end, fn {_stop_id, pattern} ->
+          pattern
+        end)
+        |> Enum.map(fn {stop_id, patterns} ->
+          %Combination{
+            route: route_id,
+            stop: stop_id,
+            direction: direction_id,
+            trip: nil,
+            patterns: patterns
+          }
+        end)
+
+      true ->
+        # in all other cases, the stop id doesn’t matter
+        [
+          %Combination{
+            route: route_id,
+            stop: nil,
+            direction: direction_id,
+            trip: nil,
+            patterns: patterns
+          }
+        ]
     end
   end
 

--- a/lib/mobile_app_backend/alerts/summary_entity_builder.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity_builder.ex
@@ -26,7 +26,13 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
   end
 
   @doc """
-  Given a list of alerts and global data, produces a list of summary entites keyed by alert id
+  Given a list of alerts and global data, produces a list of summary entities keyed by alert id.
+
+  Includes summaries for stops that are not directly affected, so that the frontend can correctly
+  display downstream alerts where needed.
+  Note that summary entities may match routes/stops/directions/trips where the alert itself
+  should not be displayed: the frontend will still decide whether or not to actually show the
+  alert, and the summary entity only determines which summary text will be displayed.
   """
   @spec build_all(
           [Alert.t()],
@@ -404,10 +410,10 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
     end)
   end
 
-  # Collapse entities where both directions produce identical summaries
+  # Discard specifiers that aren’t necessary to distinguish between summaries
   @spec dedup_summaries([SummaryEntity.t()]) :: [SummaryEntity.t()]
   def dedup_summaries(entities) do
-    # sorted from least desirable to split by to most desirable to split by
+    # sorted from most desirable to collapse into wildcards to least desirable
     all_keys = [:stop_id, :trip_id, :direction_id, :route_id]
 
     for split_key <- all_keys, reduce: entities do

--- a/test/mobile_app_backend/alerts/summary_entity_builder_test.exs
+++ b/test/mobile_app_backend/alerts/summary_entity_builder_test.exs
@@ -2,6 +2,7 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
   use ExUnit.Case
 
   alias MBTAV3API.Alert.InformedEntity
+  alias MBTAV3API.RoutePattern
   alias MobileAppBackend.Alerts.SummaryEntity
   alias MobileAppBackend.Alerts.SummaryEntityBuilder
   alias MobileAppBackend.Alerts.SummaryEntityBuilder.Combination
@@ -42,8 +43,7 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
       assert %{
                ^alert_id => [
                  %SummaryEntity{
-                   alert_id: ^alert_id,
-                   route_id: ^route_id,
+                   route_id: nil,
                    stop_id: nil,
                    trip_id: nil,
                    direction_id: nil,
@@ -55,8 +55,7 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
       assert %{
                ^alert_id => [
                  %SummaryEntity{
-                   alert_id: ^alert_id,
-                   route_id: ^route_id,
+                   route_id: nil,
                    stop_id: nil,
                    trip_id: nil,
                    direction_id: nil,
@@ -72,17 +71,46 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
       global = GlobalDataCache.get_data()
       all_child_stops = MBTAV3API.Repository.stops(include: [:child_stops])
 
-      stop_id = "place-wlsta"
+      stops = [
+        "place-brntn",
+        "place-qamnl",
+        "place-qnctr",
+        "place-wlsta",
+        "place-nqncy",
+        "place-jfk",
+        "place-andrw",
+        "place-brdwy",
+        "place-sstat",
+        "place-dwnxg",
+        "place-pktrm",
+        "place-chmnl",
+        "place-knncl",
+        "place-cntsq",
+        "place-harsq",
+        "place-portr",
+        "place-davis",
+        "place-alfcl"
+      ]
+
       route_id = "Red"
-      trip = build(:trip, route_id: route_id, stop_ids: [stop_id])
+      trip = build(:trip, route_id: route_id, stop_ids: stops)
       trip_id = trip.id
-      schedule = build(:schedule, trip_id: trip_id, route_id: route_id, stop_id: stop_id)
+
+      schedules =
+        for {stop, index} <- Enum.with_index(stops) do
+          build(:schedule,
+            departure_time: DateTime.add(now, index, :minute),
+            trip_id: trip_id,
+            route_id: route_id,
+            stop_id: stop
+          )
+        end
 
       reassign_env(:mobile_app_backend, MBTAV3API.Repository, RepositoryMock)
 
       expect(RepositoryMock, :schedules, 2, fn
         [filter: [trip: [^trip_id]], include: [trip: :stops], sort: {:stop_sequence, :asc}], [] ->
-          ok_response([schedule], [trip])
+          ok_response(schedules, [trip])
       end)
 
       stub(RepositoryMock, :stops, fn [include: [:child_stops]], [] -> all_child_stops end)
@@ -91,58 +119,339 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
         build(:alert,
           cause: :maintenance,
           effect: :suspension,
-          informed_entity: [%InformedEntity{route: route_id, trip: trip_id}]
+          informed_entity: [
+            %InformedEntity{route: route_id, trip: trip_id, direction_id: trip.direction_id}
+          ]
         )
 
       alert_id = alert.id
 
-      assert %{
-               ^alert_id => [
-                 %SummaryEntity{
-                   alert_id: ^alert_id,
-                   route_id: ^route_id,
-                   stop_id: nil,
-                   trip_id: ^trip_id,
-                   direction_id: 0,
-                   summary:
-                     "4:41 PM train from Wollaston is suspended tomorrow due to maintenance"
-                 },
-                 %MobileAppBackend.Alerts.SummaryEntity{
-                   alert_id: ^alert_id,
-                   direction_id: 1,
-                   route_id: ^route_id,
-                   stop_id: nil,
-                   summary: "Service suspended on Red Line",
-                   trip_id: ^trip_id
-                 }
-               ]
-             } = SummaryEntityBuilder.build_all([alert], now, "en", global, :notification)
+      assert %{^alert_id => entities} =
+               SummaryEntityBuilder.build_all([alert], now, "en", global, :notification)
 
-      assert %{
-               ^alert_id => [
-                 %SummaryEntity{
-                   alert_id: ^alert_id,
-                   route_id: ^route_id,
-                   stop_id: nil,
-                   trip_id: ^trip_id,
-                   direction_id: 0,
-                   summary: "This train is suspended tomorrow due to maintenance"
-                 },
-                 %MobileAppBackend.Alerts.SummaryEntity{
-                   alert_id: ^alert_id,
-                   direction_id: 1,
-                   route_id: ^route_id,
-                   stop_id: nil,
-                   summary: "Service suspended on Red Line",
-                   trip_id: ^trip_id
-                 }
-               ]
-             } = SummaryEntityBuilder.build_all([alert], now, "en", global, :card)
+      assert Enum.sort_by(entities, &{&1.route_id, &1.stop_id, &1.direction_id, &1.trip_id}) == [
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-alfcl",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "12:17 PM train from Alewife is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-andrw",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "12:06 PM train from Andrew is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-asmnl",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "Service suspended on Red Line"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-brdwy",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "12:07 PM train from Broadway is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-brntn",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "12:00 PM train from Braintree is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-chmnl",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "12:11 PM train from Charles/MGH is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-cntsq",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "12:13 PM train from Central is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-davis",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "12:16 PM train from Davis is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-dwnxg",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary:
+                   "12:09 PM train from Downtown Crossing is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-fldcr",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "Service suspended on Red Line"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-harsq",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "12:14 PM train from Harvard is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-jfk",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "12:05 PM train from JFK/UMass is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-knncl",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "12:12 PM train from Kendall/MIT is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-nqncy",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "12:04 PM train from North Quincy is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-pktrm",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "12:10 PM train from Park Street is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-portr",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "12:15 PM train from Porter is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-qamnl",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "12:01 PM train from Quincy Adams is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-qnctr",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary:
+                   "12:02 PM train from Quincy Center is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-shmnl",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "Service suspended on Red Line"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-smmnl",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "Service suspended on Red Line"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-sstat",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary:
+                   "12:08 PM train from South Station is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-wlsta",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "12:03 PM train from Wollaston is suspended today due to maintenance"
+               }
+             ]
+
+      assert %{^alert_id => entities} =
+               SummaryEntityBuilder.build_all([alert], now, "en", global, :card)
+
+      assert Enum.sort_by(entities, &{&1.route_id, &1.stop_id, &1.direction_id, &1.trip_id}) == [
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-alfcl",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "This train is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-andrw",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "This train is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-asmnl",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "Service suspended on Red Line"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-brdwy",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "This train is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-brntn",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "This train is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-chmnl",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "This train is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-cntsq",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "This train is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-davis",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "This train is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-dwnxg",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "This train is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-fldcr",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "Service suspended on Red Line"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-harsq",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "This train is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-jfk",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "This train is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-knncl",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "This train is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-nqncy",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "This train is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-pktrm",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "This train is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-portr",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "This train is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-qamnl",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "This train is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-qnctr",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "This train is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-shmnl",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "Service suspended on Red Line"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-smmnl",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "Service suspended on Red Line"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-sstat",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "This train is suspended today due to maintenance"
+               },
+               %SummaryEntity{
+                 route_id: nil,
+                 stop_id: "place-wlsta",
+                 direction_id: nil,
+                 trip_id: nil,
+                 summary: "This train is suspended today due to maintenance"
+               }
+             ]
     end
 
     test "build stop alert" do
       now = DateTime.now!("America/New_York")
-      route_id = "Red"
       stop_id = "place-wlsta"
 
       global = GlobalDataCache.get_data()
@@ -159,9 +468,8 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
       assert %{
                ^alert_id => [
                  %SummaryEntity{
-                   alert_id: ^alert_id,
-                   route_id: ^route_id,
-                   stop_id: ^stop_id,
+                   route_id: nil,
+                   stop_id: nil,
                    trip_id: nil,
                    direction_id: nil,
                    summary: "Service suspended at Wollaston"
@@ -172,9 +480,8 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
       assert %{
                ^alert_id => [
                  %SummaryEntity{
-                   alert_id: ^alert_id,
-                   route_id: ^route_id,
-                   stop_id: ^stop_id,
+                   route_id: nil,
+                   stop_id: nil,
                    trip_id: nil,
                    direction_id: nil,
                    summary: "Service suspended at Wollaston"
@@ -192,7 +499,7 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
         build(:alert,
           cause: :maintenance,
           effect: :suspension,
-          informed_entity: [%InformedEntity{route_type: 1}]
+          informed_entity: [%InformedEntity{route_type: :heavy_rail}]
         )
 
       alert_id = alert.id
@@ -203,7 +510,6 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
 
       assert [
                %SummaryEntity{
-                 alert_id: ^alert_id,
                  route_id: "Blue",
                  stop_id: nil,
                  trip_id: nil,
@@ -211,7 +517,6 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
                  summary: "Service suspended on Blue Line"
                },
                %SummaryEntity{
-                 alert_id: ^alert_id,
                  route_id: "Orange",
                  stop_id: nil,
                  trip_id: nil,
@@ -219,14 +524,15 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
                  summary: "Service suspended on Orange Line"
                },
                %SummaryEntity{
-                 alert_id: ^alert_id,
                  route_id: "Red",
                  stop_id: nil,
                  trip_id: nil,
                  direction_id: nil,
                  summary: "Service suspended on Red Line"
                }
-             ] = summary_entities |> Enum.sort_by(& &1.route_id)
+             ] =
+               summary_entities
+               |> Enum.sort_by(&{&1.route_id, &1.stop_id, &1.direction_id, &1.trip_id})
     end
   end
 
@@ -245,17 +551,51 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
           ]
         )
 
-      assert [
-               %Combination{route: ^route_id, direction: 0},
-               %Combination{route: ^route_id, direction: 1}
-             ] =
-               SummaryEntityBuilder.relevant_combinations(alert, global.stops, global)
-               |> Enum.sort_by(&{&1.route, &1.stop, &1.trip, &1.direction})
+      expected_combinations =
+        for stop <- [
+              "alfcl",
+              "andrw",
+              "asmnl",
+              "brdwy",
+              "brntn",
+              "chmnl",
+              "cntsq",
+              "davis",
+              "dwnxg",
+              "fldcr",
+              "harsq",
+              "jfk",
+              "knncl",
+              "nqncy",
+              "pktrm",
+              "portr",
+              "qamnl",
+              "qnctr",
+              "shmnl",
+              "smmnl",
+              "sstat",
+              "wlsta"
+            ],
+            direction <- [0, 1] do
+          %Combination{
+            route: "Red",
+            stop: "place-" <> stop,
+            direction: direction,
+            trip: nil,
+            patterns:
+              RoutePattern.get_relevant_patterns(route_id, "place-" <> stop, direction, global)
+          }
+        end
+
+      assert SummaryEntityBuilder.relevant_combinations(alert, {%{}, %{}, global})
+             |> Enum.sort_by(&{&1.route, &1.stop, &1.direction, &1.trip}) ==
+               expected_combinations
     end
 
     test "splits stop entities into both directions" do
       global = GlobalDataCache.get_data()
 
+      route_id = "Red"
       stop_id = "place-wlsta"
 
       alert =
@@ -265,18 +605,50 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
           informed_entity: [%InformedEntity{stop: stop_id}]
         )
 
-      assert [
-               %Combination{stop: ^stop_id, direction: 0},
-               %Combination{stop: ^stop_id, direction: 1}
-             ] =
-               SummaryEntityBuilder.relevant_combinations(alert, global.stops, global)
-               |> Enum.sort_by(&{&1.route, &1.stop, &1.trip, &1.direction})
+      expected_combinations =
+        for stop <- [
+              "alfcl",
+              "andrw",
+              "asmnl",
+              "brdwy",
+              "brntn",
+              "chmnl",
+              "cntsq",
+              "davis",
+              "dwnxg",
+              "fldcr",
+              "harsq",
+              "jfk",
+              "knncl",
+              "nqncy",
+              "pktrm",
+              "portr",
+              "qamnl",
+              "qnctr",
+              "shmnl",
+              "smmnl",
+              "sstat",
+              "wlsta"
+            ],
+            direction <- [0, 1] do
+          %Combination{
+            route: route_id,
+            stop: "place-" <> stop,
+            direction: direction,
+            trip: nil,
+            patterns:
+              RoutePattern.get_relevant_patterns(route_id, "place-" <> stop, direction, global)
+          }
+        end
+
+      assert SummaryEntityBuilder.relevant_combinations(alert, {global.stops, %{}, global})
+             |> Enum.sort_by(&{&1.route, &1.stop, &1.direction, &1.trip}) == expected_combinations
     end
 
     test "trip entities set trip" do
       route_id = "Red"
       stop_id = "place-wlsta"
-      trip = build(:trip)
+      trip = build(:trip, direction_id: 1)
 
       global = GlobalDataCache.get_data()
 
@@ -287,12 +659,47 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
           cause: :maintenance,
           effect: :suspension,
           informed_entity: [
-            %InformedEntity{route: route_id, stop: stop_id, trip: trip_id, direction_id: 1}
+            %InformedEntity{route: route_id, stop: stop_id, trip: trip_id}
           ]
         )
 
-      assert [%Combination{route: ^route_id, stop: ^stop_id, trip: ^trip_id, direction: 1}] =
-               SummaryEntityBuilder.relevant_combinations(alert, global.stops, global)
+      expected_combinations =
+        for stop <- [
+              "alfcl",
+              "andrw",
+              "asmnl",
+              "brdwy",
+              "brntn",
+              "chmnl",
+              "cntsq",
+              "davis",
+              "dwnxg",
+              "fldcr",
+              "harsq",
+              "jfk",
+              "knncl",
+              "nqncy",
+              "pktrm",
+              "portr",
+              "qamnl",
+              "qnctr",
+              "shmnl",
+              "smmnl",
+              "sstat",
+              "wlsta"
+            ] do
+          %Combination{
+            route: route_id,
+            stop: "place-" <> stop,
+            direction: 1,
+            trip: trip.id,
+            patterns: RoutePattern.get_relevant_patterns(route_id, "place-" <> stop, 1, global)
+          }
+        end
+
+      assert SummaryEntityBuilder.relevant_combinations(alert, {%{}, %{trip.id => trip}, global})
+             |> Enum.sort_by(&{&1.route, &1.stop, &1.direction, &1.trip}) ==
+               expected_combinations
     end
 
     test "creates a combination for every route with a route_type entity" do
@@ -303,120 +710,122 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
           cause: :maintenance,
           effect: :suspension,
           informed_entity: [
-            %InformedEntity{route_type: 1}
+            %InformedEntity{route_type: :heavy_rail}
           ]
         )
 
       assert [
-               %Combination{route: "Blue"},
-               %Combination{route: "Orange"},
-               %Combination{route: "Red"}
+               %Combination{route: "Blue", stop: "place-aport", direction: 0},
+               %Combination{route: "Blue", stop: "place-aport", direction: 1},
+               %Combination{route: "Blue", stop: "place-aqucl", direction: 0},
+               %Combination{route: "Blue", stop: "place-aqucl", direction: 1},
+               %Combination{route: "Blue", stop: "place-bmmnl", direction: 0},
+               %Combination{route: "Blue", stop: "place-bmmnl", direction: 1},
+               %Combination{route: "Blue", stop: "place-bomnl", direction: 0},
+               %Combination{route: "Blue", stop: "place-bomnl", direction: 1},
+               %Combination{route: "Blue", stop: "place-gover", direction: 0},
+               %Combination{route: "Blue", stop: "place-gover", direction: 1},
+               %Combination{route: "Blue", stop: "place-mvbcl", direction: 0},
+               %Combination{route: "Blue", stop: "place-mvbcl", direction: 1},
+               %Combination{route: "Blue", stop: "place-orhte", direction: 0},
+               %Combination{route: "Blue", stop: "place-orhte", direction: 1},
+               %Combination{route: "Blue", stop: "place-rbmnl", direction: 0},
+               %Combination{route: "Blue", stop: "place-rbmnl", direction: 1},
+               %Combination{route: "Blue", stop: "place-sdmnl", direction: 0},
+               %Combination{route: "Blue", stop: "place-sdmnl", direction: 1},
+               %Combination{route: "Blue", stop: "place-state", direction: 0},
+               %Combination{route: "Blue", stop: "place-state", direction: 1},
+               %Combination{route: "Blue", stop: "place-wimnl", direction: 0},
+               %Combination{route: "Blue", stop: "place-wimnl", direction: 1},
+               %Combination{route: "Blue", stop: "place-wondl", direction: 0},
+               %Combination{route: "Blue", stop: "place-wondl", direction: 1},
+               %Combination{route: "Orange", stop: "place-astao", direction: 0},
+               %Combination{route: "Orange", stop: "place-astao", direction: 1},
+               %Combination{route: "Orange", stop: "place-bbsta", direction: 0},
+               %Combination{route: "Orange", stop: "place-bbsta", direction: 1},
+               %Combination{route: "Orange", stop: "place-ccmnl", direction: 0},
+               %Combination{route: "Orange", stop: "place-ccmnl", direction: 1},
+               %Combination{route: "Orange", stop: "place-chncl", direction: 0},
+               %Combination{route: "Orange", stop: "place-chncl", direction: 1},
+               %Combination{route: "Orange", stop: "place-dwnxg", direction: 0},
+               %Combination{route: "Orange", stop: "place-dwnxg", direction: 1},
+               %Combination{route: "Orange", stop: "place-forhl", direction: 0},
+               %Combination{route: "Orange", stop: "place-forhl", direction: 1},
+               %Combination{route: "Orange", stop: "place-grnst", direction: 0},
+               %Combination{route: "Orange", stop: "place-grnst", direction: 1},
+               %Combination{route: "Orange", stop: "place-haecl", direction: 0},
+               %Combination{route: "Orange", stop: "place-haecl", direction: 1},
+               %Combination{route: "Orange", stop: "place-jaksn", direction: 0},
+               %Combination{route: "Orange", stop: "place-jaksn", direction: 1},
+               %Combination{route: "Orange", stop: "place-masta", direction: 0},
+               %Combination{route: "Orange", stop: "place-masta", direction: 1},
+               %Combination{route: "Orange", stop: "place-mlmnl", direction: 0},
+               %Combination{route: "Orange", stop: "place-mlmnl", direction: 1},
+               %Combination{route: "Orange", stop: "place-north", direction: 0},
+               %Combination{route: "Orange", stop: "place-north", direction: 1},
+               %Combination{route: "Orange", stop: "place-ogmnl", direction: 0},
+               %Combination{route: "Orange", stop: "place-ogmnl", direction: 1},
+               %Combination{route: "Orange", stop: "place-rcmnl", direction: 0},
+               %Combination{route: "Orange", stop: "place-rcmnl", direction: 1},
+               %Combination{route: "Orange", stop: "place-rugg", direction: 0},
+               %Combination{route: "Orange", stop: "place-rugg", direction: 1},
+               %Combination{route: "Orange", stop: "place-sbmnl", direction: 0},
+               %Combination{route: "Orange", stop: "place-sbmnl", direction: 1},
+               %Combination{route: "Orange", stop: "place-state", direction: 0},
+               %Combination{route: "Orange", stop: "place-state", direction: 1},
+               %Combination{route: "Orange", stop: "place-sull", direction: 0},
+               %Combination{route: "Orange", stop: "place-sull", direction: 1},
+               %Combination{route: "Orange", stop: "place-tumnl", direction: 0},
+               %Combination{route: "Orange", stop: "place-tumnl", direction: 1},
+               %Combination{route: "Orange", stop: "place-welln", direction: 0},
+               %Combination{route: "Orange", stop: "place-welln", direction: 1},
+               %Combination{route: "Red", stop: "place-alfcl", direction: 0},
+               %Combination{route: "Red", stop: "place-alfcl", direction: 1},
+               %Combination{route: "Red", stop: "place-andrw", direction: 0},
+               %Combination{route: "Red", stop: "place-andrw", direction: 1},
+               %Combination{route: "Red", stop: "place-asmnl", direction: 0},
+               %Combination{route: "Red", stop: "place-asmnl", direction: 1},
+               %Combination{route: "Red", stop: "place-brdwy", direction: 0},
+               %Combination{route: "Red", stop: "place-brdwy", direction: 1},
+               %Combination{route: "Red", stop: "place-brntn", direction: 0},
+               %Combination{route: "Red", stop: "place-brntn", direction: 1},
+               %Combination{route: "Red", stop: "place-chmnl", direction: 0},
+               %Combination{route: "Red", stop: "place-chmnl", direction: 1},
+               %Combination{route: "Red", stop: "place-cntsq", direction: 0},
+               %Combination{route: "Red", stop: "place-cntsq", direction: 1},
+               %Combination{route: "Red", stop: "place-davis", direction: 0},
+               %Combination{route: "Red", stop: "place-davis", direction: 1},
+               %Combination{route: "Red", stop: "place-dwnxg", direction: 0},
+               %Combination{route: "Red", stop: "place-dwnxg", direction: 1},
+               %Combination{route: "Red", stop: "place-fldcr", direction: 0},
+               %Combination{route: "Red", stop: "place-fldcr", direction: 1},
+               %Combination{route: "Red", stop: "place-harsq", direction: 0},
+               %Combination{route: "Red", stop: "place-harsq", direction: 1},
+               %Combination{route: "Red", stop: "place-jfk", direction: 0},
+               %Combination{route: "Red", stop: "place-jfk", direction: 1},
+               %Combination{route: "Red", stop: "place-knncl", direction: 0},
+               %Combination{route: "Red", stop: "place-knncl", direction: 1},
+               %Combination{route: "Red", stop: "place-nqncy", direction: 0},
+               %Combination{route: "Red", stop: "place-nqncy", direction: 1},
+               %Combination{route: "Red", stop: "place-pktrm", direction: 0},
+               %Combination{route: "Red", stop: "place-pktrm", direction: 1},
+               %Combination{route: "Red", stop: "place-portr", direction: 0},
+               %Combination{route: "Red", stop: "place-portr", direction: 1},
+               %Combination{route: "Red", stop: "place-qamnl", direction: 0},
+               %Combination{route: "Red", stop: "place-qamnl", direction: 1},
+               %Combination{route: "Red", stop: "place-qnctr", direction: 0},
+               %Combination{route: "Red", stop: "place-qnctr", direction: 1},
+               %Combination{route: "Red", stop: "place-shmnl", direction: 0},
+               %Combination{route: "Red", stop: "place-shmnl", direction: 1},
+               %Combination{route: "Red", stop: "place-smmnl", direction: 0},
+               %Combination{route: "Red", stop: "place-smmnl", direction: 1},
+               %Combination{route: "Red", stop: "place-sstat", direction: 0},
+               %Combination{route: "Red", stop: "place-sstat", direction: 1},
+               %Combination{route: "Red", stop: "place-wlsta", direction: 0},
+               %Combination{route: "Red", stop: "place-wlsta", direction: 1}
              ] =
-               SummaryEntityBuilder.relevant_combinations(alert, global.stops, global)
-               |> Enum.sort_by(&{&1.route, &1.stop, &1.trip, &1.direction})
-    end
-
-    test "filters identical combinations" do
-      global = GlobalDataCache.get_data()
-
-      route_id = "Red"
-      stop_id = "place-wlsta"
-      child_stop_id = "70099"
-
-      alert =
-        build(:alert,
-          cause: :maintenance,
-          effect: :suspension,
-          informed_entity: [
-            %InformedEntity{route: route_id, stop: stop_id},
-            %InformedEntity{route: route_id, stop: child_stop_id}
-          ]
-        )
-
-      assert [
-               %Combination{route: ^route_id, stop: ^stop_id, direction: 0},
-               %Combination{route: ^route_id, stop: ^stop_id, direction: 1}
-             ] =
-               SummaryEntityBuilder.relevant_combinations(alert, global.stops, global)
-               |> Enum.sort_by(&{&1.route, &1.stop, &1.trip, &1.direction})
-    end
-
-    test "filters combinations covered by another stop wildcard" do
-      global = GlobalDataCache.get_data()
-
-      stop_id = "place-wlsta"
-      route_id = "Red"
-
-      alert =
-        build(:alert,
-          cause: :maintenance,
-          effect: :suspension,
-          informed_entity: [
-            %InformedEntity{route: route_id, stop: nil},
-            %InformedEntity{route: route_id, stop: stop_id}
-          ]
-        )
-
-      assert [
-               %Combination{route: ^route_id, stop: nil, direction: 0},
-               %Combination{route: ^route_id, stop: nil, direction: 1}
-             ] =
-               SummaryEntityBuilder.relevant_combinations(alert, global.stops, global)
-               |> Enum.sort_by(&{&1.route, &1.stop, &1.trip, &1.direction})
-    end
-
-    test "filters combinations covered by another route wildcard" do
-      global = GlobalDataCache.get_data()
-
-      route_id = "Red"
-      stop_id = "place-wlsta"
-
-      alert =
-        build(:alert,
-          cause: :maintenance,
-          effect: :suspension,
-          informed_entity: [
-            %InformedEntity{route: nil, stop: stop_id},
-            %InformedEntity{route: route_id, stop: stop_id}
-          ]
-        )
-
-      assert [
-               %Combination{route: nil, stop: ^stop_id, direction: 0},
-               %Combination{route: nil, stop: ^stop_id, direction: 1}
-             ] =
-               SummaryEntityBuilder.relevant_combinations(alert, global.stops, global)
-               |> Enum.sort_by(&{&1.route, &1.stop, &1.trip, &1.direction})
-    end
-
-    test "filters combinations covered by another trip wildcard" do
-      stop = build(:stop, parent_station_id: nil)
-      child_stop = build(:stop, parent_station_id: stop.id)
-      route = build(:route, type: :heavy_rail, long_name: "Red Line")
-      trip = build(:trip, route_id: route.id, stop_ids: [child_stop.id])
-
-      global = GlobalDataCache.get_data()
-
-      route_id = "Red"
-      stop_id = "place-wlsta"
-      trip_id = trip.id
-
-      alert =
-        build(:alert,
-          cause: :maintenance,
-          effect: :suspension,
-          informed_entity: [
-            %InformedEntity{route: nil, stop: stop_id, trip: nil},
-            %InformedEntity{route: route_id, stop: stop_id, trip: trip_id, direction_id: 1}
-          ]
-        )
-
-      assert [
-               %Combination{route: nil, stop: ^stop_id, direction: 0},
-               %Combination{route: nil, stop: ^stop_id, direction: 1}
-             ] =
-               SummaryEntityBuilder.relevant_combinations(alert, global.stops, global)
-               |> Enum.sort_by(&{&1.route, &1.stop, &1.trip, &1.direction})
+               SummaryEntityBuilder.relevant_combinations(alert, {%{}, %{}, global})
+               |> Enum.sort_by(&{&1.route, &1.stop, &1.direction, &1.trip})
     end
   end
 
@@ -424,80 +833,51 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
     test "removes duplicate summaries" do
       assert [
                %SummaryEntity{
-                 alert_id: "alert",
-                 route_id: "route",
-                 stop_id: "stop1",
-                 trip_id: nil,
-                 direction_id: nil,
-                 summary: "identical summary"
-               },
-               %SummaryEntity{
-                 alert_id: "alert",
-                 route_id: "route",
-                 stop_id: "stop2",
+                 route_id: nil,
+                 stop_id: nil,
                  trip_id: nil,
                  direction_id: 0,
-                 summary: "different summary 1"
+                 summary: "direction 0 summary"
                },
                %SummaryEntity{
-                 alert_id: "alert",
-                 route_id: "route",
-                 stop_id: "stop2",
+                 route_id: nil,
+                 stop_id: nil,
                  trip_id: nil,
                  direction_id: 1,
-                 summary: "different summary 2"
-               },
-               %SummaryEntity{
-                 alert_id: "alert",
-                 route_id: "route",
-                 stop_id: "stop3",
-                 trip_id: nil,
-                 direction_id: nil,
-                 summary: "nil direction summary"
+                 summary: "direction 1 summary"
                }
              ] =
                SummaryEntityBuilder.dedup_summaries([
                  %SummaryEntity{
-                   alert_id: "alert",
                    route_id: "route",
                    stop_id: "stop1",
                    trip_id: nil,
                    direction_id: 0,
-                   summary: "identical summary"
+                   summary: "direction 0 summary"
                  },
                  %SummaryEntity{
-                   alert_id: "alert",
                    route_id: "route",
                    stop_id: "stop1",
                    trip_id: nil,
                    direction_id: 1,
-                   summary: "identical summary"
+                   summary: "direction 1 summary"
                  },
                  %SummaryEntity{
-                   alert_id: "alert",
                    route_id: "route",
                    stop_id: "stop2",
                    trip_id: nil,
                    direction_id: 0,
-                   summary: "different summary 1"
+                   summary: "direction 0 summary"
                  },
                  %SummaryEntity{
-                   alert_id: "alert",
                    route_id: "route",
                    stop_id: "stop2",
                    trip_id: nil,
                    direction_id: 1,
-                   summary: "different summary 2"
-                 },
-                 %SummaryEntity{
-                   alert_id: "alert",
-                   route_id: "route",
-                   stop_id: "stop3",
-                   trip_id: nil,
-                   direction_id: nil,
-                   summary: "nil direction summary"
+                   summary: "direction 1 summary"
                  }
                ])
+               |> Enum.sort_by(&{&1.route_id, &1.stop_id, &1.direction_id, &1.trip_id})
     end
   end
 end

--- a/test/mobile_app_backend/alerts/summary_entity_builder_test.exs
+++ b/test/mobile_app_backend/alerts/summary_entity_builder_test.exs
@@ -93,7 +93,15 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
       ]
 
       route_id = "Red"
-      trip = build(:trip, route_id: route_id, stop_ids: stops)
+
+      trip =
+        build(:trip,
+          direction_id: 1,
+          route_id: route_id,
+          route_pattern_id: "Red-3-1",
+          stop_ids: stops
+        )
+
       trip_id = trip.id
 
       schedules =
@@ -146,13 +154,6 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
                },
                %SummaryEntity{
                  route_id: nil,
-                 stop_id: "place-asmnl",
-                 direction_id: nil,
-                 trip_id: nil,
-                 summary: "Service suspended on Red Line"
-               },
-               %SummaryEntity{
-                 route_id: nil,
                  stop_id: "place-brdwy",
                  direction_id: nil,
                  trip_id: nil,
@@ -193,13 +194,6 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
                  trip_id: nil,
                  summary:
                    "12:09 PM train from Downtown Crossing is suspended today due to maintenance"
-               },
-               %SummaryEntity{
-                 route_id: nil,
-                 stop_id: "place-fldcr",
-                 direction_id: nil,
-                 trip_id: nil,
-                 summary: "Service suspended on Red Line"
                },
                %SummaryEntity{
                  route_id: nil,
@@ -260,20 +254,6 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
                },
                %SummaryEntity{
                  route_id: nil,
-                 stop_id: "place-shmnl",
-                 direction_id: nil,
-                 trip_id: nil,
-                 summary: "Service suspended on Red Line"
-               },
-               %SummaryEntity{
-                 route_id: nil,
-                 stop_id: "place-smmnl",
-                 direction_id: nil,
-                 trip_id: nil,
-                 summary: "Service suspended on Red Line"
-               },
-               %SummaryEntity{
-                 route_id: nil,
                  stop_id: "place-sstat",
                  direction_id: nil,
                  trip_id: nil,
@@ -295,154 +275,7 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
       assert Enum.sort_by(entities, &{&1.route_id, &1.stop_id, &1.direction_id, &1.trip_id}) == [
                %SummaryEntity{
                  route_id: nil,
-                 stop_id: "place-alfcl",
-                 direction_id: nil,
-                 trip_id: nil,
-                 summary: "This train is suspended today due to maintenance"
-               },
-               %SummaryEntity{
-                 route_id: nil,
-                 stop_id: "place-andrw",
-                 direction_id: nil,
-                 trip_id: nil,
-                 summary: "This train is suspended today due to maintenance"
-               },
-               %SummaryEntity{
-                 route_id: nil,
-                 stop_id: "place-asmnl",
-                 direction_id: nil,
-                 trip_id: nil,
-                 summary: "Service suspended on Red Line"
-               },
-               %SummaryEntity{
-                 route_id: nil,
-                 stop_id: "place-brdwy",
-                 direction_id: nil,
-                 trip_id: nil,
-                 summary: "This train is suspended today due to maintenance"
-               },
-               %SummaryEntity{
-                 route_id: nil,
-                 stop_id: "place-brntn",
-                 direction_id: nil,
-                 trip_id: nil,
-                 summary: "This train is suspended today due to maintenance"
-               },
-               %SummaryEntity{
-                 route_id: nil,
-                 stop_id: "place-chmnl",
-                 direction_id: nil,
-                 trip_id: nil,
-                 summary: "This train is suspended today due to maintenance"
-               },
-               %SummaryEntity{
-                 route_id: nil,
-                 stop_id: "place-cntsq",
-                 direction_id: nil,
-                 trip_id: nil,
-                 summary: "This train is suspended today due to maintenance"
-               },
-               %SummaryEntity{
-                 route_id: nil,
-                 stop_id: "place-davis",
-                 direction_id: nil,
-                 trip_id: nil,
-                 summary: "This train is suspended today due to maintenance"
-               },
-               %SummaryEntity{
-                 route_id: nil,
-                 stop_id: "place-dwnxg",
-                 direction_id: nil,
-                 trip_id: nil,
-                 summary: "This train is suspended today due to maintenance"
-               },
-               %SummaryEntity{
-                 route_id: nil,
-                 stop_id: "place-fldcr",
-                 direction_id: nil,
-                 trip_id: nil,
-                 summary: "Service suspended on Red Line"
-               },
-               %SummaryEntity{
-                 route_id: nil,
-                 stop_id: "place-harsq",
-                 direction_id: nil,
-                 trip_id: nil,
-                 summary: "This train is suspended today due to maintenance"
-               },
-               %SummaryEntity{
-                 route_id: nil,
-                 stop_id: "place-jfk",
-                 direction_id: nil,
-                 trip_id: nil,
-                 summary: "This train is suspended today due to maintenance"
-               },
-               %SummaryEntity{
-                 route_id: nil,
-                 stop_id: "place-knncl",
-                 direction_id: nil,
-                 trip_id: nil,
-                 summary: "This train is suspended today due to maintenance"
-               },
-               %SummaryEntity{
-                 route_id: nil,
-                 stop_id: "place-nqncy",
-                 direction_id: nil,
-                 trip_id: nil,
-                 summary: "This train is suspended today due to maintenance"
-               },
-               %SummaryEntity{
-                 route_id: nil,
-                 stop_id: "place-pktrm",
-                 direction_id: nil,
-                 trip_id: nil,
-                 summary: "This train is suspended today due to maintenance"
-               },
-               %SummaryEntity{
-                 route_id: nil,
-                 stop_id: "place-portr",
-                 direction_id: nil,
-                 trip_id: nil,
-                 summary: "This train is suspended today due to maintenance"
-               },
-               %SummaryEntity{
-                 route_id: nil,
-                 stop_id: "place-qamnl",
-                 direction_id: nil,
-                 trip_id: nil,
-                 summary: "This train is suspended today due to maintenance"
-               },
-               %SummaryEntity{
-                 route_id: nil,
-                 stop_id: "place-qnctr",
-                 direction_id: nil,
-                 trip_id: nil,
-                 summary: "This train is suspended today due to maintenance"
-               },
-               %SummaryEntity{
-                 route_id: nil,
-                 stop_id: "place-shmnl",
-                 direction_id: nil,
-                 trip_id: nil,
-                 summary: "Service suspended on Red Line"
-               },
-               %SummaryEntity{
-                 route_id: nil,
-                 stop_id: "place-smmnl",
-                 direction_id: nil,
-                 trip_id: nil,
-                 summary: "Service suspended on Red Line"
-               },
-               %SummaryEntity{
-                 route_id: nil,
-                 stop_id: "place-sstat",
-                 direction_id: nil,
-                 trip_id: nil,
-                 summary: "This train is suspended today due to maintenance"
-               },
-               %SummaryEntity{
-                 route_id: nil,
-                 stop_id: "place-wlsta",
+                 stop_id: nil,
                  direction_id: nil,
                  trip_id: nil,
                  summary: "This train is suspended today due to maintenance"
@@ -648,10 +481,36 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
     test "trip entities set trip" do
       route_id = "Red"
       stop_id = "place-wlsta"
-      trip = build(:trip, direction_id: 1)
+
+      trip =
+        build(:trip,
+          direction_id: 1,
+          route_pattern_id: "Red-3-1",
+          stop_ids: [
+            "place-brntn",
+            "place-qamnl",
+            "place-qnctr",
+            "place-wlsta",
+            "place-nqncy",
+            "place-jfk",
+            "place-andrw",
+            "place-brdwy",
+            "place-sstat",
+            "place-dwnxg",
+            "place-pktrm",
+            "place-chmnl",
+            "place-knncl",
+            "place-cntsq",
+            "place-harsq",
+            "place-portr",
+            "place-davis",
+            "place-alfcl"
+          ]
+        )
 
       global = GlobalDataCache.get_data()
 
+      pattern = global.route_patterns[trip.route_pattern_id]
       trip_id = trip.id
 
       alert =
@@ -667,14 +526,12 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
         for stop <- [
               "alfcl",
               "andrw",
-              "asmnl",
               "brdwy",
               "brntn",
               "chmnl",
               "cntsq",
               "davis",
               "dwnxg",
-              "fldcr",
               "harsq",
               "jfk",
               "knncl",
@@ -683,8 +540,6 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
               "portr",
               "qamnl",
               "qnctr",
-              "shmnl",
-              "smmnl",
               "sstat",
               "wlsta"
             ] do
@@ -693,7 +548,7 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
             stop: "place-" <> stop,
             direction: 1,
             trip: trip.id,
-            patterns: RoutePattern.get_relevant_patterns(route_id, "place-" <> stop, 1, global)
+            patterns: [pattern]
           }
         end
 

--- a/test/mobile_app_backend/alerts/with_summary_pub_sub_test.exs
+++ b/test/mobile_app_backend/alerts/with_summary_pub_sub_test.exs
@@ -5,6 +5,7 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSubTest do
   alias MBTAV3API.Store
   alias MobileAppBackend.Alerts
   alias MobileAppBackend.Alerts.AlertWithSummaries
+  alias MobileAppBackend.Alerts.SummaryEntity
   alias MobileAppBackend.Alerts.WithSummaryPubSub
   import Mox
   import Test.Support.Helpers
@@ -113,7 +114,11 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSubTest do
 
       assert_receive {:new_alerts, new_alerts}
 
-      assert to_alert_map([AlertWithSummaries.from_alert(alert_1, [])]) == new_alerts
+      assert to_alert_map([
+               AlertWithSummaries.from_alert(alert_1, [
+                 %SummaryEntity{summary: "Delay until further notice"}
+               ])
+             ]) == new_alerts
 
       # Doesn't re-send the same alerts that have already been seen
       WithSummaryPubSub.handle_info(:broadcast, state)
@@ -125,10 +130,14 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSubTest do
 
       assert_receive {:new_alerts, new_alerts}
 
-      assert to_alert_map([AlertWithSummaries.from_alert(alert_2, [])]) == new_alerts
+      assert to_alert_map([
+               AlertWithSummaries.from_alert(alert_2, [%SummaryEntity{summary: "Delay"}])
+             ]) == new_alerts
     end
 
     test ":broadcast filters out upcoming single tracking alerts", state do
+      route = build(:route)
+
       single_tracking_future =
         build(:alert,
           id: "a_1",
@@ -138,7 +147,8 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSubTest do
               start: DateTime.add(DateTime.now!("America/New_York"), 10, :minute),
               end: nil
             }
-          ]
+          ],
+          informed_entity: [%Alert.InformedEntity{route: route.id}]
         )
 
       single_tracking_now =
@@ -150,7 +160,8 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSubTest do
               start: DateTime.add(DateTime.now!("America/New_York"), -10, :minute),
               end: nil
             }
-          ]
+          ],
+          informed_entity: [%Alert.InformedEntity{route: route.id}]
         )
 
       AlertsStoreMock
@@ -161,14 +172,18 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSubTest do
       GlobalDataCacheMock
       |> stub(:default_key, fn -> :default_key end)
       |> stub(:get_data, fn _ ->
-        %{route_patterns: %{}}
+        %{route: %{route.id => route}, route_patterns: %{}}
       end)
 
       RepositoryMock |> stub(:stops, fn _, _ -> {:ok, %{data: []}} end)
 
       WithSummaryPubSub.handle_info(:broadcast, state)
 
-      assert to_alert_map([AlertWithSummaries.from_alert(single_tracking_now, [])]) ==
+      assert to_alert_map([
+               AlertWithSummaries.from_alert(single_tracking_now, [
+                 %SummaryEntity{summary: "Delay until further notice"}
+               ])
+             ]) ==
                WithSummaryPubSub.subscribe(ets_table: state.last_dispatched_table_name)
 
       WithSummaryPubSub.handle_info(:broadcast, state)


### PR DESCRIPTION
### Summary

_Ticket:_ [Alert Summary Consolidation | Backend generates all necessary summaries](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1216565516165771)

This wound up being more complicated than I thought, and I didn’t exactly think it would be easy.

I do not think there are other cases we’re missing.

### Testing

Updated unit tests to expect new behavior.