### PR TITLE
chore(renovate): group erlang/elixir/alpine updates together

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,9 +10,10 @@
   "packageRules": [
     {
       "description": "manage erlang/elixir/alpine version directly from hexpm docker image",
-      "matchPackageNames": [
+      "matchDepNames": [
         "erlang",
         "elixir",
+        "hexpm/elixir",
         "alpine"
       ],
       "matchManagers": [
@@ -20,6 +21,36 @@
         "dockerfile"
       ],
       "enabled": false
+    },
+    {
+      "description": "propose erlang/elixir/alpine updates at separate levels in parallel",
+      "matchDepNames": [
+        "erlang",
+        "elixir",
+        "alpine"
+      ],
+      "matchManagers": [
+        "regex"
+      ],
+      "separateMajorMinor": true,
+      "separateMinorPatch": true,
+      "separateMultipleMajor": true,
+      "separateMultipleMinor": true
+    },
+    {
+      "description": "group erlang/elixir/alpine patch updates together",
+      "matchDepNames": [
+        "erlang",
+        "elixir",
+        "alpine"
+      ],
+      "matchManagers": [
+        "regex"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "groupName": "runtime (patch)"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
### Summary

_Ticket:_ [Try renovate instead of dependabot for backend](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215606746972638)

We are successfully receiving updates for Erlang, Elixir, and Alpine, but not every combination actually exists, so we can’t always upgrade piecemeal. As far as I can tell, this should give us all our patch updates together at once, and any minor updates separately so that we can pick the versions that work from those.

### Testing

Not realistically testable.