### PR TITLE
fix(Notifications.Engine): FH2 trip-specific alert missing location & timeframe

### DIFF
--- a/lib/mobile_app_backend/notifications/engine.ex
+++ b/lib/mobile_app_backend/notifications/engine.ex
@@ -82,6 +82,8 @@ defmodule MobileAppBackend.Notifications.Engine do
           [subscription.stop_id]
       end
 
+    alerts = filter_trip_alerts_serving_stop(alerts, target_stop_with_children)
+
     applicable_alerts =
       applicable_alerts(alerts, subscription, route_ids, target_stop_with_children)
 
@@ -101,6 +103,46 @@ defmodule MobileAppBackend.Notifications.Engine do
 
     Enum.flat_map(relevant_alerts, fn %Alert{} = alert ->
       List.wrap(alert_candidate(subscription, alert, now))
+    end)
+  end
+
+  defp filter_trip_alerts_serving_stop(alerts, target_stop_with_children) do
+    trip_ids =
+      alerts
+      |> Enum.flat_map(& &1.informed_entity)
+      |> Enum.map(& &1.trip)
+      |> Enum.uniq()
+      |> Enum.reject(&is_nil/1)
+
+    if Enum.empty?(trip_ids) do
+      alerts
+    else
+      filter_trip_alerts_serving_stop(alerts, trip_ids, target_stop_with_children)
+    end
+  end
+
+  defp filter_trip_alerts_serving_stop(alerts, trip_ids, target_stop_with_children) do
+    {:ok, %{data: trips}} =
+      Repository.trips(
+        filter: [id: trip_ids],
+        include: [:stops],
+        fields: [stop: []]
+      )
+
+    target_stop_set = MapSet.new(target_stop_with_children)
+    trip_by_id = Map.new(trips, &{&1.id, MapSet.new(&1.stop_ids)})
+
+    Enum.filter(alerts, fn %Alert{} = alert ->
+      Alert.any_informed_entity_satisfies(alert, fn ie ->
+        trip_id = ie.trip
+
+        trip_stop_ids = Map.get(trip_by_id, trip_id)
+
+        trip_stop_ids != nil &&
+          trip_stop_ids
+          |> MapSet.intersection(target_stop_set)
+          |> MapSet.size() > 0
+      end)
     end)
   end
 

--- a/test/mobile_app_backend/notifications/engine_test.exs
+++ b/test/mobile_app_backend/notifications/engine_test.exs
@@ -876,7 +876,7 @@ defmodule MobileAppBackend.Notifications.EngineTest do
     now = DateTime.now!("America/New_York")
     upstream_timestamp = DateTime.add(now, -2)
 
-    trip = build(:trip, route_id: "Red")
+    trip = build(:trip, route_id: "Red", stop_ids: ["place-sstat"])
     trip_id = trip.id
 
     alert =
@@ -912,6 +912,12 @@ defmodule MobileAppBackend.Notifications.EngineTest do
         ok_response([build(:schedule, trip_id: trip_id)], [trip])
       end
     )
+    |> expect(
+      :trips,
+      fn [filter: [id: [^trip_id]], include: [:stops], fields: [stop: []]], _ ->
+        ok_response([trip], %{})
+      end
+    )
 
     assert [
              %OutgoingNotification{
@@ -921,5 +927,172 @@ defmodule MobileAppBackend.Notifications.EngineTest do
              }
            ] =
              Engine.notifications([subscription], [alert], now)
+  end
+
+  test "Doesn't send notification for trip that doesn't serve subscribed stop (even if the route sometime serves that stop)" do
+    now = ~B[2026-07-31 10:00:00]
+    hingham = build(:stop, id: "Hingham", name: "Hingham")
+    hull = build(:stop, id: "Hull", name: "Hull")
+    george = build(:stop, id: "George", name: "George")
+    logan = build(:stop, id: "Logan", name: "Logan")
+    route = build(:route, id: "Boat-F2H", type: :ferry, long_name: "Hingham/Hull Ferry")
+
+    trip_stops_at_both =
+      build(:trip,
+        id: "other",
+        direction_id: 1,
+        headsign: "Logan",
+        route_id: route.id,
+        stop_ids: [
+          hingham.id,
+          hull.id,
+          george.id,
+          logan.id
+        ]
+      )
+
+    affected_trip_only_george =
+      build(:trip,
+        id: "affected",
+        direction_id: 1,
+        headsign: "Logan",
+        route_id: route.id,
+        stop_ids: [hingham.id, george.id, logan.id]
+      )
+
+    trips =
+      [trip_stops_at_both, affected_trip_only_george]
+      |> Map.new(fn trip -> {trip.id, trip} end)
+
+    patterns =
+      Enum.map([trip_stops_at_both, affected_trip_only_george], fn trip ->
+        build(:route_pattern,
+          id: "RP_#{trip.id}",
+          route_id: route.id,
+          direction_id: 1,
+          representative_trip_id: trip.id
+        )
+      end)
+
+    reassign_env(:mobile_app_backend, MBTAV3API.Repository, RepositoryMock)
+
+    RepositoryMock
+    |> expect(
+      :schedules,
+      1,
+      fn [filter: [trip: [trip_id]], include: :trip, sort: {:stop_sequence, :asc}], _ ->
+        trip = Map.get(trips, trip_id)
+
+        ok_response(
+          Enum.map(trip.stop_ids, fn stop_id ->
+            build(:schedule,
+              trip_id: trip_id,
+              route_id: route.id,
+              stop_id: stop_id,
+              departure_time: ~B[2026-07-31 10:35:00]
+            )
+          end),
+          [trip]
+        )
+      end
+    )
+    |> expect(:trips, 4, fn params, _ ->
+      case params do
+        [filter: [id: trip_id]] ->
+          ok_response([Map.get(trips, trip_id)])
+
+        [filter: [id: [trip_id]], include: [:stops], fields: [stop: []]] ->
+          ok_response([Map.get(trips, trip_id)])
+      end
+    end)
+
+    reassign_env(
+      :mobile_app_backend,
+      MobileAppBackend.GlobalDataCache.Module,
+      GlobalDataCacheMock
+    )
+
+    GlobalDataCacheMock
+    |> expect(:default_key, 2, fn -> :default_key end)
+    |> expect(:get_data, 2, fn _ ->
+      %{
+        lines: %{},
+        pattern_ids_by_stop: %{},
+        routes: %{"Boat-F1" => build(:route, type: :ferry, id: "Boat-F1"), route.id => route},
+        route_patterns: Map.new(patterns, &{&1.id, &1}),
+        stops: %{
+          hingham.id => hingham,
+          hull.id => hull,
+          george.id => george,
+          logan.id => logan
+        },
+        trips: %{
+          trip_stops_at_both.id => trip_stops_at_both,
+          affected_trip_only_george.id => affected_trip_only_george
+        }
+      }
+    end)
+
+    alert =
+      build(:alert,
+        active_period: [
+          %Alert.ActivePeriod{start: ~B[2026-07-31 10:15:00], end: ~B[2026-07-31 12:00:00]}
+        ],
+        duration_certainty: :known,
+        effect: :dock_closure,
+        informed_entity: [
+          %Alert.InformedEntity{
+            route: route.id,
+            stop: george.id,
+            trip: affected_trip_only_george.id,
+            direction_id: nil,
+            activities: [:board, :exit]
+          },
+          %Alert.InformedEntity{
+            route: "Boat-F1",
+            stop: george.id,
+            trip: affected_trip_only_george.id,
+            direction_id: nil,
+            activities: [:board, :exit]
+          }
+        ]
+      )
+
+    subscription_hull =
+      NotificationsFactory.build(:notification_subscription,
+        route_id: route.id,
+        stop_id: hull.id,
+        direction_id: 1,
+        windows: [
+          NotificationsFactory.build(:window,
+            start_time: now |> DateTime.add(-10, :hour) |> DateTime.to_time(),
+            end_time: now |> DateTime.add(10, :hour) |> DateTime.to_time(),
+            days_of_week: Range.to_list(0..6)
+          )
+        ]
+      )
+
+    subscription_hingham =
+      NotificationsFactory.build(:notification_subscription,
+        route_id: route.id,
+        stop_id: hingham.id,
+        direction_id: 1,
+        windows: [
+          NotificationsFactory.build(:window,
+            start_time: now |> DateTime.add(-10, :hour) |> DateTime.to_time(),
+            end_time: now |> DateTime.add(10, :hour) |> DateTime.to_time(),
+            days_of_week: Range.to_list(0..6)
+          )
+        ]
+      )
+
+    assert [] =
+             Engine.notifications([subscription_hull], [alert], now)
+
+    assert [outgoing_notification] =
+             Engine.notifications([subscription_hull, subscription_hingham], [alert], now)
+
+    assert %{body: "10:35 AM ferry to Logan will not stop at George today"} =
+             OutgoingNotification.localize(outgoing_notification, "en")
   end
 end

--- a/test/mobile_app_backend/notifications/scheduler_test.exs
+++ b/test/mobile_app_backend/notifications/scheduler_test.exs
@@ -444,6 +444,8 @@ defmodule MobileAppBackend.Notifications.SchedulerTest do
         stop_ids: ["FR-0201-02"]
       )
 
+    trip_id = trip.id
+
     start_time = DateTime.add(now, 3, :hour)
 
     alert =
@@ -467,7 +469,9 @@ defmodule MobileAppBackend.Notifications.SchedulerTest do
         last_push_notification_timestamp: DateTime.add(now, -1, :minute)
       )
 
-    parent_stop = build(:stop, id: "place-FR-0201", name: "Concord")
+    parent_stop =
+      build(:stop, id: "place-FR-0201", name: "Concord", child_stop_ids: ["FR-0201-02"])
+
     stop = build(:stop, id: "FR-0201-02", name: "Concord", parent_station_id: parent_stop.id)
 
     reassign_env(:mobile_app_backend, MBTAV3API.Repository, RepositoryMock)
@@ -485,6 +489,12 @@ defmodule MobileAppBackend.Notifications.SchedulerTest do
         [trip]
       )
     end)
+    |> expect(
+      :trips,
+      fn [filter: [id: [^trip_id]], include: [:stops], fields: [stop: []]], _ ->
+        ok_response([trip], %{})
+      end
+    )
 
     reassign_env(
       :mobile_app_backend,
@@ -565,6 +575,8 @@ defmodule MobileAppBackend.Notifications.SchedulerTest do
         stop_ids: ["FR-0201-02"]
       )
 
+    trip_id = trip.id
+
     start_time = DateTime.add(now, 20, :minute)
 
     alert =
@@ -588,7 +600,9 @@ defmodule MobileAppBackend.Notifications.SchedulerTest do
         last_push_notification_timestamp: DateTime.add(now, -1, :minute)
       )
 
-    parent_stop = build(:stop, id: "place-FR-0201", name: "Concord")
+    parent_stop =
+      build(:stop, id: "place-FR-0201", name: "Concord", child_stop_ids: ["FR-0201-02"])
+
     stop = build(:stop, id: "FR-0201-02", name: "Concord", parent_station_id: parent_stop.id)
 
     reassign_env(:mobile_app_backend, MBTAV3API.Repository, RepositoryMock)
@@ -606,6 +620,12 @@ defmodule MobileAppBackend.Notifications.SchedulerTest do
         [trip]
       )
     end)
+    |> expect(
+      :trips,
+      fn [filter: [id: [^trip_id]], include: [:stops], fields: [stop: []]], _ ->
+        ok_response([trip], %{})
+      end
+    )
 
     reassign_env(
       :mobile_app_backend,


### PR DESCRIPTION
### Summary

_Ticket:_ [Trip-specific ferry alert missing information](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1217168623666487?focus=true)

<!-- What is this PR for? -->

There were 2 issues involved here:
1. Users with Hull favorited would receive a misleading Standard notification like "Ferries will not stop at Georges Island starting 10:15 AM today" even though the trip specified in the alert doesn't serve Hull. This is misleading, because only 1 trip for the day was skipping Georges, not all trips after 10:15. They should have received no notification.
2. Users with Hull **and** Hingham favorited would receive a very confusing notification like ""Ferries will not stop at  " because the logic for combining summaries doesn't really work for combing a Standard notification (wrong, from Hull) with a trip-specific notification (right, from Hingham). 

This PR addresses the core of 1, which makes 2 not possible for this scenario. However, it is worth further consideration how we attempt to combine summaries, which I have made a [placeholder ticket
](https://app.asana.com/1/15492006741476/project/1205425564113216/task/1217454774712131?focus=true) for.
### Testing

<!-- What testing have you done? -->

* Added unit tests
* ~TODO:~ test in dev-orange