### PR TITLE
Perf?: Parallelize alert summary building for changed alerts

### DIFF
--- a/lib/mobile_app_backend/alerts/summary_entity_builder.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity_builder.ex
@@ -48,7 +48,7 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
         fn alert ->
           {alert.id, build_for_alert(alert, at_time, locale, global, context)}
         end,
-        max_concurrency: 20,
+        max_concurrency: 5,
         timeout: 100_000,
         on_timeout: :kill_task
       )

--- a/lib/mobile_app_backend/alerts/summary_entity_builder.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity_builder.ex
@@ -43,9 +43,16 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
         ) :: %{String.t() => [SummaryEntity.t()]}
   def build_all(alerts, at_time, locale, global, context) do
     Map.new(
-      Enum.map(alerts, fn alert ->
-        {alert.id, build_for_alert(alert, at_time, locale, global, context)}
-      end)
+      alerts
+      |> Task.async_stream(
+        fn alert ->
+          {alert.id, build_for_alert(alert, at_time, locale, global, context)}
+        end,
+        max_concurrency: 50,
+        timeout: 100_000,
+        on_timeout: :kill_task
+      )
+      |> Enum.map(fn {:ok, result} -> result end)
     )
   end
 

--- a/lib/mobile_app_backend/alerts/summary_entity_builder.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity_builder.ex
@@ -48,7 +48,7 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
         fn alert ->
           {alert.id, build_for_alert(alert, at_time, locale, global, context)}
         end,
-        max_concurrency: 5,
+        max_concurrency: 10,
         timeout: 100_000,
         on_timeout: :kill_task
       )

--- a/lib/mobile_app_backend/alerts/summary_entity_builder.ex
+++ b/lib/mobile_app_backend/alerts/summary_entity_builder.ex
@@ -48,7 +48,7 @@ defmodule MobileAppBackend.Alerts.SummaryEntityBuilder do
         fn alert ->
           {alert.id, build_for_alert(alert, at_time, locale, global, context)}
         end,
-        max_concurrency: 50,
+        max_concurrency: 20,
         timeout: 100_000,
         on_timeout: :kill_task
       )


### PR DESCRIPTION
### Summary

_Ticket:_ [Parallelize calculating summaries](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1217382894124560?focus=true)

<!-- What is this PR for? -->
Trying to improve performance of alert summary building

### Testing

<!-- What testing have you done? -->
Ran test and deployed to dev orange