### PR TITLE
fix: minor updates from load testing alert summaries

### DIFF
--- a/lib/mobile_app_backend/alerts/summary_entity_builder.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity_builder.ex
@@ -260,30 +260,38 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
     patterns = RoutePattern.get_relevant_patterns(route_id, nil, direction_id, global)
 
     cond do
-      not is_nil(trip_id) ->
+      not is_nil(trip_id) && not is_nil(trips[trip_id]) ->
         # for trip-specific alerts, we usually need the stop id for trip identity,
         # and we only want the stops the trip will actually visit
         trip = trips[trip_id]
 
-        if is_nil(trip) do
-          Logger.error("unknown trip #{trip_id} for route #{route_id} direction #{direction_id}")
-          []
-        else
-          pattern = Enum.find(patterns, &(&1.id == trip.route_pattern_id))
-          stop_ids = trip.stop_ids
+        pattern = Enum.find(patterns, &(&1.id == trip.route_pattern_id))
+        stop_ids = trip.stop_ids
 
-          Enum.map(stop_ids, fn stop_id ->
-            stop_id = Stop.parent_id_if_exists(stop_id, global.stops)
+        Enum.map(stop_ids, fn stop_id ->
+          stop_id = Stop.parent_id_if_exists(stop_id, global.stops)
 
-            %Combination{
-              route: route_id,
-              stop: stop_id,
-              direction: direction_id,
-              trip: trip_id,
-              patterns: List.wrap(pattern)
-            }
-          end)
-        end
+          %Combination{
+            route: route_id,
+            stop: stop_id,
+            direction: direction_id,
+            trip: trip_id,
+            patterns: List.wrap(pattern)
+          }
+        end)
+
+      not is_nil(trip_id) && is_nil(trips[trip_id]) ->
+        Logger.error("unknown trip #{trip_id} for route #{route_id} direction #{direction_id}")
+
+        [
+          %Combination{
+            route: route_id,
+            stop: nil,
+            direction: direction_id,
+            trip: trip_id,
+            patterns: []
+          }
+        ]
 
       String.starts_with?(route_id, "Green-") or length(patterns) > 1 ->
         # for branching routes or the Green Line, the summary may differ by stop id

--- a/lib/mobile_app_backend/alerts/summary_entity_builder.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity_builder.ex
@@ -264,20 +264,26 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
         # for trip-specific alerts, we usually need the stop id for trip identity,
         # and we only want the stops the trip will actually visit
         trip = trips[trip_id]
-        pattern = Enum.find(patterns, &(&1.id == trip.route_pattern_id))
-        stop_ids = trip.stop_ids
 
-        Enum.map(stop_ids, fn stop_id ->
-          stop_id = Stop.parent_id_if_exists(stop_id, global.stops)
+        if is_nil(trip) do
+          Logger.error("unknown trip #{trip_id} for route #{route_id} direction #{direction_id}")
+          []
+        else
+          pattern = Enum.find(patterns, &(&1.id == trip.route_pattern_id))
+          stop_ids = trip.stop_ids
 
-          %Combination{
-            route: route_id,
-            stop: stop_id,
-            direction: direction_id,
-            trip: trip_id,
-            patterns: [pattern]
-          }
-        end)
+          Enum.map(stop_ids, fn stop_id ->
+            stop_id = Stop.parent_id_if_exists(stop_id, global.stops)
+
+            %Combination{
+              route: route_id,
+              stop: stop_id,
+              direction: direction_id,
+              trip: trip_id,
+              patterns: [pattern]
+            }
+          end)
+        end
 
       String.starts_with?(route_id, "Green-") or length(patterns) > 1 ->
         # for branching routes or the Green Line, the summary may differ by stop id
@@ -388,8 +394,15 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
                include: [trip: :stops],
                sort: {:stop_sequence, :asc}
              ) do
-          {:ok, %{data: schedules, included: %{trips: trips}}} -> {schedules, trips}
-          _ -> {nil, nil}
+          {:ok, %{data: schedules, included: %{trips: trips}}} ->
+            {schedules, trips}
+
+          response ->
+            Logger.error(
+              "failed to fetch schedules for trip_ids #{inspect(trip_ids)} response=#{inspect(response)}"
+            )
+
+            {nil, nil}
         end
     end
   end

--- a/lib/mobile_app_backend/alerts/summary_entity_builder.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity_builder.ex
@@ -264,7 +264,6 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
         # for trip-specific alerts, we usually need the stop id for trip identity,
         # and we only want the stops the trip will actually visit
         trip = trips[trip_id]
-
         pattern = Enum.find(patterns, &(&1.id == trip.route_pattern_id))
         stop_ids = trip.stop_ids
 

--- a/lib/mobile_app_backend/alerts/summary_entity_builder.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity_builder.ex
@@ -280,7 +280,7 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
               stop: stop_id,
               direction: direction_id,
               trip: trip_id,
-              patterns: [pattern]
+              patterns: List.wrap(pattern)
             }
           end)
         end

--- a/lib/mobile_app_backend/application.ex
+++ b/lib/mobile_app_backend/application.ex
@@ -54,7 +54,7 @@ defmodule MobileAppBackend.Application do
         if Application.get_env(:mobile_app_backend, :start_pub_subs?, true) do
           [
             MobileAppBackend.Alerts.PubSub,
-            MobileAppBackend.Alerts.WithSummaryPubSub,
+          #  MobileAppBackend.Alerts.WithSummaryPubSub,
             MobileAppBackend.Vehicles.PubSub,
             MobileAppBackend.Predictions.PubSub
           ]

--- a/lib/mobile_app_backend/application.ex
+++ b/lib/mobile_app_backend/application.ex
@@ -54,7 +54,7 @@ defmodule MobileAppBackend.Application do
         if Application.get_env(:mobile_app_backend, :start_pub_subs?, true) do
           [
             MobileAppBackend.Alerts.PubSub,
-          #  MobileAppBackend.Alerts.WithSummaryPubSub,
+            MobileAppBackend.Alerts.WithSummaryPubSub,
             MobileAppBackend.Vehicles.PubSub,
             MobileAppBackend.Predictions.PubSub
           ]

--- a/lib/mobile_app_backend/application.ex
+++ b/lib/mobile_app_backend/application.ex
@@ -54,6 +54,7 @@ defmodule MobileAppBackend.Application do
         if Application.get_env(:mobile_app_backend, :start_pub_subs?, true) do
           [
             MobileAppBackend.Alerts.PubSub,
+            MobileAppBackend.Alerts.WithSummaryPubSub,
             MobileAppBackend.Vehicles.PubSub,
             MobileAppBackend.Predictions.PubSub
           ]

--- a/load_testing/locustfile.py
+++ b/load_testing/locustfile.py
@@ -1,6 +1,5 @@
 import datetime
 import random
-from hashlib import sha256
 from zoneinfo import ZoneInfo
 
 import requests

--- a/load_testing/locustfile.py
+++ b/load_testing/locustfile.py
@@ -99,7 +99,7 @@ class MobileAppUser(HttpUser, PhoenixChannelUser):
                 self.alerts_channel.leave()
                 self.alerts_channel = None
         
-        self.alerts_channel = self.socket.channel("alerts")
+        self.alerts_channel = self.socket.channel("alerts:v3")
         self.alerts_channel.join()
     
     def fetch_schedules_for_stops(self, stop_ids):

--- a/load_testing/locustfile.py
+++ b/load_testing/locustfile.py
@@ -42,12 +42,12 @@ def on_init(environment, **_kwargs):
     initial_global_response = requests.get(f"{host}/api/global")
     initial_global_headers = {}
     if initial_global_response.status_code == 200:
-        initial_global_headers = {"if-none-match": sha256(initial_global_response.text.encode()).hexdigest()}
+        initial_global_headers = {"if-none-match": initial_global_response.headers.get("etag", "")}
 
     initial_rail_response = requests.get(f"{host}/api/shapes/map-friendly/rail")
     initial_rail_headers = {}
     if initial_rail_response.status_code == 200:
-        initial_rail_headers = {"if-none-match": sha256(initial_rail_response.text.encode()).hexdigest()}
+        initial_rail_headers = {"if-none-match": initial_rail_response.headers.get("etag", "")}
 
 
 @events.init_command_line_parser.add_listener
@@ -90,11 +90,11 @@ class MobileAppUser(HttpUser, PhoenixChannelUser):
     def app_reload(self):
         global_response = self.client.get("/api/global", headers=self.global_headers)
         if global_response.status_code == 200:
-            self.global_headers = {"if-none-match": sha256(global_response.text.encode()).hexdigest()}
+            self.global_headers = {"if-none-match": global_response.headers.get("etag", "")}
         
         rail_response = self.client.get("/api/shapes/map-friendly/rail", headers=self.rail_headers)
         if rail_response.status_code == 200:
-            self.rail_headers = {"if-none-match": sha256(rail_response.text.encode()).hexdigest()}
+            self.rail_headers = {"if-none-match": global_response.headers.get("etag", "")}
 
         if self.alerts_channel is not None:
                 self.alerts_channel.leave()
@@ -169,7 +169,12 @@ class MobileAppUser(HttpUser, PhoenixChannelUser):
             self.stop_id = random.choice(all_stations_and_bus)
         predictions_for_stop = requests.get(
             "https://api-v3.mbta.com/predictions", 
-            params={"stop": self.stop_id}, headers=self.v3_api_headers).json()["data"]
+            params={"stop": self.stop_id}, headers=self.v3_api_headers).json()
+        if predictions_for_stop is not None and "data" in predictions_for_stop:
+            predictions_for_stop = predictions_for_stop["data"]
+        else:
+            print(f"Predictions fetch fail - stop={self.stop_id} response={predictions_for_stop}")
+            predictions_for_stop = []
         if (len(predictions_for_stop) != 0):
             prediction = predictions_for_stop[0]
             trip_id = prediction["relationships"]["trip"]["data"]["id"]

--- a/test/mobile_app_backend/alerts/alert_summary_test.exs
+++ b/test/mobile_app_backend/alerts/alert_summary_test.exs
@@ -2114,6 +2114,48 @@ defmodule MobileAppBackend.Alerts.AlertSummaryTest do
                )
     end
 
+    # This test specifies the current behavior that should be changed.
+    test "trip specific reminder no schedules today" do
+      now = ~B[2026-03-12 12:00:00]
+      stop = build(:stop, name: "Ruggles")
+      route = build(:route)
+      pattern = build(:route_pattern, route_id: route.id)
+      trip = build(:trip, route_pattern_id: pattern.id)
+
+      alert =
+        build(:alert,
+          active_period: [
+            %Alert.ActivePeriod{
+              start: now |> DateTime.add(1, :day) |> DateTime.add(-2, :hour),
+              end: now |> DateTime.add(1, :day) |> DateTime.add(2, :hour)
+            }
+          ],
+          effect: :suspension,
+          informed_entity: [%Alert.InformedEntity{trip: trip.id}]
+        )
+
+      assert %MobileAppBackend.Alerts.AlertSummary.Standard{
+               effect: :suspension,
+               is_update: false,
+               location: nil,
+               recurrence: nil,
+               timeframe: %MobileAppBackend.Alerts.AlertSummary.Timeframe.StartingTomorrow{}
+             } =
+               AlertSummary.summarizing(
+                 alert,
+                 stop.id,
+                 0,
+                 [pattern],
+                 now,
+                 [],
+                 %{
+                   stops: %{stop.id => stop},
+                   routes: %{route.id => route}
+                 },
+                 :notification
+               )
+    end
+
     test "trip shuttle recurrence" do
       now = ~B[2026-03-09 12:00:00]
       stop1 = build(:stop, name: "Ruggles")

--- a/test/mobile_app_backend/alerts/summary_entity_builder_test.exs
+++ b/test/mobile_app_backend/alerts/summary_entity_builder_test.exs
@@ -283,6 +283,106 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
              ]
     end
 
+    # This is the current behavior, which I think we'll want to change, but leaving it here
+    # so we have a test to make sure the future change works as expected.
+     test "build trip alert for a trip not scheduled today" do
+      now = ~B[2026-06-03 12:00:00]
+
+      global = GlobalDataCache.get_data()
+      all_child_stops = MBTAV3API.Repository.stops(include: [:child_stops])
+
+      stops = [
+        "place-brntn",
+        "place-qamnl",
+        "place-qnctr",
+        "place-wlsta",
+        "place-nqncy",
+        "place-jfk",
+        "place-andrw",
+        "place-brdwy",
+        "place-sstat",
+        "place-dwnxg",
+        "place-pktrm",
+        "place-chmnl",
+        "place-knncl",
+        "place-cntsq",
+        "place-harsq",
+        "place-portr",
+        "place-davis",
+        "place-alfcl"
+      ]
+
+      route_id = "Red"
+
+      trip =
+        build(:trip,
+          direction_id: 1,
+          route_id: route_id,
+          route_pattern_id: "Red-3-1",
+          stop_ids: stops
+        )
+
+      trip_id = trip.id
+
+      tomorrow = DateTime.add(now, 1, :day)
+
+      _schedules =
+        for {stop, index} <- Enum.with_index(stops) do
+          build(:schedule,
+            departure_time: DateTime.add(tomorrow, index, :minute),
+            trip_id: trip_id,
+            route_id: route_id,
+            stop_id: stop
+          )
+        end
+
+      reassign_env(:mobile_app_backend, MBTAV3API.Repository, RepositoryMock)
+
+      expect(RepositoryMock, :schedules, 2, fn
+        [filter: [trip: [^trip_id]], include: [trip: :stops], sort: {:stop_sequence, :asc}], [] ->
+          ok_response([], [trip])
+      end)
+
+      stub(RepositoryMock, :stops, fn [include: [:child_stops]], [] -> all_child_stops end)
+
+      alert =
+        build(:alert,
+          cause: :maintenance,
+          effect: :suspension,
+          informed_entity: [
+            %InformedEntity{route: route_id, trip: trip_id, direction_id: trip.direction_id}
+          ]
+        )
+
+      alert_id = alert.id
+
+      assert %{^alert_id => entities} =
+               SummaryEntityBuilder.build_all([alert], now, "en", global, :notification)
+
+      assert Enum.sort_by(entities, &{&1.route_id, &1.stop_id, &1.direction_id, &1.trip_id}) == [
+                      %MobileAppBackend.Alerts.SummaryEntity{
+                direction_id: nil,
+                route_id: nil,
+                stop_id: nil,
+                summary: "Service suspended on Red Line",
+                trip_id: nil
+              }
+             ]
+
+      assert %{^alert_id => entities} =
+               SummaryEntityBuilder.build_all([alert], now, "en", global, :card)
+
+      assert Enum.sort_by(entities, &{&1.route_id, &1.stop_id, &1.direction_id, &1.trip_id}) == [
+           %MobileAppBackend.Alerts.SummaryEntity{
+                direction_id: nil,
+                route_id: nil,
+                stop_id: nil,
+                summary: "Service suspended on Red Line",
+                trip_id: nil
+              }
+             ]
+    end
+
     test "build stop alert" do
       now = DateTime.now!("America/New_York")
       stop_id = "place-wlsta"

--- a/test/mobile_app_backend/alerts/summary_entity_builder_test.exs
+++ b/test/mobile_app_backend/alerts/summary_entity_builder_test.exs
@@ -285,7 +285,7 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
 
     # This is the current behavior, which I think we'll want to change, but leaving it here
     # so we have a test to make sure the future change works as expected.
-     test "build trip alert for a trip not scheduled today" do
+    test "build trip alert for a trip not scheduled today" do
       now = ~B[2026-06-03 12:00:00]
 
       global = GlobalDataCache.get_data()
@@ -360,26 +360,26 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
                SummaryEntityBuilder.build_all([alert], now, "en", global, :notification)
 
       assert Enum.sort_by(entities, &{&1.route_id, &1.stop_id, &1.direction_id, &1.trip_id}) == [
-                      %MobileAppBackend.Alerts.SummaryEntity{
-                direction_id: nil,
-                route_id: nil,
-                stop_id: nil,
-                summary: "Service suspended on Red Line",
-                trip_id: nil
-              }
+               %MobileAppBackend.Alerts.SummaryEntity{
+                 direction_id: nil,
+                 route_id: nil,
+                 stop_id: nil,
+                 summary: "Service suspended on Red Line",
+                 trip_id: nil
+               }
              ]
 
       assert %{^alert_id => entities} =
                SummaryEntityBuilder.build_all([alert], now, "en", global, :card)
 
       assert Enum.sort_by(entities, &{&1.route_id, &1.stop_id, &1.direction_id, &1.trip_id}) == [
-           %MobileAppBackend.Alerts.SummaryEntity{
-                direction_id: nil,
-                route_id: nil,
-                stop_id: nil,
-                summary: "Service suspended on Red Line",
-                trip_id: nil
-              }
+               %MobileAppBackend.Alerts.SummaryEntity{
+                 direction_id: nil,
+                 route_id: nil,
+                 stop_id: nil,
+                 summary: "Service suspended on Red Line",
+                 trip_id: nil
+               }
              ]
     end
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Alert Summary Consolidation | Load testing](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1216122497530220?focus=true)

<!-- What is this PR for? -->

Full notes from load testing [in this doc](https://app.notion.com/p/mbta-downtown-crossing/Load-Testing-Alert-Summaries-3b1f5d8d11ea805187d3fa53048d2bff). 
I did not find a significant difference between testing between alerts:v2 and alerts:v3. 

This includes a couple of minor improvements to the load testing script and some tests that capture an edge case we currently aren't handling. I've added a [ticket](https://app.asana.com/1/15492006741476/project/1205425564113216/task/1217168623666489?focus=true) to address that separately.
### Testing

* Ran load tests with the script updates
* Added unit tests for the edge case we should update

<!-- What testing have you done? -->