### PR TITLE
tmp(Store.Alerts): Add symphony to upcoming GL disruption

### DIFF
--- a/lib/mbta_v3_api/store/alerts.ex
+++ b/lib/mbta_v3_api/store/alerts.ex
@@ -74,114 +74,42 @@ defmodule MBTAV3API.Store.Alerts.Impl do
     }
   end
 
-  # Convert the struct to a record for ETS
-  # override alert 679818 behavior to temporarily address GL North Station alert boundary issue
-  defp to_record(%Alert{id: "679818"} = alert) do
+  defp to_record(%Alert{id: "1022119"} = alert) do
     entities =
       alert.informed_entity
       |> Enum.concat([
         %Alert.InformedEntity{
-          stop: "70203",
+          stop: "place-symcl",
           direction_id: 1,
           route_type: :light_rail,
-          route: "Green-B",
+          route: "Green-E",
           activities: [:board, :exit, :ride]
         },
         %Alert.InformedEntity{
-          stop: "70203",
+          stop: "place-symcl",
+          direction_id: 0,
+          route_type: :light_rail,
+          route: "Green-E",
+          activities: [:board, :exit, :ride]
+        },
+        %Alert.InformedEntity{
+          stop: "70241",
+          direction_id: 0,
+          route_type: :light_rail,
+          route: "Green-E",
+          activities: [:board, :exit, :ride]
+        },
+        %Alert.InformedEntity{
+          stop: "70242",
           direction_id: 1,
           route_type: :light_rail,
-          route: "Green-C",
-          activities: [:board, :exit, :ride]
-        },
-        %Alert.InformedEntity{
-          stop: "70204",
-          direction_id: 0,
-          route_type: :light_rail,
-          route: "Green-B",
-          activities: [:board, :exit, :ride]
-        },
-        %Alert.InformedEntity{
-          stop: "70204",
-          direction_id: 0,
-          route_type: :light_rail,
-          route: "Green-C",
-          activities: [:board, :exit, :ride]
-        },
-        %Alert.InformedEntity{
-          stop: "70206",
-          direction_id: 0,
-          route_type: :light_rail,
-          route: "Green-B",
-          activities: [:board, :ride]
-        },
-        %Alert.InformedEntity{
-          stop: "70206",
-          direction_id: 0,
-          route_type: :light_rail,
-          route: "Green-C",
-          activities: [:board, :ride]
-        },
-        %Alert.InformedEntity{
-          stop: "place-haecl",
-          direction_id: 0,
-          route_type: :light_rail,
-          route: "Green-B",
-          activities: [:board, :exit, :ride]
-        },
-        %Alert.InformedEntity{
-          stop: "place-haecl",
-          direction_id: 1,
-          route_type: :light_rail,
-          route: "Green-B",
-          activities: [:board, :exit, :ride]
-        },
-        %Alert.InformedEntity{
-          stop: "place-haecl",
-          direction_id: 0,
-          route_type: :light_rail,
-          route: "Green-C",
-          activities: [:board, :exit, :ride]
-        },
-        %Alert.InformedEntity{
-          stop: "place-haecl",
-          direction_id: 1,
-          route_type: :light_rail,
-          route: "Green-C",
-          activities: [:board, :exit, :ride]
-        },
-        %Alert.InformedEntity{
-          stop: "place-north",
-          direction_id: 0,
-          route_type: :light_rail,
-          route: "Green-B",
-          activities: [:board, :exit, :ride]
-        },
-        %Alert.InformedEntity{
-          stop: "place-north",
-          direction_id: 1,
-          route_type: :light_rail,
-          route: "Green-B",
-          activities: [:board, :exit, :ride]
-        },
-        %Alert.InformedEntity{
-          stop: "place-north",
-          direction_id: 0,
-          route_type: :light_rail,
-          route: "Green-C",
-          activities: [:board, :exit, :ride]
-        },
-        %Alert.InformedEntity{
-          stop: "place-north",
-          direction_id: 1,
-          route_type: :light_rail,
-          route: "Green-C",
+          route: "Green-E",
           activities: [:board, :exit, :ride]
         }
       ])
 
     {
-      "679818",
+      "1022119",
       %{alert | informed_entity: entities}
     }
   end


### PR DESCRIPTION
### Summary

_Ticket:_ [Backend patch symphony alert to resolve diagram issue](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1216965173223588?focus=true)

<!-- What is this PR for? -->
Hardcode symphony into the upcoming GL alert to fix diagram. Also removes an old hardcoded informed entity override 

### Testing

Ran locally with my computer time set to 8/1, confirmed that the dashed line on the E branch continues through Symphony
<img width="45%" height="1512" alt="image" src="https://github.com/user-attachments/assets/165ffabe-210a-4189-a658-ad07bec8d942" />


<!-- What testing have you done? -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216563453881565