### PR TITLE
fix(WithSummaryPubSub): broadcast latest alerts data from table always

### DIFF
--- a/lib/mobile_app_backend/alerts/with_summary_pub_sub.ex
+++ b/lib/mobile_app_backend/alerts/with_summary_pub_sub.ex
@@ -125,12 +125,12 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSub do
   end
 
   def handle_info(
-        {:new_alerts, %{alerts: all_alerts}},
+        {:new_alerts, _alerts_data},
         %{last_dispatched_table_name: last_dispatched} = state
       ) do
     Logger.info("#{__MODULE__} handle :new_alerts started")
     now = Map.get(state, :now, DateTime.now!("America/New_York"))
-    all_summaries = recalculate(last_dispatched, now, Map.values(all_alerts))
+    all_summaries = recalculate(last_dispatched, now)
     perform_broadcast(last_dispatched, all_summaries)
 
     {:noreply, state}

--- a/test/mobile_app_backend/alerts/with_summary_pub_sub_test.exs
+++ b/test/mobile_app_backend/alerts/with_summary_pub_sub_test.exs
@@ -164,6 +164,50 @@ defmodule MobileAppBackend.Alerts.WithSummaryPubSubTest do
              ]) == new_alerts
     end
 
+    test "handle_info(:new_alerts) uses the latest data from the table, not what is included in the message",
+         state do
+      alert_1 =
+        build(:alert,
+          id: "a_1",
+          cause: :mainetenance,
+          active_period: [
+            %Alert.ActivePeriod{
+              start: ~B[2024-02-12 09:44:04],
+              end: nil
+            }
+          ]
+        )
+
+      alert_2 = build(:alert, id: "a_2", cause: :rail_defect)
+
+      AlertsStoreMock
+      |> expect(:fetch, 1, fn _ -> [alert_1] end)
+
+      GlobalDataCacheMock
+      |> stub(:default_key, fn -> :default_key end)
+      |> stub(:get_data, fn _ ->
+        %{route_patterns: %{}}
+      end)
+
+      RepositoryMock |> stub(:stops, fn _, _ -> {:ok, %{data: []}} end)
+
+      WithSummaryPubSub.subscribe(ets_table: state.last_dispatched_table_name)
+
+      WithSummaryPubSub.handle_info({:new_alerts, %{alerts: %{alert_2.id => alert_2}}}, state)
+
+      assert_receive {:new_alerts, pushed_alerts}
+
+      assert to_alert_map([
+               AlertWithSummaries.from_alert(
+                 alert_1,
+                 [
+                   %SummaryEntity{summary: "**Delay** until further notice"}
+                 ],
+                 state.now
+               )
+             ]) == pushed_alerts
+    end
+
     test ":broadcast filters out upcoming single tracking alerts", state do
       route = build(:route)
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Alert Summary Consolidation | Load testing](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1216122497530220?focus=true)

<!-- What is this PR for? -->
Follow up work from monitoring the performance of `WithSummaryPubSub`. We were seeing a high MsgQ for WithSummaryPubSub. This build up should be less likely after our performance improvements, including https://github.com/mbta/mobile_app_backend/pull/679, https://github.com/mbta/mobile_app_backend/pull/668, and upstream changes to alert data to ensure consistent informed entity ordering. 

However, if we ever find the MsgQ starting to pile up again, we want to make sure that we are always recalculating summaries based on the latest alert data stored in the ETS table (*not* the alerts included in the `:new_alerts` push from `Alerts.PubSub`, which if the queue is backed up could be out of date.

### Testing
<!-- What testing have you done? -->
Added a test to make sure the alerts from the table are used instead of the alerts included in the `handle_info` payload.