### PR TITLE
feat(WithSummaryPubSub): Re-enable, and recalculate only summaries that may have changed

### DIFF
--- a/lib/mobile_app_backend/alerts/alert_with_summaries.ex
+++ b/lib/mobile_app_backend/alerts/alert_with_summaries.ex
@@ -1,7 +1,5 @@
 defmodule MobileAppBackend.Alerts.AlertWithSummaries do
   alias MBTAV3API.Alert
-  alias MBTAV3API.Alert.ActivePeriod
-  alias MBTAV3API.Alert.InformedEntity
   alias MobileAppBackend.Alerts.SummaryEntity
 
   @type t :: %__MODULE__{

--- a/lib/mobile_app_backend/alerts/alert_with_summaries.ex
+++ b/lib/mobile_app_backend/alerts/alert_with_summaries.ex
@@ -41,4 +41,15 @@ defmodule MobileAppBackend.Alerts.AlertWithSummaries do
       Util.DateTime.datetime_to_gtfs(old_alert_with_summaries.summaries_updated_at) !=
         Util.DateTime.datetime_to_gtfs(now)
   end
+
+  @spec flatten_alert_fields(t()) :: map()
+  @doc """
+  Flattens the alert fields to the top level for convenience when treating an `AlertWithSummaries` as an `Alert`
+  """
+  def flatten_alert_fields(alert_with_summaries) do
+    alert_with_summaries
+    |> Map.from_struct()
+    |> Map.drop([:alert])
+    |> Map.merge(Map.from_struct(alert_with_summaries.alert))
+  end
 end

--- a/lib/mobile_app_backend/alerts/alert_with_summaries.ex
+++ b/lib/mobile_app_backend/alerts/alert_with_summaries.ex
@@ -19,6 +19,7 @@ defmodule MobileAppBackend.Alerts.AlertWithSummaries do
           lifecycle: Alert.lifecycle(),
           severity: integer(),
           summaries: [SummaryEntity.t()],
+          summaries_updated_at: DateTime.t(),
           updated_at: DateTime.t()
         }
 
@@ -38,10 +39,37 @@ defmodule MobileAppBackend.Alerts.AlertWithSummaries do
     :lifecycle,
     :severity,
     :summaries,
+    :summaries_updated_at,
     :updated_at
   ]
 
   @spec from_alert(Alert.t(), [SummaryEntity.t()]) :: t()
-  def from_alert(alert, summaries),
-    do: struct(%__MODULE__{summaries: summaries}, Map.from_struct(alert))
+  def from_alert(alert, summaries, summaries_updated_at \\ DateTime.now!("America/New_York")) do
+    struct(
+      %__MODULE__{summaries: summaries, summaries_updated_at: summaries_updated_at},
+      Map.from_struct(alert)
+    )
+  end
+
+  @doc """
+  Alert summaries should be recalculated if any of the following are true:
+  - The alert has changed (e.g. description, header, effect, etc.)
+  - The alert has changed from active to inactive or vice versa
+  - It is a different day than the last time summaries were calculated (either calendar date or service date)
+  """
+  def should_recalculate_summaries?(
+        old_alert_with_summaries,
+        new_alert,
+        now \\ DateTime.now!("America/New_York")
+      ) do
+    old_alert = struct(Alert, Map.from_struct(old_alert_with_summaries))
+
+    old_alert != new_alert ||
+      Alert.active?(old_alert, old_alert_with_summaries.summaries_updated_at) !=
+        Alert.active?(new_alert, now) ||
+      DateTime.to_date(old_alert_with_summaries.summaries_updated_at) !=
+        DateTime.to_date(now) ||
+      Util.DateTime.datetime_to_gtfs(old_alert_with_summaries.summaries_updated_at) !=
+        Util.DateTime.datetime_to_gtfs(now)
+  end
 end

--- a/lib/mobile_app_backend/alerts/alert_with_summaries.ex
+++ b/lib/mobile_app_backend/alerts/alert_with_summaries.ex
@@ -5,50 +5,21 @@ defmodule MobileAppBackend.Alerts.AlertWithSummaries do
   alias MobileAppBackend.Alerts.SummaryEntity
 
   @type t :: %__MODULE__{
-          id: String.t(),
-          active_period: [ActivePeriod.t()],
-          cause: Alert.cause(),
-          closed_timestamp: DateTime.t() | nil,
-          description: String.t() | nil,
-          duration_certainty: Alert.duration_certainty(),
-          effect: Alert.effect(),
-          effect_name: String.t() | nil,
-          header: String.t() | nil,
-          informed_entity: [InformedEntity.t()],
-          last_push_notification_timestamp: DateTime.t() | nil,
-          lifecycle: Alert.lifecycle(),
-          severity: integer(),
+          alert: Alert.t(),
           summaries: [SummaryEntity.t()],
-          summaries_updated_at: DateTime.t(),
-          updated_at: DateTime.t()
+          summaries_updated_at: DateTime.t()
         }
 
   @derive Jason.Encoder
   defstruct [
-    :id,
-    :active_period,
-    :cause,
-    :closed_timestamp,
-    :description,
-    :duration_certainty,
-    :effect,
-    :effect_name,
-    :header,
-    :informed_entity,
-    :last_push_notification_timestamp,
-    :lifecycle,
-    :severity,
+    :alert,
     :summaries,
-    :summaries_updated_at,
-    :updated_at
+    :summaries_updated_at
   ]
 
   @spec from_alert(Alert.t(), [SummaryEntity.t()]) :: t()
   def from_alert(alert, summaries, summaries_updated_at \\ DateTime.now!("America/New_York")) do
-    struct(
-      %__MODULE__{summaries: summaries, summaries_updated_at: summaries_updated_at},
-      Map.from_struct(alert)
-    )
+    %__MODULE__{alert: alert, summaries: summaries, summaries_updated_at: summaries_updated_at}
   end
 
   @doc """
@@ -62,7 +33,7 @@ defmodule MobileAppBackend.Alerts.AlertWithSummaries do
         new_alert,
         now \\ DateTime.now!("America/New_York")
       ) do
-    old_alert = struct(Alert, Map.from_struct(old_alert_with_summaries))
+    old_alert = old_alert_with_summaries.alert
 
     old_alert != new_alert ||
       Alert.active?(old_alert, old_alert_with_summaries.summaries_updated_at) !=

--- a/lib/mobile_app_backend/alerts/summary_entity_builder.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity_builder.ex
@@ -44,18 +44,7 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
   def build_all(alerts, at_time, locale, global, context) do
     Map.new(
       Enum.map(alerts, fn alert ->
-        Logger.info("#{__MODULE__} building summaries for alert #{alert.id}")
-
-        {time_micros, result} =
-          :timer.tc(fn ->
-            build_for_alert(alert, at_time, locale, global, context)
-          end)
-
-        Logger.info(
-          "#{__MODULE__} completed building summaries for alert #{alert.id} duration=#{time_micros / 1000}"
-        )
-
-        {alert.id, result}
+        {alert.id, build_for_alert(alert, at_time, locale, global, context)}
       end)
     )
   end

--- a/lib/mobile_app_backend/alerts/summary_entity_builder.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity_builder.ex
@@ -60,6 +60,14 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
     )
   end
 
+  @spec build_all([Alert.t()], DateTime.t(), String.t(), AlertSummary.context()) ::
+          %{String.t() => [SummaryEntity.t()]}
+  def build_all(alerts, at_time, locale, context) do
+    global = GlobalDataCache.get_data()
+
+    build_all(alerts, at_time, locale, global, context)
+  end
+
   @spec build_all([Alert.t()], String.t(), AlertSummary.context()) ::
           %{String.t() => [SummaryEntity.t()]}
   def build_all(alerts, locale, context) do

--- a/lib/mobile_app_backend/alerts/summary_entity_builder.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity_builder.ex
@@ -44,7 +44,18 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
   def build_all(alerts, at_time, locale, global, context) do
     Map.new(
       Enum.map(alerts, fn alert ->
-        {alert.id, build_for_alert(alert, at_time, locale, global, context)}
+        Logger.info("#{__MODULE__} building summaries for alert #{alert.id}")
+
+        {time_micros, result} =
+          :timer.tc(fn ->
+            build_for_alert(alert, at_time, locale, global, context)
+          end)
+
+        Logger.info(
+          "#{__MODULE__} completed building summaries for alert #{alert.id} duration=#{time_micros / 1000}"
+        )
+
+        {alert.id, result}
       end)
     )
   end

--- a/lib/mobile_app_backend/alerts/with_summary_pub_sub.ex
+++ b/lib/mobile_app_backend/alerts/with_summary_pub_sub.ex
@@ -117,10 +117,11 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSub do
   @impl GenServer
   def handle_info(:broadcast, %{last_dispatched_table_name: last_dispatched} = state) do
     Logger.info("#{__MODULE__} handle :broadcast started")
+    now = Map.get(state, :now, DateTime.now!("America/New_York"))
 
     {time_micros, _results} =
       :timer.tc(fn ->
-        all_summaries = recalculate(last_dispatched)
+        all_summaries = recalculate(last_dispatched, now)
 
         perform_broadcast(last_dispatched, all_summaries)
       end)
@@ -136,10 +137,11 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSub do
         %{last_dispatched_table_name: last_dispatched} = state
       ) do
     Logger.info("#{__MODULE__} handle :new_alerts started")
+    now = Map.get(state, :now, DateTime.now!("America/New_York"))
 
     {time_micros, _results} =
       :timer.tc(fn ->
-        all_summaries = recalculate(last_dispatched, Map.values(all_alerts))
+        all_summaries = recalculate(last_dispatched, now, Map.values(all_alerts))
 
         perform_broadcast(last_dispatched, all_summaries)
       end)
@@ -171,24 +173,74 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSub do
   @typep summary_key :: locale :: String.t()
   @typep all_summaries :: %{summary_key() => alerts_with_summaries()}
 
-  defp recalculate(ets_table, all_alerts \\ nil) do
+  defp recalculate(ets_table, now, all_alerts \\ nil) do
+    old_summaries_by_locale =
+      case :ets.lookup(ets_table, :all_summaries) do
+        [{:all_summaries, all_summaries}] -> all_summaries
+        [] -> %{}
+      end
+
     all_alerts = all_alerts || Store.Alerts.fetch([])
-    all_summaries = build_all_summaries(all_alerts)
+
+    changed_alerts =
+      alerts_to_recalculate(
+        Map.get(old_summaries_by_locale, @default_locale, %{}),
+        all_alerts,
+        now
+      )
+
+    {time_micros, alerts_with_changed_summaries_by_locale} =
+      :timer.tc(fn -> build_all_summaries(changed_alerts, now) end)
+
+    Logger.info(
+      "#{__MODULE__} recalculated summaries recalculated=#{length(changed_alerts)} total=#{length(all_alerts)} duration=#{time_micros / 1_000}"
+    )
+
+    all_summaries =
+      Map.merge(old_summaries_by_locale, alerts_with_changed_summaries_by_locale, fn _locale,
+                                                                                     old_alerts_with_summaries,
+                                                                                     new_alerts_with_summaries ->
+        ids_to_remove =
+          MapSet.difference(
+            MapSet.new(Map.keys(old_alerts_with_summaries)),
+            MapSet.new(Enum.map(all_alerts, & &1.id))
+          )
+
+        old_alerts_with_summaries
+        |> Map.drop(MapSet.to_list(ids_to_remove))
+        |> Map.merge(new_alerts_with_summaries)
+      end)
+
     :ets.insert(ets_table, {:all_summaries, all_summaries})
     all_summaries
   end
 
-  @spec build_all_summaries([Alert.t()]) :: all_summaries()
-  defp build_all_summaries(alerts) do
+  @spec alerts_to_recalculate(%{Alert.id() => AlertWithSummaries.t()}, [Alert.t()], DateTime.t()) ::
+          [Alert.t()]
+  defp alerts_to_recalculate(old_summary_map, new_alerts, now) do
+    new_alerts
+    |> Enum.filter(fn alert ->
+      old_alert_with_summaries = Map.get(old_summary_map, alert.id)
+
+      if old_alert_with_summaries do
+        AlertWithSummaries.should_recalculate_summaries?(old_alert_with_summaries, alert, now)
+      else
+        true
+      end
+    end)
+  end
+
+  @spec build_all_summaries([Alert.t()], DateTime.t()) :: all_summaries()
+  defp build_all_summaries(alerts, now) do
     alerts_by_id = Map.new(alerts, &{&1.id, &1})
 
     for locale <- Application.get_env(:mobile_app_backend, :locale_codes),
         into: %{} do
       alerts_with_summaries =
-        SummaryEntityBuilder.build_all(alerts, locale, :card)
+        SummaryEntityBuilder.build_all(alerts, now, locale, :card)
         |> Map.new(fn {alert_id, summary_entities} ->
           alert = alerts_by_id[alert_id]
-          value = AlertWithSummaries.from_alert(alert, summary_entities)
+          value = AlertWithSummaries.from_alert(alert, summary_entities, now)
           {alert_id, value}
         end)
 

--- a/lib/mobile_app_backend/alerts/with_summary_pub_sub.ex
+++ b/lib/mobile_app_backend/alerts/with_summary_pub_sub.ex
@@ -92,9 +92,10 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSub do
   # Temporary patch because upcoming single tracking alerts are displayed
   # incorrectly in the app. Remove any single tracking alerts that aren't happening
   # right now.
-  defp filter_upcoming_single_tracking_alerts(alerts) do
-    Map.filter(alerts, fn {_key, alert} ->
-      !(alert.cause == :single_tracking && !Alert.active?(alert))
+  defp filter_upcoming_single_tracking_alerts(alerts_with_summaries) do
+    Map.filter(alerts_with_summaries, fn {_key, alert_with_summaries} ->
+      !(alert_with_summaries.alert.cause == :single_tracking &&
+          !Alert.active?(alert_with_summaries.alert))
     end)
   end
 

--- a/lib/mobile_app_backend/alerts/with_summary_pub_sub.ex
+++ b/lib/mobile_app_backend/alerts/with_summary_pub_sub.ex
@@ -33,6 +33,8 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSub do
   alias MobileAppBackend.Alerts.AlertWithSummaries
   alias MobileAppBackend.Alerts.SummaryEntityBuilder
 
+  require Logger
+
   @behaviour __MODULE__.Behaviour
 
   @default_locale MobileAppBackend.Application.default_locale()
@@ -114,10 +116,18 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSub do
 
   @impl GenServer
   def handle_info(:broadcast, %{last_dispatched_table_name: last_dispatched} = state) do
-    all_summaries = recalculate(last_dispatched)
+    Logger.info("#{__MODULE__} handle :broadcast started")
 
-    perform_broadcast(last_dispatched, all_summaries)
+    {time_micros, _results} =
+      :timer.tc(fn ->
+        all_summaries = recalculate(last_dispatched)
 
+        perform_broadcast(last_dispatched, all_summaries)
+      end)
+
+    time_ms = time_micros / 1000
+
+    Logger.info("#{__MODULE__} handle :broadcast completed duration=#{time_ms}")
     {:noreply, state, :hibernate}
   end
 
@@ -125,8 +135,18 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSub do
         {:new_alerts, %{alerts: all_alerts}},
         %{last_dispatched_table_name: last_dispatched} = state
       ) do
-    all_summaries = recalculate(last_dispatched, Map.values(all_alerts))
-    perform_broadcast(last_dispatched, all_summaries)
+    Logger.info("#{__MODULE__} handle :new_alerts started")
+
+    {time_micros, _results} =
+      :timer.tc(fn ->
+        all_summaries = recalculate(last_dispatched, Map.values(all_alerts))
+
+        perform_broadcast(last_dispatched, all_summaries)
+      end)
+
+    time_ms = time_micros / 1000
+    Logger.info("#{__MODULE__} handle :new_alerts completed duration=#{time_ms}")
+
     {:noreply, state}
   end
 

--- a/lib/mobile_app_backend/alerts/with_summary_pub_sub.ex
+++ b/lib/mobile_app_backend/alerts/with_summary_pub_sub.ex
@@ -116,19 +116,10 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSub do
 
   @impl GenServer
   def handle_info(:broadcast, %{last_dispatched_table_name: last_dispatched} = state) do
-    Logger.info("#{__MODULE__} handle :broadcast started")
     now = Map.get(state, :now, DateTime.now!("America/New_York"))
+    all_summaries = recalculate(last_dispatched, now)
+    perform_broadcast(last_dispatched, all_summaries)
 
-    {time_micros, _results} =
-      :timer.tc(fn ->
-        all_summaries = recalculate(last_dispatched, now)
-
-        perform_broadcast(last_dispatched, all_summaries)
-      end)
-
-    time_ms = time_micros / 1000
-
-    Logger.info("#{__MODULE__} handle :broadcast completed duration=#{time_ms}")
     {:noreply, state, :hibernate}
   end
 
@@ -138,16 +129,8 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSub do
       ) do
     Logger.info("#{__MODULE__} handle :new_alerts started")
     now = Map.get(state, :now, DateTime.now!("America/New_York"))
-
-    {time_micros, _results} =
-      :timer.tc(fn ->
-        all_summaries = recalculate(last_dispatched, now, Map.values(all_alerts))
-
-        perform_broadcast(last_dispatched, all_summaries)
-      end)
-
-    time_ms = time_micros / 1000
-    Logger.info("#{__MODULE__} handle :new_alerts completed duration=#{time_ms}")
+    all_summaries = recalculate(last_dispatched, now, Map.values(all_alerts))
+    perform_broadcast(last_dispatched, all_summaries)
 
     {:noreply, state}
   end

--- a/lib/mobile_app_backend/application.ex
+++ b/lib/mobile_app_backend/application.ex
@@ -54,6 +54,7 @@ defmodule MobileAppBackend.Application do
         if Application.get_env(:mobile_app_backend, :start_pub_subs?, true) do
           [
             MobileAppBackend.Alerts.PubSub,
+            MobileAppBackend.Alerts.WithSummaryPubSub,
             MobileAppBackend.Vehicles.PubSub,
             MobileAppBackend.Predictions.PubSub
           ]

--- a/lib/mobile_app_backend/pub_sub.ex
+++ b/lib/mobile_app_backend/pub_sub.ex
@@ -93,6 +93,7 @@ defmodule MobileAppBackend.PubSub do
   defmacro __using__(opts) do
     quote location: :keep, bind_quoted: [opts: opts] do
       use GenServer
+      require Logger
 
       @broadcast_interval_ms Keyword.fetch!(opts, :broadcast_interval_ms)
 
@@ -101,11 +102,14 @@ defmodule MobileAppBackend.PubSub do
       # consumers don't have to wait `:broadcast_interval_ms` to receive their first message.
       @impl true
       def handle_info(:reset_event, state) do
+        Logger.info("#{__MODULE__} broadcasting on :reset_event")
         send(self(), :broadcast)
         {:noreply, state, :hibernate}
       end
 
       def handle_info(:timed_broadcast, state) do
+        Logger.info("#{__MODULE__} broadcasting on :timed_broadcast #{@broadcast_interval_ms}")
+
         send(self(), :broadcast)
         broadcast_timer(@broadcast_interval_ms)
         {:noreply, state, :hibernate}

--- a/lib/mobile_app_backend/pub_sub.ex
+++ b/lib/mobile_app_backend/pub_sub.ex
@@ -93,7 +93,6 @@ defmodule MobileAppBackend.PubSub do
   defmacro __using__(opts) do
     quote location: :keep, bind_quoted: [opts: opts] do
       use GenServer
-      require Logger
 
       @broadcast_interval_ms Keyword.fetch!(opts, :broadcast_interval_ms)
 
@@ -102,14 +101,11 @@ defmodule MobileAppBackend.PubSub do
       # consumers don't have to wait `:broadcast_interval_ms` to receive their first message.
       @impl true
       def handle_info(:reset_event, state) do
-        Logger.info("#{__MODULE__} broadcasting on :reset_event")
         send(self(), :broadcast)
         {:noreply, state, :hibernate}
       end
 
       def handle_info(:timed_broadcast, state) do
-        Logger.info("#{__MODULE__} broadcasting on :timed_broadcast #{@broadcast_interval_ms}")
-
         send(self(), :broadcast)
         broadcast_timer(@broadcast_interval_ms)
         {:noreply, state, :hibernate}

--- a/lib/mobile_app_backend_web/channels/alerts_channel.ex
+++ b/lib/mobile_app_backend_web/channels/alerts_channel.ex
@@ -118,26 +118,7 @@ defmodule MobileAppBackendWeb.AlertsChannel do
   defp alert_hashes(alert_map) do
     Map.new(alert_map, fn {key, val} ->
       {key,
-       val
-       |> Map.from_struct()
-       |> Enum.sort_by(fn {key, _value} -> key end)
-       |> Enum.map(fn {key, value} ->
-         case key do
-           # Do some hacky sorting of informed entities, since the backend can return them arbitrarily in any order
-           :informed_entity ->
-             {key,
-              Enum.sort_by(value, fn entity ->
-                "#{entity.route}-#{entity.stop}-#{entity.direction_id}-#{entity.route_type}-#{entity.facility}-#{entity.trip}"
-              end)}
-
-           # Summaries can also change order based on the entity order, so sort those too
-           :summaries ->
-             {key, Enum.sort_by(value, fn summary -> summary.summary end)}
-
-           _ ->
-             {key, value}
-         end
-       end)
+       val.summaries_updated_at
        |> :erlang.term_to_binary()
        |> then(&:crypto.hash(:md5, &1))
        |> Base.encode16()}

--- a/lib/mobile_app_backend_web/channels/alerts_channel.ex
+++ b/lib/mobile_app_backend_web/channels/alerts_channel.ex
@@ -54,7 +54,7 @@ defmodule MobileAppBackendWeb.AlertsChannel do
     %{alerts_with_summaries: alerts} = pubsub_module.subscribe(get_opts(socket))
     socket = assign(socket, :last_alerts, alert_hashes(alerts))
 
-    {:ok, %AlertUpdate{remove: [], update: alerts}, socket}
+    {:ok, %AlertUpdate{remove: [], update: flatten_alert_fields(alerts)}, socket}
   end
 
   defp get_opts(socket) do
@@ -104,7 +104,10 @@ defmodule MobileAppBackendWeb.AlertsChannel do
     response =
       %AlertUpdate{
         remove: MapSet.to_list(removed_ids),
-        update: Map.filter(alerts, fn {id, _alert} -> Enum.member?(update_ids, id) end)
+        update:
+          alerts
+          |> Map.filter(fn {id, _alert} -> Enum.member?(update_ids, id) end)
+          |> flatten_alert_fields()
       }
 
     if !AlertUpdate.empty?(response) do
@@ -112,6 +115,13 @@ defmodule MobileAppBackendWeb.AlertsChannel do
     end
 
     assign(socket, :last_alerts, current_hashes)
+  end
+
+  defp flatten_alert_fields(alerts_map) do
+    alerts_map
+    |> Map.new(fn {id, alert_with_summaries} ->
+      {id, AlertWithSummaries.flatten_alert_fields(alert_with_summaries)}
+    end)
   end
 
   @spec alert_hashes(%{String.t() => Alert.t()}) :: %{String.t() => String.t()}

--- a/test/mobile_app_backend/alerts/alert_with_summaries_test.exs
+++ b/test/mobile_app_backend/alerts/alert_with_summaries_test.exs
@@ -1,0 +1,105 @@
+defmodule MobileAppBackend.Alerts.AlertWithSummariesTest do
+  use ExUnit.Case, async: true
+
+  import MobileAppBackend.Factory
+  import Test.Support.Sigils
+
+  alias MBTAV3API.Alert
+  alias MobileAppBackend.Alerts.AlertWithSummaries
+  alias MobileAppBackend.Alerts.SummaryEntity
+
+  describe "should_recalculate_summaries?/3" do
+    test "returns true when alert content has changed" do
+      old_alert = build(:alert, id: "a_1")
+
+      old_with_summary =
+        AlertWithSummaries.from_alert(old_alert, [%SummaryEntity{summary: "asdf"}])
+
+      new_alert = %{old_alert | informed_entity: [%Alert.InformedEntity{route: "Red"}]}
+
+      assert AlertWithSummaries.should_recalculate_summaries?(
+               old_with_summary,
+               new_alert,
+               DateTime.now!("America/New_York")
+             )
+    end
+
+    test "returns true when active status has changed" do
+      now = DateTime.now!("America/New_York")
+
+      old_alert =
+        build(:alert,
+          id: "a_1",
+          active_period: [
+            %Alert.ActivePeriod{
+              start: DateTime.add(now, 1, :hour),
+              end: DateTime.add(now, 3, :hour)
+            }
+          ]
+        )
+
+      old_with_summary =
+        AlertWithSummaries.from_alert(old_alert, [%SummaryEntity{summary: "asdf"}], now)
+
+      assert AlertWithSummaries.should_recalculate_summaries?(
+               old_with_summary,
+               old_alert,
+               DateTime.add(now, 2, :hour)
+             )
+    end
+
+    test "returns true when calendar date has changed" do
+      now = DateTime.now!("America/New_York")
+
+      old_alert =
+        build(:alert,
+          id: "a_1"
+        )
+
+      old_with_summary =
+        AlertWithSummaries.from_alert(old_alert, [%SummaryEntity{summary: "asdf"}], now)
+
+      assert AlertWithSummaries.should_recalculate_summaries?(
+               old_with_summary,
+               old_alert,
+               DateTime.add(now, 1, :day)
+             )
+    end
+
+    test "returns true when GTFS service date has changed" do
+      now = ~B[2026-08-05 01:01:01]
+
+      old_alert =
+        build(:alert,
+          id: "a_1"
+        )
+
+      old_with_summary =
+        AlertWithSummaries.from_alert(old_alert, [%SummaryEntity{summary: "asdf"}], now)
+
+      assert AlertWithSummaries.should_recalculate_summaries?(
+               old_with_summary,
+               old_alert,
+               ~B[2026-08-05 06:01:01]
+             )
+    end
+
+    test "returns false when alert, active state, and dates are unchanged" do
+      now = ~B[2026-08-05 06:01:01]
+
+      old_alert =
+        build(:alert,
+          id: "a_1"
+        )
+
+      old_with_summary =
+        AlertWithSummaries.from_alert(old_alert, [%SummaryEntity{summary: "asdf"}], now)
+
+      refute AlertWithSummaries.should_recalculate_summaries?(
+               old_with_summary,
+               old_alert,
+               ~B[2026-08-05 07:01:01]
+             )
+    end
+  end
+end

--- a/test/mobile_app_backend/alerts/with_summary_pub_sub_test.exs
+++ b/test/mobile_app_backend/alerts/with_summary_pub_sub_test.exs
@@ -70,7 +70,12 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSubTest do
   describe "handle_info" do
     setup do
       _dispatched_table = :ets.new(:test_last_dispatched, [:set, :named_table])
-      {:ok, %{last_dispatched_table_name: :test_last_dispatched}}
+
+      {:ok,
+       %{
+         last_dispatched_table_name: :test_last_dispatched,
+         now: DateTime.now!("America/New_York")
+       }}
     end
 
     test "broadcasts on :reset_event", state do
@@ -115,9 +120,13 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSubTest do
       assert_receive {:new_alerts, new_alerts}
 
       assert to_alert_map([
-               AlertWithSummaries.from_alert(alert_1, [
-                 %SummaryEntity{summary: "Delay until further notice"}
-               ])
+               AlertWithSummaries.from_alert(
+                 alert_1,
+                 [
+                   %SummaryEntity{summary: "Delay until further notice"}
+                 ],
+                 state.now
+               )
              ]) == new_alerts
 
       # Doesn't re-send the same alerts that have already been seen
@@ -131,7 +140,11 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSubTest do
       assert_receive {:new_alerts, new_alerts}
 
       assert to_alert_map([
-               AlertWithSummaries.from_alert(alert_2, [%SummaryEntity{summary: "Delay"}])
+               AlertWithSummaries.from_alert(
+                 alert_2,
+                 [%SummaryEntity{summary: "Delay"}],
+                 state.now
+               )
              ]) == new_alerts
     end
 
@@ -144,7 +157,7 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSubTest do
           cause: :single_tracking,
           active_period: [
             %Alert.ActivePeriod{
-              start: DateTime.add(DateTime.now!("America/New_York"), 10, :minute),
+              start: DateTime.add(state.now, 10, :minute),
               end: nil
             }
           ],
@@ -157,7 +170,7 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSubTest do
           cause: :single_tracking,
           active_period: [
             %Alert.ActivePeriod{
-              start: DateTime.add(DateTime.now!("America/New_York"), -10, :minute),
+              start: DateTime.add(state.now, -10, :minute),
               end: nil
             }
           ],
@@ -180,9 +193,13 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSubTest do
       WithSummaryPubSub.handle_info(:broadcast, state)
 
       assert to_alert_map([
-               AlertWithSummaries.from_alert(single_tracking_now, [
-                 %SummaryEntity{summary: "Delay until further notice"}
-               ])
+               AlertWithSummaries.from_alert(
+                 single_tracking_now,
+                 [
+                   %SummaryEntity{summary: "Delay until further notice"}
+                 ],
+                 state.now
+               )
              ]) ==
                WithSummaryPubSub.subscribe(ets_table: state.last_dispatched_table_name)
 
@@ -191,6 +208,61 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSubTest do
       assert_receive {:new_alerts, new_alerts}
 
       assert to_alert_map([]) == new_alerts
+    end
+
+    test ":broadcast sends message when the date has changed from inactive to active", state do
+      alert_1 =
+        build(:alert,
+          id: "a_1",
+          active_period: [
+            %Alert.ActivePeriod{
+              start: DateTime.add(state.now, 23, :hour),
+              end: nil
+            }
+          ]
+        )
+
+      AlertsStoreMock
+      # 1st and 2nd broadcast
+      |> expect(:fetch, 2, fn _ -> [alert_1] end)
+
+      GlobalDataCacheMock
+      |> stub(:default_key, fn -> :default_key end)
+      |> stub(:get_data, fn _ ->
+        %{route_patterns: %{}}
+      end)
+
+      RepositoryMock |> stub(:stops, fn _, _ -> {:ok, %{data: []}} end)
+
+      WithSummaryPubSub.subscribe(ets_table: state.last_dispatched_table_name)
+
+      WithSummaryPubSub.handle_info(:broadcast, state)
+
+      assert_receive {:new_alerts, new_alerts}
+
+      assert to_alert_map([
+               AlertWithSummaries.from_alert(
+                 alert_1,
+                 [
+                   %SummaryEntity{summary: "Delay starting tomorrow"}
+                 ],
+                 state.now
+               )
+             ]) == new_alerts
+
+      # Resends when summaries change due to passage of time
+      new_now = DateTime.add(state.now, 1, :day)
+      WithSummaryPubSub.handle_info(:broadcast, %{state | now: new_now})
+
+      assert_receive {:new_alerts, new_alerts}
+
+      assert to_alert_map([
+               AlertWithSummaries.from_alert(
+                 alert_1,
+                 [%SummaryEntity{summary: "Delay until further notice"}],
+                 new_now
+               )
+             ]) == new_alerts
     end
   end
 end

--- a/test/mobile_app_backend/alerts/with_summary_pub_sub_test.exs
+++ b/test/mobile_app_backend/alerts/with_summary_pub_sub_test.exs
@@ -36,7 +36,7 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSubTest do
     %{
       alerts_with_summaries:
         alerts_with_summaries
-        |> Map.new(&{&1.id, &1})
+        |> Map.new(&{&1.alert.id, &1})
     }
   end
 
@@ -53,10 +53,26 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSubTest do
     test "returns initial data" do
       alert_1 = build(:alert, id: "a_1")
 
-      ets_table = :ets.new(nil, [:set])
-      :ets.insert(ets_table, {:all_summaries, %{"en" => %{alert_1.id => alert_1}}})
+      with_summaries = %AlertWithSummaries{
+        alert: alert_1,
+        summaries: [],
+        summaries_updated_at: DateTime.now!("America/New_York")
+      }
 
-      assert to_alert_map([alert_1]) == WithSummaryPubSub.subscribe(ets_table: ets_table)
+      ets_table = :ets.new(nil, [:set])
+
+      :ets.insert(
+        ets_table,
+        {:all_summaries,
+         %{
+           "en" => %{
+             alert_1.id => with_summaries
+           }
+         }}
+      )
+
+      assert to_alert_map([with_summaries]) ==
+               WithSummaryPubSub.subscribe(ets_table: ets_table)
     end
 
     test "returns empty list when no alerts" do

--- a/test/mobile_app_backend_web/channels/alerts_channel_test.exs
+++ b/test/mobile_app_backend_web/channels/alerts_channel_test.exs
@@ -25,11 +25,21 @@ defmodule MobileAppBackendWeb.AlertsChannelTest do
 
   setup :verify_on_exit!
 
-  defp to_alert_map(alerts),
-    do:
-      alerts
-      |> Enum.map(fn alert -> {alert.id, alert} end)
-      |> Map.new()
+  defp to_alert_map([%AlertWithSummaries{} | _rest] = alerts) do
+    alerts
+    |> Enum.map(fn alert_with_summaries ->
+      {alert_with_summaries.alert.id, alert_with_summaries}
+    end)
+    |> Map.new()
+  end
+
+  defp to_alert_map(alerts) do
+    alerts
+    |> Enum.map(fn alert ->
+      {alert.id, alert}
+    end)
+    |> Map.new()
+  end
 
   test "joins and subscribes correctly", %{socket: socket} do
     alert1 = %Alert{
@@ -133,53 +143,63 @@ defmodule MobileAppBackendWeb.AlertsChannelTest do
 
   test "joins and subscribes v3 correctly", %{socket: socket} do
     alert1 = %AlertWithSummaries{
-      id: "501047",
-      active_period: [%Alert.ActivePeriod{start: ~B[2023-05-26 16:46:13]}],
-      effect: :station_issue,
-      effect_name: nil,
-      informed_entity: [
-        %Alert.InformedEntity{
-          activities: [:board],
-          route: "Green-D",
-          route_type: :light_rail,
-          stop: "70511"
-        },
-        %Alert.InformedEntity{
-          activities: [:board],
-          route: "88",
-          route_type: :bus,
-          stop: "place-lech"
-        }
-      ],
-      lifecycle: :ongoing,
+      alert: %Alert{
+        id: "501047",
+        active_period: [%Alert.ActivePeriod{start: ~B[2023-05-26 16:46:13]}],
+        effect: :station_issue,
+        effect_name: nil,
+        informed_entity: [
+          %Alert.InformedEntity{
+            activities: [:board],
+            route: "Green-D",
+            route_type: :light_rail,
+            stop: "70511"
+          },
+          %Alert.InformedEntity{
+            activities: [:board],
+            route: "88",
+            route_type: :bus,
+            stop: "place-lech"
+          }
+        ],
+        lifecycle: :ongoing
+      },
       summaries: [%SummaryEntity{summary: "test summary"}]
     }
 
     alert2 = %AlertWithSummaries{
-      id: "559018",
-      active_period: [
-        %Alert.ActivePeriod{start: ~B[2024-03-14 16:12:00], end: ~B[2024-03-14 18:13:39]}
-      ],
-      effect: :delay,
-      effect_name: nil,
-      informed_entity: [
-        %Alert.InformedEntity{activities: [:board, :exit, :ride], route: "120", route_type: :bus}
-      ],
-      lifecycle: :new,
+      alert: %Alert{
+        id: "559018",
+        active_period: [
+          %Alert.ActivePeriod{start: ~B[2024-03-14 16:12:00], end: ~B[2024-03-14 18:13:39]}
+        ],
+        effect: :delay,
+        effect_name: nil,
+        informed_entity: [
+          %Alert.InformedEntity{
+            activities: [:board, :exit, :ride],
+            route: "120",
+            route_type: :bus
+          }
+        ],
+        lifecycle: :new
+      },
       summaries: [%SummaryEntity{summary: "test summary"}]
     }
 
     alert3 = %AlertWithSummaries{
-      id: "559019",
-      active_period: [
-        %Alert.ActivePeriod{start: ~B[2024-03-14 16:12:00], end: ~B[2024-03-14 18:13:39]}
-      ],
-      effect: :delay,
-      effect_name: nil,
-      informed_entity: [
-        %Alert.InformedEntity{activities: [:board, :exit, :ride], route: "1", route_type: :bus}
-      ],
-      lifecycle: :new,
+      alert: %Alert{
+        id: "559019",
+        active_period: [
+          %Alert.ActivePeriod{start: ~B[2024-03-14 16:12:00], end: ~B[2024-03-14 18:13:39]}
+        ],
+        effect: :delay,
+        effect_name: nil,
+        informed_entity: [
+          %Alert.InformedEntity{activities: [:board, :exit, :ride], route: "1", route_type: :bus}
+        ],
+        lifecycle: :new
+      },
       summaries: [%SummaryEntity{summary: "test summary"}]
     }
 
@@ -194,14 +214,21 @@ defmodule MobileAppBackendWeb.AlertsChannelTest do
      }, socket} =
       subscribe_and_join(socket, "alerts:v3")
 
-    data2 = to_alert_map([%{alert1 | description: "different description"}])
+    data2 =
+      to_alert_map([
+        %{
+          alert1
+          | alert: %{alert1.alert | description: "different description"},
+            summaries_updated_at: DateTime.utc_now()
+        }
+      ])
 
     AlertsChannel.handle_info(
-      {:new_alerts, %{alerts_with_summaries: Map.merge(data2, %{alert3.id => alert3})}},
+      {:new_alerts, %{alerts_with_summaries: Map.merge(data2, %{alert3.alert.id => alert3})}},
       socket
     )
 
-    alert2_id = alert2.id
+    alert2_id = alert2.alert.id
 
     assert_push("stream_data", %AlertsChannel.AlertUpdate{
       remove: [^alert2_id],
@@ -211,39 +238,47 @@ defmodule MobileAppBackendWeb.AlertsChannelTest do
 
   test "v3 skips updates if there are no changes", %{socket: socket} do
     alert1 = %AlertWithSummaries{
-      id: "501047",
-      active_period: [%Alert.ActivePeriod{start: ~B[2023-05-26 16:46:13]}],
-      effect: :station_issue,
-      effect_name: nil,
-      informed_entity: [
-        %Alert.InformedEntity{
-          activities: [:board],
-          route: "Green-D",
-          route_type: :light_rail,
-          stop: "70511"
-        },
-        %Alert.InformedEntity{
-          activities: [:board],
-          route: "88",
-          route_type: :bus,
-          stop: "place-lech"
-        }
-      ],
-      lifecycle: :ongoing,
+      alert: %Alert{
+        id: "501047",
+        active_period: [%Alert.ActivePeriod{start: ~B[2023-05-26 16:46:13]}],
+        effect: :station_issue,
+        effect_name: nil,
+        informed_entity: [
+          %Alert.InformedEntity{
+            activities: [:board],
+            route: "Green-D",
+            route_type: :light_rail,
+            stop: "70511"
+          },
+          %Alert.InformedEntity{
+            activities: [:board],
+            route: "88",
+            route_type: :bus,
+            stop: "place-lech"
+          }
+        ],
+        lifecycle: :ongoing
+      },
       summaries: [%SummaryEntity{summary: "test summary"}]
     }
 
     alert2 = %AlertWithSummaries{
-      id: "559018",
-      active_period: [
-        %Alert.ActivePeriod{start: ~B[2024-03-14 16:12:00], end: ~B[2024-03-14 18:13:39]}
-      ],
-      effect: :delay,
-      effect_name: nil,
-      informed_entity: [
-        %Alert.InformedEntity{activities: [:board, :exit, :ride], route: "120", route_type: :bus}
-      ],
-      lifecycle: :new,
+      alert: %Alert{
+        id: "559018",
+        active_period: [
+          %Alert.ActivePeriod{start: ~B[2024-03-14 16:12:00], end: ~B[2024-03-14 18:13:39]}
+        ],
+        effect: :delay,
+        effect_name: nil,
+        informed_entity: [
+          %Alert.InformedEntity{
+            activities: [:board, :exit, :ride],
+            route: "120",
+            route_type: :bus
+          }
+        ],
+        lifecycle: :new
+      },
       summaries: [%SummaryEntity{summary: "test summary"}]
     }
 

--- a/test/mobile_app_backend_web/channels/alerts_channel_test.exs
+++ b/test/mobile_app_backend_web/channels/alerts_channel_test.exs
@@ -41,6 +41,15 @@ defmodule MobileAppBackendWeb.AlertsChannelTest do
     |> Map.new()
   end
 
+  defp to_flattended_alert_map([%AlertWithSummaries{} | _rest] = alerts) do
+    alerts
+    |> Enum.map(fn alert_with_summaries ->
+      {alert_with_summaries.alert.id,
+       AlertWithSummaries.flatten_alert_fields(alert_with_summaries)}
+    end)
+    |> Map.new()
+  end
+
   test "joins and subscribes correctly", %{socket: socket} do
     alert1 = %Alert{
       id: "501047",
@@ -81,8 +90,7 @@ defmodule MobileAppBackendWeb.AlertsChannelTest do
 
     expect(AlertsPubSubMock, :subscribe, 1, fn _ -> data1 end)
 
-    {:ok, ^data1, socket} =
-      subscribe_and_join(socket, "alerts")
+    {:ok, ^data1, socket} = subscribe_and_join(socket, "alerts")
 
     data2 = %{alerts: to_alert_map([alert1])}
 
@@ -210,21 +218,20 @@ defmodule MobileAppBackendWeb.AlertsChannelTest do
     {:ok,
      %AlertsChannel.AlertUpdate{
        remove: [],
-       update: ^data1
+       update: update
      }, socket} =
       subscribe_and_join(socket, "alerts:v3")
 
-    data2 =
-      to_alert_map([
-        %{
-          alert1
-          | alert: %{alert1.alert | description: "different description"},
-            summaries_updated_at: DateTime.utc_now()
-        }
-      ])
+    assert update == to_flattended_alert_map([alert1, alert2, alert3])
+
+    updated_alert1 = %{
+      alert1
+      | alert: %{alert1.alert | description: "different description"},
+        summaries_updated_at: DateTime.utc_now()
+    }
 
     AlertsChannel.handle_info(
-      {:new_alerts, %{alerts_with_summaries: Map.merge(data2, %{alert3.alert.id => alert3})}},
+      {:new_alerts, %{alerts_with_summaries: to_alert_map([updated_alert1, alert3])}},
       socket
     )
 
@@ -232,8 +239,10 @@ defmodule MobileAppBackendWeb.AlertsChannelTest do
 
     assert_push("stream_data", %AlertsChannel.AlertUpdate{
       remove: [^alert2_id],
-      update: ^data2
+      update: update
     })
+
+    assert update == to_flattended_alert_map([updated_alert1])
   end
 
   test "v3 skips updates if there are no changes", %{socket: socket} do
@@ -289,9 +298,11 @@ defmodule MobileAppBackendWeb.AlertsChannelTest do
     {:ok,
      %AlertsChannel.AlertUpdate{
        remove: [],
-       update: ^data1
+       update: update
      }, socket} =
       subscribe_and_join(socket, "alerts:v3")
+
+    assert update == to_flattended_alert_map([alert1, alert2])
 
     AlertsChannel.handle_info(
       {:new_alerts, %{alerts_with_summaries: data1}},


### PR DESCRIPTION
### Summary

_Ticket:_ [Alert Summary Consolidation | Load testing](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1216122497530220?focus=true)

<!-- What is this PR for? -->
While monitoring LiveDashboard in staging, I noticed WithSummaryPubSub had a MsgQ that kept creeping up, ~1 per minute. After adding some temporary loging, I found it takes ~50 seconds to recalculate all summaries. There is a timed recalculation every 60 seconds, plus whenever the alerts data updates, which seems to also happen every ~60 seconds (I think because "until further notice" alerts get extended end periods).

After this change, we only recalculate summaries for alerts that plausibly may have a summary change

### Testing
* Added unit tests
* Deployed to staging and confirmed not every summary is recalculated
<img width="1265" height="691" alt="image" src="https://github.com/user-attachments/assets/4cf2f047-821c-46e6-aba4-08ca7f800d49" />

### Notes
* This wasn't caught when load testing in dev-orange because the alerts in dev-orange are different than prod. For alerts-related load testing, we may want to either make more realistic alerts or temporarily switch over to using a V3 API environment that includes the prod alerts feed.

<!-- What testing have you done? -->