### PR TITLE
Perf: use ets.info size to get alarm size when checking health instea…

### DIFF
--- a/lib/mbta_v3_api/store.ex
+++ b/lib/mbta_v3_api/store.ex
@@ -122,7 +122,7 @@ defmodule MBTAV3API.Store do
       end
 
       @impl true
-      def table_size() do
+      def table_size do
         Application.get_env(:mobile_app_backend, __MODULE__, unquote(implementation_module)).table_size()
       end
     end

--- a/lib/mbta_v3_api/store.ex
+++ b/lib/mbta_v3_api/store.ex
@@ -43,6 +43,11 @@ defmodule MBTAV3API.Store do
   """
   @callback fetch_with_associations(fetch_keys()) :: JsonApi.Object.full_map()
 
+  @doc """
+  Return the number of records in the store
+  """
+  @callback table_size() :: non_neg_integer()
+
   @spec timed_fetch(atom(), :ets.match_spec(), String.t()) :: [any()]
   @doc """
   Fetch matching records from the given table and log the duration.
@@ -114,6 +119,11 @@ defmodule MBTAV3API.Store do
         Application.get_env(:mobile_app_backend, __MODULE__, unquote(implementation_module)).process_remove(
           references
         )
+      end
+
+      @impl true
+      def table_size() do
+        Application.get_env(:mobile_app_backend, __MODULE__, unquote(implementation_module)).table_size()
       end
     end
   end

--- a/lib/mbta_v3_api/store/alerts.ex
+++ b/lib/mbta_v3_api/store/alerts.ex
@@ -140,7 +140,7 @@ defmodule MBTAV3API.Store.Alerts.Impl do
   end
 
   @impl true
-  def table_size() do
+  def table_size do
     :ets.info(@alerts_table_name, :size)
   end
 

--- a/lib/mbta_v3_api/store/alerts.ex
+++ b/lib/mbta_v3_api/store/alerts.ex
@@ -140,6 +140,11 @@ defmodule MBTAV3API.Store.Alerts.Impl do
   end
 
   @impl true
+  def table_size() do
+    :ets.info(@alerts_table_name, :size)
+  end
+
+  @impl true
   def process_remove(references) do
     for reference <- references do
       case reference do

--- a/lib/mbta_v3_api/store/predictions.ex
+++ b/lib/mbta_v3_api/store/predictions.ex
@@ -194,7 +194,7 @@ defmodule MBTAV3API.Store.Predictions.Impl do
   end
 
   @impl true
-  def table_size() do
+  def table_size do
     :ets.info(@predictions_table_name, :size)
   end
 

--- a/lib/mbta_v3_api/store/predictions.ex
+++ b/lib/mbta_v3_api/store/predictions.ex
@@ -193,6 +193,11 @@ defmodule MBTAV3API.Store.Predictions.Impl do
     :ok
   end
 
+  @impl true
+  def table_size() do
+    :ets.info(@predictions_table_name, :size)
+  end
+
   defp process_one_remove(%{type: "prediction", id: id}) do
     Logger.debug("#{__MODULE__} process_remove type=prediction id=#{id}")
     :ets.delete(@predictions_table_name, id)

--- a/lib/mbta_v3_api/store/vehicles.ex
+++ b/lib/mbta_v3_api/store/vehicles.ex
@@ -119,6 +119,11 @@ defmodule MBTAV3API.Store.Vehicles.Impl do
     :ok
   end
 
+  @impl true
+  def table_size() do
+    :ets.info(@vehicles_table_name, :size)
+  end
+
   defp upsert_data(vehicles) do
     records = vehicles |> Stream.filter(& &1.revenue) |> Enum.map(&to_record(&1))
 

--- a/lib/mbta_v3_api/store/vehicles.ex
+++ b/lib/mbta_v3_api/store/vehicles.ex
@@ -120,7 +120,7 @@ defmodule MBTAV3API.Store.Vehicles.Impl do
   end
 
   @impl true
-  def table_size() do
+  def table_size do
     :ets.info(@vehicles_table_name, :size)
   end
 

--- a/lib/mobile_app_backend/health/checker/alerts.ex
+++ b/lib/mobile_app_backend/health/checker/alerts.ex
@@ -21,7 +21,7 @@ defmodule MobileAppBackend.Health.Checker.Alerts.Impl do
 
   @impl true
   def check_health do
-    store_count = length(Store.Alerts.fetch(fields: [alert: []]))
+    store_count = Store.Alerts.table_size()
 
     case Repository.alerts([]) do
       {:ok, %{data: repo_alerts}} ->

--- a/test/mbta_v3_api/store/alerts_test.exs
+++ b/test/mbta_v3_api/store/alerts_test.exs
@@ -90,4 +90,14 @@ defmodule MBTAV3API.Store.AlertsTest do
     |> Store.Alerts.fetch()
     |> Enum.sort_by(& &1.id)
   end
+
+  describe "table_size" do
+    test "returns the number of records in the store", %{alert_1: alert_1, alert_2: alert_2} do
+      Store.Alerts.process_upsert(:add, [alert_1, alert_2])
+      assert Store.Alerts.table_size() == 2
+
+      Store.Alerts.process_remove([%Reference{type: "alert", id: alert_1.id}])
+      assert Store.Alerts.table_size() == 1
+    end
+  end
 end

--- a/test/mbta_v3_api/store/predictions_test.exs
+++ b/test/mbta_v3_api/store/predictions_test.exs
@@ -309,4 +309,22 @@ defmodule MBTAV3API.Store.PredictionsTest do
                Store.Predictions.fetch_with_associations([[stop_id: "12345"]])
     end
   end
+
+  describe "table_size" do
+    test "returns the number of records in the store", %{
+      prediction_1: prediction_1,
+      prediction_2: prediction_2,
+      trip_1: trip_1,
+      trip_2: trip_2
+    } do
+      Store.Predictions.process_upsert(:add, [prediction_1, prediction_2, trip_1, trip_2])
+      assert Store.Predictions.table_size() == 2
+
+      Store.Predictions.process_remove([
+        %Reference{type: "prediction", id: prediction_1.id}
+      ])
+
+      assert Store.Predictions.table_size() == 1
+    end
+  end
 end

--- a/test/mbta_v3_api/store/vehicles_test.exs
+++ b/test/mbta_v3_api/store/vehicles_test.exs
@@ -136,4 +136,17 @@ defmodule MBTAV3API.Store.VehiclesTest do
                Store.Vehicles.fetch_with_associations([[id: "v_1"], [id: "v_2"]])
     end
   end
+
+  describe "table_size" do
+    test "returns the number of records in the store", %{
+      vehicle_1: vehicle_1,
+      vehicle_2: vehicle_2
+    } do
+      Store.Vehicles.process_upsert(:add, [vehicle_1, vehicle_2])
+      assert Store.Vehicles.table_size() == 2
+
+      Store.Vehicles.process_remove([%Reference{type: "vehicle", id: vehicle_1.id}])
+      assert Store.Vehicles.table_size() == 1
+    end
+  end
 end

--- a/test/mobile_app_backend/health/checker/alerts_test.exs
+++ b/test/mobile_app_backend/health/checker/alerts_test.exs
@@ -92,9 +92,7 @@ defmodule MobileAppBackend.Health.Checker.AlertsTest do
     end
 
     test "returns ok when alert counts match" do
-      expect(AlertsStoreMock, :fetch, fn _ ->
-        [build(:alert, id: "a_1", effect: :shuttle)]
-      end)
+      expect(AlertsStoreMock, :table_size, fn -> 1 end)
 
       first_timestamp = Checker.LastFreshStore.last_fresh_timestamp()
       assert :ok = Checker.check_health()
@@ -103,9 +101,7 @@ defmodule MobileAppBackend.Health.Checker.AlertsTest do
     end
 
     test "returns ok when alert counts do not match but last match time < 5 min" do
-      expect(AlertsStoreMock, :fetch, fn _ ->
-        [build(:alert, id: "a_1", effect: :shuttle), build(:alert, id: "a_2", effect: :closure)]
-      end)
+      expect(AlertsStoreMock, :table_size, fn -> 2 end)
 
       set_log_level(:warning)
 
@@ -115,9 +111,7 @@ defmodule MobileAppBackend.Health.Checker.AlertsTest do
     end
 
     test "returns error when alert counts do not match and last match time > 5 min" do
-      expect(AlertsStoreMock, :fetch, fn _ ->
-        [build(:alert, id: "a_1", effect: :shuttle), build(:alert, id: "a_2", effect: :closure)]
-      end)
+      expect(AlertsStoreMock, :table_size, fn -> 2 end)
 
       set_log_level(:warning)
 
@@ -142,9 +136,7 @@ defmodule MobileAppBackend.Health.Checker.AlertsTest do
 
       reassign_env(:mobile_app_backend, MBTAV3API.Store.Alerts, AlertsStoreMock)
 
-      expect(AlertsStoreMock, :fetch, fn _ ->
-        [build(:alert, id: "a_1", effect: :shuttle), build(:alert, id: "a_2", effect: :closure)]
-      end)
+      expect(AlertsStoreMock, :table_size, fn -> 2 end)
 
       expect(
         MobileAppBackend.HTTPMock,


### PR DESCRIPTION
…d of querying the entire table

### Summary

_Ticket:_ N/A

<!-- What is this PR for? -->
Trying to improve performance by instead of querying all the alerts for validating size of alerts store against alerts repo

### Testing

<!-- What testing have you done? -->
Added and ran unit tests