### PR TITLE
fix: Support multiple hostnames

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -121,12 +121,14 @@ if config_env() == :prod do
       """
 
   host = System.get_env("PHX_HOST") || "example.com"
+  hosts = String.split(System.get_env("PHX_HOSTS") || host, ",", trim: true)
   port = String.to_integer(System.get_env("PORT") || "4000")
 
   config :mobile_app_backend, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")
 
   config :mobile_app_backend, MobileAppBackendWeb.Endpoint,
     url: [host: host, port: 443, scheme: "https"],
+    check_origin: Enum.map(hosts, &("https://" <> &1)),
     http: [
       # Enable IPv6 and bind on all interfaces.
       # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.


### PR DESCRIPTION
### Summary

_Ticket:_ [Enable LiveDashboard](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1216655729859151?focus=true)

Update the backend to pull from the new `PHX_HOSTS` env var, which includes a list of all supported hostnames for the service. Currently `PHX_HOST` isn't set to a real host, so this sets that properly, and also sets the list of all possible hosts to the `check_origin` config.

### Testing

Deployed on dev orange with the updated module, works as expected
