### PR TITLE
chore(renovate): fix group name and add changelog links

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,7 +50,37 @@
       "matchUpdateTypes": [
         "patch"
       ],
-      "groupName": "runtime (patch)"
+      "groupName": "erlang/elixir/alpine"
+    },
+    {
+      "description": "link to erlang release notes",
+      "matchDepNames": [
+        "erlang"
+      ],
+      "matchManagers": [
+        "regex"
+      ],
+      "changelogUrl": "https://www.erlang.org/patches/OTP-{{ newVersion }}"
+    },
+    {
+      "description": "link to elixir release notes",
+      "matchDepNames": [
+        "elixir"
+      ],
+      "matchManagers": [
+        "regex"
+      ],
+      "changelogUrl": "https://github.com/elixir-lang/elixir/releases/tag/v{{ newVersion }}"
+    },
+    {
+      "description": "link to alpine news page",
+      "matchDepNames": [
+        "alpine"
+      ],
+      "matchManagers": [
+        "regex"
+      ],
+      "changelogUrl": "https://alpinelinux.org/posts/"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
### Summary

_Ticket:_ [Try renovate instead of dependabot for backend](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215606746972638)

The Renovate setup is officially working now — https://github.com/mbta/mobile_app_backend/pull/659 has the exact set of things I wanted it to, including the patch Alpine release and not the minor Alpine release — but it could use just a bit more cleaning up. I manually added `(patch)` to the group name even though Renovate adds that automatically, which is ugly, and also it’d be nice if it was easier to see what was new in any given update we’re installing this way.

### Testing

Not testable.