### PR TITLE
fix(renovate): correctly match full line in regexes

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,7 +30,7 @@
         ".tool-versions"
       ],
       "matchStrings": [
-        "^erlang\\s+(?<currentValue>[\\d.]+)$"
+        "(^|\\n)erlang\\s+(?<currentValue>[\\d.]+)(\\n|$)"
       ],
       "depNameTemplate": "erlang",
       "packageNameTemplate": "hexpm/elixir",
@@ -45,7 +45,7 @@
         ".tool-versions"
       ],
       "matchStrings": [
-        "-otp-(?<currentValue>\\d+)"
+        "-otp-(?<currentValue>\\d+)(\\n|$)"
       ],
       "depNameTemplate": "erlang",
       "packageNameTemplate": "hexpm/elixir",
@@ -60,7 +60,7 @@
         "Dockerfile"
       ],
       "matchStrings": [
-        "^ARG ERLANG_VERSION=(?<currentValue>[\\d.]+)$"
+        "(^|\\n)ARG ERLANG_VERSION=(?<currentValue>[\\d.]+)(\\n|$)"
       ],
       "depNameTemplate": "erlang",
       "packageNameTemplate": "hexpm/elixir",
@@ -75,7 +75,7 @@
         ".tool-versions"
       ],
       "matchStrings": [
-        "^elixir\\s+(?<currentValue>[\\d.]+)-otp-\\d+$"
+        "(^|\\n)elixir\\s+(?<currentValue>[\\d.]+)-otp-\\d+(\\n|$)"
       ],
       "depNameTemplate": "elixir",
       "packageNameTemplate": "hexpm/elixir",
@@ -90,7 +90,7 @@
         "Dockerfile"
       ],
       "matchStrings": [
-        "^ARG ELIXIR_VERSION=(?<currentValue>[\\d.]+)$"
+        "(^|\\n)ARG ELIXIR_VERSION=(?<currentValue>[\\d.]+)(\\n|$)"
       ],
       "depNameTemplate": "elixir",
       "packageNameTemplate": "hexpm/elixir",
@@ -105,7 +105,7 @@
         "Dockerfile"
       ],
       "matchStrings": [
-        "^ARG ALPINE_VERSION=(?<currentValue>[\\d.]+)$"
+        "(^|\\n)ARG ALPINE_VERSION=(?<currentValue>[\\d.]+)(\\n|$)"
       ],
       "depNameTemplate": "alpine",
       "packageNameTemplate": "hexpm/elixir",


### PR DESCRIPTION
### Summary

_Ticket:_ [Try renovate instead of dependabot for backend](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215606746972638)

Evidently, I had somehow gotten it into my head that Renovate would run `matchStrings` regexes in a way that would let `^` and `$` match the beginning and end of an individual line; that is not true. `\A` and `\Z` are start- and end-of-line anchors in some regex engines, but not all, so I’m using `(^|\n)` and `(\n|$)` instead. In all probability, I don’t need those at all because nothing else will match in the middle of a line, but I’d rather have them and not need them than need them and not have them.

### Testing

Not really testable.