### PR TITLE
Feat: group notifications on iOS using thread-id

### DIFF
--- a/lib/mobile_app_backend/notifications/deliverer.ex
+++ b/lib/mobile_app_backend/notifications/deliverer.ex
@@ -58,7 +58,9 @@ defmodule MobileAppBackend.Notifications.Deliverer do
           }
         },
         apns: %FCM.ApnsConfig{
-          payload: %{aps: %{sound: "default"}}
+          payload: %{
+            aps: %{sound: "default", "thread-id": alert_id}
+          }
         },
         fcm_options: %FCM.FcmOptions{
           analytics_label: analytics_label

--- a/test/mobile_app_backend/health/checker/alerts_test.exs
+++ b/test/mobile_app_backend/health/checker/alerts_test.exs
@@ -5,7 +5,6 @@ defmodule MobileAppBackend.Health.Checker.AlertsTest do
   alias MobileAppBackend.Health.Checker.Alerts, as: Checker
 
   import ExUnit.CaptureLog
-  import MobileAppBackend.Factory
   import Mox
   import Test.Support.Helpers
 

--- a/test/mobile_app_backend/notifications/deliverer_test.exs
+++ b/test/mobile_app_backend/notifications/deliverer_test.exs
@@ -65,7 +65,9 @@ defmodule MobileAppBackend.Notifications.DelivererTest do
                      "visibility" => "public"
                    }
                  },
-                 "apns" => %{"payload" => %{"aps" => %{"sound" => "default"}}},
+                 "apns" => %{
+                   "payload" => %{"aps" => %{"sound" => "default", "thread-id" => alert_id}}
+                 },
                  "fcm_options" => %{"analytics_label" => analytics_label}
                }
              }


### PR DESCRIPTION
### Summary

_Ticket:_ [All Clear | Investigate tagging notifications for grouping by OS](https://app.asana.com/1/15492006741476/project/1215456342910576/task/1217410813479642?focus=true)

<!-- What is this PR for? -->
Adding thread-id to the APNS  payload
### Testing

<!-- What testing have you done? -->
- Deployed to dev orange and check that notifications with the same alert id were grouped together