### PR TITLE
fix: include bolding in summaries for cards

### DIFF
--- a/lib/mobile_app_backend/alerts/summary_entity_builder.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity_builder.ex
@@ -149,7 +149,8 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
     formatted =
       FormattedAlert.summary(
         %FormattedAlert{alert: alert, alert_summary: summary},
-        locale
+        locale,
+        context == :card
       )
 
     %SummaryEntity{

--- a/test/mobile_app_backend/alerts/summary_entity_builder_test.exs
+++ b/test/mobile_app_backend/alerts/summary_entity_builder_test.exs
@@ -59,7 +59,7 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
                    stop_id: nil,
                    trip_id: nil,
                    direction_id: nil,
-                   summary: "Service suspended on Red Line"
+                   summary: "**Service suspended** on **Red Line**"
                  }
                ]
              } = SummaryEntityBuilder.build_all([alert], now, "en", global, :card)
@@ -377,7 +377,7 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
                  direction_id: nil,
                  route_id: nil,
                  stop_id: nil,
-                 summary: "Service suspended on Red Line",
+                 summary: "**Service suspended** on **Red Line**",
                  trip_id: nil
                }
              ]
@@ -417,7 +417,7 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilderTest do
                    stop_id: nil,
                    trip_id: nil,
                    direction_id: nil,
-                   summary: "Service suspended at Wollaston"
+                   summary: "**Service suspended** at **Wollaston**"
                  }
                ]
              } = SummaryEntityBuilder.build_all([alert], now, "en", global, :card)

--- a/test/mobile_app_backend/alerts/with_summary_pub_sub_test.exs
+++ b/test/mobile_app_backend/alerts/with_summary_pub_sub_test.exs
@@ -139,7 +139,7 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSubTest do
                AlertWithSummaries.from_alert(
                  alert_1,
                  [
-                   %SummaryEntity{summary: "Delay until further notice"}
+                   %SummaryEntity{summary: "**Delay** until further notice"}
                  ],
                  state.now
                )
@@ -158,7 +158,7 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSubTest do
       assert to_alert_map([
                AlertWithSummaries.from_alert(
                  alert_2,
-                 [%SummaryEntity{summary: "Delay"}],
+                 [%SummaryEntity{summary: "**Delay**"}],
                  state.now
                )
              ]) == new_alerts
@@ -212,7 +212,7 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSubTest do
                AlertWithSummaries.from_alert(
                  single_tracking_now,
                  [
-                   %SummaryEntity{summary: "Delay until further notice"}
+                   %SummaryEntity{summary: "**Delay** until further notice"}
                  ],
                  state.now
                )
@@ -260,7 +260,7 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSubTest do
                AlertWithSummaries.from_alert(
                  alert_1,
                  [
-                   %SummaryEntity{summary: "Delay starting tomorrow"}
+                   %SummaryEntity{summary: "**Delay** starting tomorrow"}
                  ],
                  state.now
                )
@@ -275,7 +275,7 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSubTest do
       assert to_alert_map([
                AlertWithSummaries.from_alert(
                  alert_1,
-                 [%SummaryEntity{summary: "Delay until further notice"}],
+                 [%SummaryEntity{summary: "**Delay** until further notice"}],
                  new_now
                )
              ]) == new_alerts


### PR DESCRIPTION
### Summary

_Ticket:_ [Alert Summary Consolidation | Make the frontend display backend generated summaries](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215637601111273?focus=true)

We want to maintain the emphasis in contexts where we can actually display it.

### Testing

Updated tests.